### PR TITLE
Kill PATH_MAX

### DIFF
--- a/src/core/wee-config-file.c
+++ b/src/core/wee-config-file.c
@@ -41,6 +41,7 @@
 #include "wee-log.h"
 #include "wee-string.h"
 #include "wee-version.h"
+#include "wee-util.h"
 #include "../gui/gui-color.h"
 #include "../gui/gui-chat.h"
 #include "../plugins/plugin.h"
@@ -2022,7 +2023,7 @@ config_file_write_internal (struct t_config_file *config_file,
                             int default_options)
 {
     int filename_length, rc;
-    char *filename, *filename2, resolved_path[PATH_MAX];
+    char *filename, *filename2, *resolved_path;
     struct t_config_section *ptr_section;
     struct t_config_option *ptr_option;
 
@@ -2051,17 +2052,16 @@ config_file_write_internal (struct t_config_file *config_file,
     snprintf (filename2, filename_length + 32, "%s.weechattmp", filename);
 
     /* if filename is a symbolic link, use target as filename */
-    if (realpath (filename, resolved_path))
+    if ((resolved_path = util_realpath (filename)))
     {
         if (strcmp (filename, resolved_path) != 0)
         {
             free (filename);
-            filename = strdup (resolved_path);
-            if (!filename)
-            {
-                free (filename2);
-                return WEECHAT_CONFIG_WRITE_MEMORY_ERROR;
-            }
+            filename = resolved_path;
+        }
+        else
+        {
+            free (resolved_path);
         }
     }
 

--- a/src/core/wee-string.c
+++ b/src/core/wee-string.c
@@ -2809,3 +2809,82 @@ string_end ()
         string_hashtable_shared = NULL;
     }
 }
+
+/*
+ * Copies a nul-terminated string into the dest buffer, include the
+ * trailing nul, and return a pointer to the trailing nul byte.
+ *
+ * Return value: a pointer to trailing nul byte.
+ *
+ * Implementation adapted from glib/gstrfuncs.c (LGPLv2+)
+ */
+
+static char *
+string_stpcpy (char *dest, const char *src)
+{
+#if _XOPEN_SOURCE >= 700 || _POSIX_C_SOURCE >= 200809L
+    return stpcpy (dest, src);
+#else
+    register char *d = dest;
+    register const char *s = src;
+
+    if (!dest || !src)
+	    return NULL;
+
+    do
+        *d++ = *s;
+    while (*s++ != '\0');
+
+    return d - 1;
+#endif
+}
+
+/*
+ * Concatenates a NULL-terminated list of strings into a newly
+ * allocated string.
+ *
+ * The returned string should be freed with free() when no longer
+ * needed.
+ *
+ * Implementation adapted from glib/gstrfuncs.c (LGPLv2+)
+ */
+
+char *
+string_strconcat (const char *string1, ...)
+{
+    size_t  l;
+    va_list args;
+    char   *s;
+    char   *concat;
+    char   *ptr;
+
+    if (!string1)
+        return NULL;
+
+    l = 1 + strlen (string1);
+    va_start (args, string1);
+    s = va_arg (args, char*);
+    while (s)
+    {
+        l += strlen (s);
+        s = va_arg (args, char*);
+    }
+    va_end (args);
+
+    concat = malloc(l);
+    if (!concat)
+        return NULL;
+    ptr = concat;
+
+    ptr = string_stpcpy(ptr, string1);
+    va_start (args, string1);
+    s = va_arg (args, char*);
+    while (s)
+    {
+        ptr = string_stpcpy (ptr, s);
+        s = va_arg (args, char*);
+    }
+    va_end (args);
+
+    return concat;
+}

--- a/src/core/wee-string.h
+++ b/src/core/wee-string.h
@@ -94,5 +94,6 @@ extern char *string_replace_with_callback (const char *string,
 extern const char *string_shared_get (const char *string);
 extern void string_shared_free (const char *string);
 extern void string_end ();
+WEECHAT_SENTINEL extern char *string_strconcat (const char *string1, ...);
 
 #endif /* __WEECHAT_STRING_H */

--- a/src/core/wee-util.c
+++ b/src/core/wee-util.c
@@ -24,6 +24,7 @@
 #endif
 
 #include <stdlib.h>
+#include <limits.h>
 #include <errno.h>
 #include <string.h>
 #include <sys/types.h>
@@ -749,4 +750,30 @@ util_version_number (const char *version)
 
     return (version_int[0] << 24) | (version_int[1] << 16)
         | (version_int[2] << 8) | version_int[3];
+}
+
+/*
+ * Return the canonicalized absolute pathname, NULL if error.
+ *
+ * Note: result must be freed after use.
+ */
+
+char *
+util_realpath (const char *filename)
+{
+#if _POSIX_C_SOURCE >= 200809L || ! defined PATH_MAX
+    return realpath(filename, NULL);
+#else
+    char *resolved_path = malloc(PATH_MAX);
+
+    if( realpath(filename, resolved_path) )
+    {
+        return resolved_path;
+    }
+    else
+    {
+        free(resolved_path);
+        return NULL;
+    }
+#endif
 }

--- a/src/core/wee-util.h
+++ b/src/core/wee-util.h
@@ -52,5 +52,6 @@ extern char *util_search_full_lib_name (const char *filename,
                                         const char *sys_directory);
 extern char *util_file_get_content (const char *filename);
 extern int util_version_number (const char *version);
+extern char *util_realpath (const char *filename);
 
 #endif /* __WEECHAT_UTIL_H */

--- a/src/core/weechat.c
+++ b/src/core/weechat.c
@@ -88,6 +88,7 @@ struct timeval weechat_current_start_timeval; /* start time used to display */
 int weechat_quit = 0;                  /* = 1 if quit request from user     */
 int weechat_sigsegv = 0;               /* SIGSEGV received?                 */
 char *weechat_home = NULL;             /* home dir. (default: ~/.weechat)   */
+char *weechat_dir_absolute_path = NULL;/* home dir absolute path            */
 char *weechat_local_charset = NULL;    /* example: ISO-8859-1, UTF-8        */
 int weechat_server_cmd_line = 0;       /* at least 1 server on cmd line     */
 int weechat_auto_load_plugins = 1;     /* auto load plugins                 */
@@ -164,6 +165,7 @@ weechat_parse_args (int argc, char *argv[])
     weechat_argv0 = strdup (argv[0]);
     weechat_upgrading = 0;
     weechat_home = NULL;
+    weechat_dir_absolute_path = NULL;
     weechat_server_cmd_line = 0;
     weechat_auto_load_plugins = 1;
     weechat_plugin_no_dlclose = 0;
@@ -180,7 +182,10 @@ weechat_parse_args (int argc, char *argv[])
             || (strcmp (argv[i], "--dir") == 0))
         {
             if (i + 1 < argc)
+            {
                 weechat_home = strdup (argv[++i]);
+                weechat_dir_absolute_path = util_realpath(weechat_home);
+            }
             else
             {
                 string_iconv_fprintf (stderr,
@@ -311,11 +316,13 @@ weechat_create_home_dir ()
             {
                 snprintf (weechat_home, dir_length,
                           "%s%s", ptr_home, config_weechat_home + 1);
+                weechat_dir_absolute_path = util_realpath(weechat_home);
             }
         }
         else
         {
             weechat_home = strdup (config_weechat_home);
+            weechat_dir_absolute_path = util_realpath(weechat_home);
         }
 
         if (!weechat_home)
@@ -397,6 +404,8 @@ weechat_shutdown (int return_code, int crash)
         free (weechat_argv0);
     if (weechat_home)
         free (weechat_home);
+    if (weechat_dir_absolute_path)
+        free (weechat_dir_absolute_path);
     log_close ();
     if (weechat_local_charset)
         free (weechat_local_charset);

--- a/src/core/weechat.h
+++ b/src/core/weechat.h
@@ -91,6 +91,13 @@
 /* internal charset */
 #define WEECHAT_INTERNAL_CHARSET "UTF-8"
 
+/* Provide macros to feature GCC function attribute */
+#if     __GNUC__ >= 4
+#define WEECHAT_SENTINEL __attribute__((__sentinel__))
+#else
+#define WEECHAT_SENTINEL
+#endif
+
 /* global variables and functions */
 extern int weechat_debug_core;
 extern char *weechat_argv0;

--- a/src/core/weechat.h
+++ b/src/core/weechat.h
@@ -83,11 +83,6 @@
     #define DIR_SEPARATOR_CHAR  '/'
 #endif
 
-/* some systems like GNU/Hurd do not define PATH_MAX */
-#ifndef PATH_MAX
-    #define PATH_MAX 4096
-#endif
-
 /* internal charset */
 #define WEECHAT_INTERNAL_CHARSET "UTF-8"
 

--- a/src/core/weechat.h
+++ b/src/core/weechat.h
@@ -107,6 +107,7 @@ extern struct timeval weechat_current_start_timeval;
 extern int weechat_upgrade_count;
 extern int weechat_quit;
 extern char *weechat_home;
+extern char *weechat_dir_absolute_path;
 extern char *weechat_local_charset;
 extern int weechat_plugin_no_dlclose;
 extern int weechat_no_gnutls;

--- a/src/plugins/fifo/fifo.c
+++ b/src/plugins/fifo/fifo.c
@@ -64,16 +64,11 @@ void
 fifo_remove_old_pipes ()
 {
     char *buf;
-    int buf_len, prefix_len;
+    int prefix_len;
     const char *weechat_home, *dir_separator;
     DIR *dp;
     struct dirent *entry;
     struct stat statbuf;
-
-    buf_len = PATH_MAX;
-    buf = malloc (buf_len);
-    if (!buf)
-        return;
 
     weechat_home = weechat_info_get ("weechat_dir", "");
     dir_separator = weechat_info_get ("dir_separator", "");
@@ -90,21 +85,22 @@ fifo_remove_old_pipes ()
 
             if (strncmp (entry->d_name, FIFO_FILENAME_PREFIX, prefix_len) == 0)
             {
-                snprintf (buf, buf_len, "%s%s%s",
-                          weechat_home, dir_separator, entry->d_name);
-                if (stat (buf, &statbuf) != -1)
+                buf = weechat_string_strconcat(weechat_home, dir_separator, entry->d_name, NULL);
+                if (buf)
                 {
-                    weechat_printf (NULL,
-                                    _("%s: removing old fifo pipe \"%s\""),
-                                    FIFO_PLUGIN_NAME, buf);
-                    unlink (buf);
+                    if (stat (buf, &statbuf) != -1)
+                    {
+                        weechat_printf (NULL,
+                                        _("%s: removing old fifo pipe \"%s\""),
+                                        FIFO_PLUGIN_NAME, buf);
+                        unlink (buf);
+                    }
+                    free (buf);
                 }
             }
         }
         closedir (dp);
     }
-
-    free (buf);
 }
 
 /*

--- a/src/plugins/plugin-api.c
+++ b/src/plugins/plugin-api.c
@@ -287,7 +287,6 @@ plugin_api_info_get_internal (void *data, const char *info_name,
 {
     time_t inactivity;
     static char value[32], version_number[32] = { '\0' };
-    static char weechat_dir_absolute_path[PATH_MAX] = { '\0' };
 
     /* make C compiler happy */
     (void) data;
@@ -323,12 +322,7 @@ plugin_api_info_get_internal (void *data, const char *info_name,
     }
     else if (string_strcasecmp (info_name, "weechat_dir") == 0)
     {
-        if (!weechat_dir_absolute_path[0])
-        {
-            if (!realpath (weechat_home, weechat_dir_absolute_path))
-                return NULL;
-        }
-        return (weechat_dir_absolute_path[0]) ?
+        return (weechat_dir_absolute_path) ?
             weechat_dir_absolute_path : weechat_home;
     }
     else if (string_strcasecmp (info_name, "weechat_libdir") == 0)

--- a/src/plugins/plugin.c
+++ b/src/plugins/plugin.c
@@ -567,6 +567,7 @@ plugin_load (const char *filename, int argc, char **argv)
         new_plugin->util_timeval_add = &util_timeval_add;
         new_plugin->util_get_time_string = &util_get_time_string;
         new_plugin->util_version_number = &util_version_number;
+        new_plugin->util_realpath = &util_realpath;
 
         new_plugin->list_new = &weelist_new;
         new_plugin->list_add = &weelist_add;

--- a/src/plugins/plugin.c
+++ b/src/plugins/plugin.c
@@ -536,6 +536,7 @@ plugin_load (const char *filename, int argc, char **argv)
         new_plugin->string_is_command_char = &string_is_command_char;
         new_plugin->string_input_for_buffer = &string_input_for_buffer;
         new_plugin->string_eval_expression = &eval_expression;
+        new_plugin->string_strconcat = &string_strconcat;
 
         new_plugin->utf8_has_8bits = &utf8_has_8bits;
         new_plugin->utf8_is_valid = &utf8_is_valid;

--- a/src/plugins/script/script-repo.c
+++ b/src/plugins/script/script-repo.c
@@ -167,7 +167,8 @@ char *
 script_repo_get_filename_loaded (struct t_script_repo *script)
 {
     const char *weechat_home;
-    char *filename, resolved_path[PATH_MAX];
+    char *filename;
+    char *resolved_path;
     int length;
     struct stat st;
 
@@ -199,13 +200,15 @@ script_repo_get_filename_loaded (struct t_script_repo *script)
         return NULL;
     }
 
-    if (realpath (filename, resolved_path))
+    resolved_path = weechat_util_realpath(filename);
+    if (resolved_path)
     {
         if (strcmp (filename, resolved_path) != 0)
         {
             free (filename);
-            return strdup (resolved_path);
+            return resolved_path;
         }
+        free (resolved_path);
     }
 
     return filename;

--- a/src/plugins/weechat-plugin.h
+++ b/src/plugins/weechat-plugin.h
@@ -29,11 +29,6 @@ extern "C" {
 #include <sys/types.h>
 #include <sys/socket.h>
 
-/* some systems like GNU/Hurd do not define PATH_MAX */
-#ifndef PATH_MAX
-    #define PATH_MAX 4096
-#endif
-
 struct t_config_option;
 struct t_gui_window;
 struct t_gui_buffer;

--- a/src/plugins/weechat-plugin.h
+++ b/src/plugins/weechat-plugin.h
@@ -311,6 +311,7 @@ struct t_weechat_plugin
     void (*util_timeval_add) (struct timeval *tv, long interval);
     char *(*util_get_time_string) (const time_t *date);
     int (*util_version_number) (const char *version);
+    char *(*util_realpath) (const char *filename);
 
     /* sorted lists */
     struct t_weelist *(*list_new) ();
@@ -1124,6 +1125,8 @@ extern int weechat_plugin_end (struct t_weechat_plugin *plugin);
     weechat_plugin->util_get_time_string(__date)
 #define weechat_util_version_number(__version)                          \
     weechat_plugin->util_version_number(__version)
+#define weechat_util_realpath(__filename)                               \
+    weechat_plugin->util_realpath(__filename)
 
 /* sorted list */
 #define weechat_list_new()                                              \

--- a/src/plugins/weechat-plugin.h
+++ b/src/plugins/weechat-plugin.h
@@ -57,7 +57,7 @@ struct timeval;
  * please change the date with current one; for a second change at same
  * date, increment the 01, otherwise please keep 01.
  */
-#define WEECHAT_PLUGIN_API_VERSION "20140304-01"
+#define WEECHAT_PLUGIN_API_VERSION "20140309-01"
 
 /* macros for defining plugin infos */
 #define WEECHAT_PLUGIN_NAME(__name)                                     \
@@ -160,6 +160,13 @@ struct timeval;
 #define WEECHAT_HOOK_SIGNAL_STRING                  "string"
 #define WEECHAT_HOOK_SIGNAL_INT                     "int"
 #define WEECHAT_HOOK_SIGNAL_POINTER                 "pointer"
+
+/* Provide macros to feature GCC function attribute */
+#if     __GNUC__ >= 4
+#define WEECHAT_SENTINEL __attribute__((__sentinel__))
+#else
+#define WEECHAT_SENTINEL
+#endif
 
 /* macro to format string with variable args, using dynamic buffer size */
 #define weechat_va_format(__format)                                     \
@@ -269,6 +276,7 @@ struct t_weechat_plugin
                                      struct t_hashtable *pointers,
                                      struct t_hashtable *extra_vars,
                                      struct t_hashtable *options);
+    WEECHAT_SENTINEL char *(*string_strconcat) (const char *string1, ...);
 
     /* UTF-8 strings */
     int (*utf8_has_8bits) (const char *string);
@@ -1052,6 +1060,8 @@ extern int weechat_plugin_end (struct t_weechat_plugin *plugin);
                                        __extra_vars, __options)         \
     weechat_plugin->string_eval_expression(__expr, __pointers,          \
                                            __extra_vars, __options)
+#define weechat_string_strconcat(__string1, ...)                        \
+    weechat_plugin->string_strconcat(__string1, __VA_ARGS__)
 
 /* UTF-8 strings */
 #define weechat_utf8_has_8bits(__string)                                \


### PR DESCRIPTION
This removes everything PATH_MAX. weechat_string_strconcat() is implemented, cribbed from glib, and util_realpath() uses realpath() in the safest, most portable way I've been able to deduce (see http://pubs.opengroup.org/onlinepubs/9699919799/functions/realpath.html ).