### PR TITLE
Assume iconv usability when cross compiling.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -252,7 +252,7 @@ if test "x$ac_found_iconv_header" = "xyes" ; then
                 return 0;
             }
             return 1;
-      }],iconv_found="yes")
+      }],iconv_found="yes", iconv_found="no", iconv_found="assume-yes")
   if test "x$iconv_found" = "xno" ; then
      AC_MSG_RESULT(no)
   else


### PR DESCRIPTION
AC_TRY_RUN needs a fallback action when cross compiling.
