### PR TITLE
relay: Don't print ::ffff: in IPv4-mapped IPv6 addresses

### DIFF
--- a/src/plugins/relay/relay-server.c
+++ b/src/plugins/relay/relay-server.c
@@ -269,6 +269,12 @@ relay_server_sock_cb (void *data, int fd)
                        INET6_ADDRSTRLEN))
         {
             ptr_ip_address = ipv6_address;
+
+            if (strncmp (ptr_ip_address, "::ffff:", 7) == 0)
+            {
+                /* actually an IPv4-mapped IPv6 address, so skip ::ffff: */
+                ptr_ip_address += 7;
+            }
         }
     }
     else


### PR DESCRIPTION
I think this is the only place in WeeChat where this happens. In my opinion ::ffff: is an internal detail of how IPv4 addresses are dealt with in IPv6 socket structures, and shouldn't be printed anywhere. 

This also simplifies `relay.network.allowed_ips`, as the same IPv4 IP will be identical, regardless of whether it was handled by an IPv6 or IPv4 socket.
