### PR TITLE
.travis.yml: install msgcheck directly from git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
     - sudo apt-get update -qq
     - sudo apt-get -y install devscripts equivs python-pip libenchant-dev
     - sudo mk-build-deps -i debian/control
-    - sudo pip install msgcheck pylint
+    - sudo pip install git+https://github.com/FlashCode/msgcheck.git pylint --upgrade
 
 script:
     - mkdir build


### PR DESCRIPTION
and also upgrade it and pylint if they happen to be installed.

As it is @FlashCode 's repository, it's probably as stable as WeeChat
git and it might contain changes that they didn't remember to send to
git, so I think that this is wanted change.

If this isn't, this can be closed as this is just a suggestion and pull
request.
