### PR TITLE
trigger: refuse triggers with . in their name

### DIFF
--- a/src/plugins/trigger/trigger.c
+++ b/src/plugins/trigger/trigger.c
@@ -706,6 +706,9 @@ trigger_name_valid (const char *name)
     /* no spaces allowed */
     if (strchr (name, ' '))
         return 0;
+    /* no periods allowed since it is saved via wee_config option name */
+    if (strchr (name, '.'))
+        return 0;
 
     /* name is valid */
     return 1;


### PR DESCRIPTION
gb reported that he can create triggers with a period in their name, but they are lost when he /upgrades. The reason is because the trigger name is parsed out of the option name when in trigger-config.c:448
