### PR TITLE
core: callback_free_key shouldn't pass an already free'd value

### DIFF
--- a/doc/en/weechat_plugin_api.en.asciidoc
+++ b/doc/en/weechat_plugin_api.en.asciidoc
@@ -3812,7 +3812,14 @@ my_free_value_cb (struct t_hashtable *hashtable, const void *key, void *value)
     /* ... */
 }
 
+void
+my_free_key_cb (struct t_hashtable *hashtable, void *key)
+{
+    /* ... */
+}
+
 weechat_hashtable_set_pointer (hashtable, "callback_free_value", &my_free_value_cb);
+weechat_hashtable_set_pointer (hashtable, "callback_free_key", &my_free_key_cb);
 ----
 
 [NOTE]

--- a/src/core/wee-hashtable.c
+++ b/src/core/wee-hashtable.c
@@ -307,8 +307,7 @@ hashtable_free_key (struct t_hashtable *hashtable,
     if (hashtable->callback_free_key)
     {
         (void) (hashtable->callback_free_key) (hashtable,
-                                               item->key,
-                                               item->value);
+                                               item->key);
     }
     else
     {

--- a/src/core/wee-hashtable.h
+++ b/src/core/wee-hashtable.h
@@ -28,7 +28,7 @@ typedef unsigned long long (t_hashtable_hash_key)(struct t_hashtable *hashtable,
 typedef int (t_hashtable_keycmp)(struct t_hashtable *hashtable,
                                  const void *key1, const void *key2);
 typedef void (t_hashtable_free_key)(struct t_hashtable *hashtable,
-                                    void *key, const void *value);
+                                    void *key);
 typedef void (t_hashtable_free_value)(struct t_hashtable *hashtable,
                                       const void *key, void *value);
 typedef void (t_hashtable_map)(void *data,

--- a/src/core/wee-string.c
+++ b/src/core/wee-string.c
@@ -2816,11 +2816,10 @@ string_shared_keycmp (struct t_hashtable *hashtable,
 
 void
 string_shared_free_key (struct t_hashtable *hashtable,
-                        void *key, const void *value)
+                        void *key)
 {
     /* make C compiler happy */
     (void) hashtable;
-    (void) value;
 
     free (key);
 }


### PR DESCRIPTION
In hashtable_remove_item(), hashtable_free_value() is called before hashtable_free_key(). It therefore seems wrong to have a pointer to the value as a callback_free_key function parameter.
