### PR TITLE
python: use HINTS for introspected values

### DIFF
--- a/cmake/FindPython.cmake
+++ b/cmake/FindPython.cmake
@@ -63,17 +63,17 @@ if(PYTHON_EXECUTABLE)
 
   find_path(PYTHON_INCLUDE_PATH
     NAMES Python.h
-    PATHS ${PYTHON_INC_DIR}
+    HINTS ${PYTHON_INC_DIR}
     )
   if(ENABLE_PYTHON3)
     find_library(PYTHON_LIBRARY
       NAMES python3.4 python3.3 python3.2 python3.1 python3.0 python3 python2.7 python2.6 python2.5 python
-      PATHS ${PYTHON_POSSIBLE_LIB_PATH}
+      HINTS ${PYTHON_POSSIBLE_LIB_PATH}
       )
   else()
     find_library(PYTHON_LIBRARY
       NAMES python2.7 python2.6 python2.5 python
-      PATHS ${PYTHON_POSSIBLE_LIB_PATH}
+      HINTS ${PYTHON_POSSIBLE_LIB_PATH}
       )
   endif()
 


### PR DESCRIPTION
CMake [recommends using HINTS](http://www.cmake.org/cmake/help/v3.0/command/find_library.html) instead of PATHS for introspected values. PATHS are very low-priority and are considered after defaults and system environment variables; for Homebrew this means that the introspected values end up being ignored, which results in linking to the wrong Python.
