### PR TITLE
Add option to stop connection if SASL authentication fails (irc.server.*.sasl_disconnect_on_fail).

### DIFF
--- a/src/plugins/irc/irc-config.c
+++ b/src/plugins/irc/irc-config.c
@@ -1772,6 +1772,18 @@ irc_config_server_new_option (struct t_config_file *config_file,
                 callback_change, callback_change_data,
                 NULL, NULL);
             break;
+        case IRC_SERVER_OPTION_SASL_DISCONNECT_ON_FAIL:
+            new_option = weechat_config_new_option (
+                config_file, section,
+                option_name, "boolean",
+                N_("disconnect if SASL authentication fails (to prevent hostname leaks)"),
+                NULL, 0, 0,
+                default_value, value,
+                null_value_allowed,
+                callback_check_value, callback_check_value_data,
+                callback_change, callback_change_data,
+                NULL, NULL);
+            break;
         case IRC_SERVER_OPTION_AUTOCONNECT:
             new_option = weechat_config_new_option (
                 config_file, section,

--- a/src/plugins/irc/irc-protocol.c
+++ b/src/plugins/irc/irc-protocol.c
@@ -5089,6 +5089,18 @@ IRC_PROTOCOL_CALLBACK(sasl_end)
                              date, nick, address, host, command,
                              ignored, argc, argv, argv_eol);
 
+    if (strcmp (argv[1], "903") != 0 && IRC_SERVER_OPTION_BOOLEAN(server, IRC_SERVER_OPTION_SASL_DISCONNECT_ON_FAIL))
+    {
+        /* Check if we are already connected to the server,
+         * to prevent disconnects in case of 907.
+         */
+
+        if (!server->is_connected)
+            irc_server_disconnect (server, 0, 1);
+
+        return WEECHAT_RC_OK;
+    }
+
     if (!server->is_connected)
         irc_server_sendf (server, 0, NULL, "CAP END");
 

--- a/src/plugins/irc/irc-server.h
+++ b/src/plugins/irc/irc-server.h
@@ -49,6 +49,7 @@ enum t_irc_server_option
     IRC_SERVER_OPTION_SASL_USERNAME, /* username for SASL authentication     */
     IRC_SERVER_OPTION_SASL_PASSWORD, /* password for SASL authentication     */
     IRC_SERVER_OPTION_SASL_TIMEOUT,  /* timeout for SASL authentication      */
+    IRC_SERVER_OPTION_SASL_DISCONNECT_ON_FAIL, /* disconnect on SASL fail    */
     IRC_SERVER_OPTION_AUTOCONNECT,   /* autoconnect to server at startup     */
     IRC_SERVER_OPTION_AUTORECONNECT, /* autoreconnect when disconnected      */
     IRC_SERVER_OPTION_AUTORECONNECT_DELAY, /* delay before trying again reco */


### PR DESCRIPTION
See https://savannah.nongnu.org/task/?12204.

This also adds support for the 902 numeric (`ERR_NICKLOCKED`), which is used if SASL authentication fails because an account is frozen, locked or held.
