### PR TITLE
Fix include flags for LibGcrypt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,7 @@ endif()
 find_package(GCRYPT REQUIRED)
 add_definitions(-DHAVE_GCRYPT)
 list(APPEND EXTRA_LIBS ${GCRYPT_LDFLAGS})
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${GCRYPT_CFLAGS}")
 
 # Check for GnuTLS
 if(ENABLE_GNUTLS)


### PR DESCRIPTION
When it's not installed in a default path, the compiler calls will not find Gcrypt unless we add it like this.
