### PR TITLE
doc: FAQ: use all options with homebrew

### DIFF
--- a/doc/en/weechat_faq.en.asciidoc
+++ b/doc/en/weechat_faq.en.asciidoc
@@ -63,7 +63,8 @@ brew info weechat
 You can install WeeChat with this command:
 
 ----
-brew install weechat --with-python --with-perl
+brew install aspell
+brew install weechat --with-aspell --with-curl --with-guile --with-lua --with-perl --with-python --with-ruby --with-tcl
 ----
 
 [[lost]]


### PR DESCRIPTION
It can be confusing for OS X users to have different packages installed
than what ship with most of WeeChat packages on other operating systems.

I added `brew install aspell` on top, because of the warning in
`brew info weechat` saying that `If Aspell was installed
automatically as part of weechat, there won't be any dictionaries.`