### PR TITLE
Update irc-nick.c

### DIFF
--- a/src/plugins/irc/irc-nick.c
+++ b/src/plugins/irc/irc-nick.c
@@ -84,8 +84,6 @@ irc_nick_is_nick (const char *string)
 
     while (ptr && ptr[0])
     {
-        if (!strchr (IRC_NICK_VALID_CHARS, *ptr))
-            return 0;
         ptr++;
     }
 


### PR DESCRIPTION
weechat breaks on networks that allow color codes in nicknames, this fixes that.
see: http://savannah.nongnu.org/bugs/?41416