### PR TITLE
core: add config option to ignore prefix characters in completions

### DIFF
--- a/src/core/wee-config.c
+++ b/src/core/wee-config.c
@@ -246,6 +246,7 @@ struct t_config_option *config_color_nicklist_offline;
 struct t_config_option *config_completion_base_word_until_cursor;
 struct t_config_option *config_completion_command_inline;
 struct t_config_option *config_completion_default_template;
+struct t_config_option *config_completion_ignore_prefix_chars;
 struct t_config_option *config_completion_nick_add_space;
 struct t_config_option *config_completion_nick_completer;
 struct t_config_option *config_completion_nick_first_only;
@@ -3210,6 +3211,11 @@ config_weechat_init_options ()
            "\"weechat_hook_command\")"),
         NULL, 0, 0, "%(nicks)|%(irc_channels)", NULL, 0,
         NULL, NULL, NULL, NULL, NULL, NULL);
+    config_completion_ignore_prefix_chars = config_file_new_option (
+        weechat_config_file, ptr_section,
+        "ignore_prefix_chars", "string",
+        N_("characters to ignore when they prefix words to complete"),
+        NULL, 0, 0, "@():", NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL);
     config_completion_nick_add_space = config_file_new_option (
         weechat_config_file, ptr_section,
         "nick_add_space", "boolean",

--- a/src/core/wee-config.h
+++ b/src/core/wee-config.h
@@ -279,6 +279,7 @@ extern struct t_config_option *config_color_nicklist_offline;
 extern struct t_config_option *config_completion_base_word_until_cursor;
 extern struct t_config_option *config_completion_command_inline;
 extern struct t_config_option *config_completion_default_template;
+extern struct t_config_option *config_completion_ignore_prefix_chars;
 extern struct t_config_option *config_completion_nick_add_space;
 extern struct t_config_option *config_completion_nick_completer;
 extern struct t_config_option *config_completion_nick_first_only;


### PR DESCRIPTION
This configuation option (config_completion_ignore_prefix_chars) makes the specified characters (default: "@():") be treated as though they were spaces when performing completions. So "@Ni" completes to "@Nick", etc.

affected functions:
- gui_completion_find_context