### PR TITLE
doc: fix "Get backtrace with gdb" in user guide

### DIFF
--- a/doc/en/weechat_user.en.asciidoc
+++ b/doc/en/weechat_user.en.asciidoc
@@ -430,10 +430,6 @@ in '/home/xxx/', then run gdb with this command:
 gdb /usr/bin/weechat /home/xxx/core
 ----
 
-[NOTE]
-If you installed binary package 'weechat-dbg' (for example under Debian), then
-you can use this path for WeeChat binary: '/usr/lib/debug/usr/bin/weechat'
-
 Then under gdb, use command `bt full` to display backtrace.
 You will see something like that:
 


### PR DESCRIPTION
/usr/lib/debug/usr/bin/weechat doesn't exist with newer distributions
(Ubuntu 14.10) and on distributions where it exists, running
`/usr/bin/weechat` works as well.

```
gdb /usr/bin/weechat-curses
<...>
Reading symbols from /usr/bin/weechat-curses...Reading symbols from
/usr/lib/debug/usr/bin/weechat-curses...done.
```

This gdb is from Debian GNU/Linux 7.8 (wheezy).