### PR TITLE
trigger: hide password when messaging NickServ through default alias

### DIFF
--- a/src/plugins/trigger/trigger-config.c
+++ b/src/plugins/trigger/trigger-config.c
@@ -63,7 +63,7 @@ char *trigger_config_default_list[][1 + TRIGGER_NUM_OPTIONS] =
       "5000|input_text_display;5000|history_add;5000|irc_command_auth",
       "",
       "==^("
-      "(/(msg|quote) +nickserv "
+      "(/(msg|m|quote) +nickserv "
       "+(id|identify|register|ghost +[^ ]+|release +[^ ]+|regain +[^ ]+) +)|"
       "/oper +[^ ]+ +|"
       "/quote +pass +|"


### PR DESCRIPTION
There is a default alias `M => msg` which is easy to type when interacting with NickServ for example but the passwords were only hidden when using the non-alias. This pull request fixes that.