### PR TITLE
no longer put weechat version at the top of configs

### DIFF
--- a/src/core/wee-config-file.c
+++ b/src/core/wee-config-file.c
@@ -2229,16 +2229,6 @@ config_file_write_internal (struct t_config_file *config_file,
         goto error;
     }
 
-    /* write header with name of config file and WeeChat version */
-    if (!string_iconv_fprintf (config_file->file, "#\n"))
-        goto error;
-    if (!string_iconv_fprintf (config_file->file,
-                               "# %s -- %s v%s\n#\n",
-                               config_file->filename,
-                               version_get_name (),
-                               version_get_version ()))
-        goto error;
-
     /* write all sections */
     for (ptr_section = config_file->sections; ptr_section;
          ptr_section = ptr_section->next_section)


### PR DESCRIPTION
I had some spare time at work, so I tried to find the piece of code that actually puts the weechat version into the config and removed it. This is to fix #407 