### PR TITLE
core: add option weechat.look.prefix_unalign_multiline_words

### DIFF
--- a/src/core/wee-config.c
+++ b/src/core/wee-config.c
@@ -161,6 +161,7 @@ struct t_config_option *config_look_prefix_buffer_align_more;
 struct t_config_option *config_look_prefix_buffer_align_more_after;
 struct t_config_option *config_look_prefix_same_nick;
 struct t_config_option *config_look_prefix_suffix;
+struct t_config_option *config_look_prefix_unalign_multiline_words;
 struct t_config_option *config_look_quote_nick_prefix;
 struct t_config_option *config_look_quote_nick_suffix;
 struct t_config_option *config_look_quote_time_format;
@@ -2770,6 +2771,13 @@ config_weechat_init_options ()
         "prefix_suffix", "string",
         N_("string displayed after prefix"),
         NULL, 0, 0, "|", NULL, 0, NULL, NULL, &config_change_buffers, NULL, NULL, NULL);
+    config_look_prefix_unalign_multiline_words = config_file_new_option (
+        weechat_config_file, ptr_section,
+        "prefix_unalign_multiline_words", "boolean",
+        N_("continue words longer than a single line directly at the "
+           "beginning of the next line (default off)"),
+        NULL, 0, 0, "off", NULL, 0,
+        NULL, NULL, &config_change_buffers, NULL, NULL, NULL);
     config_look_quote_nick_prefix = config_file_new_option (
         weechat_config_file, ptr_section,
         "quote_nick_prefix", "string",

--- a/src/core/wee-config.h
+++ b/src/core/wee-config.h
@@ -207,6 +207,7 @@ extern struct t_config_option *config_look_prefix_buffer_align_more;
 extern struct t_config_option *config_look_prefix_buffer_align_more_after;
 extern struct t_config_option *config_look_prefix_same_nick;
 extern struct t_config_option *config_look_prefix_suffix;
+extern struct t_config_option *config_look_prefix_unalign_multiline_words;
 extern struct t_config_option *config_look_quote_nick_prefix;
 extern struct t_config_option *config_look_quote_nick_suffix;
 extern struct t_config_option *config_look_quote_time_format;

--- a/src/gui/curses/gui-curses-chat.c
+++ b/src/gui/curses/gui-curses-chat.c
@@ -490,6 +490,25 @@ gui_chat_display_word (struct t_gui_window *window,
     {
         /* insert spaces for aligning text under time/nick */
         length_align = gui_line_get_align (window->buffer, line, 0, 0);
+
+        int temporarily_disable_prefix_suffix = 0;
+        if (CONFIG_BOOLEAN(config_look_prefix_unalign_multiline_words))
+        {
+            int max_normal_length = gui_chat_get_real_width (window) - length_align;
+            if (CONFIG_INTEGER(config_look_align_end_of_lines) == CONFIG_LOOK_ALIGN_END_OF_LINES_MESSAGE)
+            {
+                max_normal_length -= 1;
+                max_normal_length -= gui_chat_strlen_screen (CONFIG_STRING(config_look_prefix_suffix));
+            }
+
+            if (*lines_displayed > 0 && end_line - data >= max_normal_length
+                && chars_displayed >= max_normal_length)
+            {
+                length_align = 0;
+                temporarily_disable_prefix_suffix = 1;
+            }
+        }
+
         if ((window->win_chat_cursor_x == 0)
             && (*lines_displayed > pre_lines_displayed)
             /* FIXME: modify arbitrary value for non aligning messages on time/nick? */
@@ -500,7 +519,8 @@ gui_chat_display_word (struct t_gui_window *window,
                 && (CONFIG_INTEGER(config_look_prefix_align) != CONFIG_LOOK_PREFIX_ALIGN_NONE)
                 && CONFIG_STRING(config_look_prefix_suffix)
                 && CONFIG_STRING(config_look_prefix_suffix)[0]
-                && line->data->date > 0)
+                && line->data->date > 0
+                && !temporarily_disable_prefix_suffix)
             {
                 if (!simulate)
                 {


### PR DESCRIPTION
This solves the multi-line URL copying issue that has kept me from migrating to WeeChat from Irssi. It brings infinite and glorious convenience to every user who isn't a fan of vertical splits!

The point of this is that you can use weechat.look.align_end_of_lines = message to get nice formatting, but words that wrap to multiple lines are formatted like weechat.look.align_end_of_lines = time. This allows long URLs to be clicked and the full word to be conveniently copy-pasted.

You may still need weechat.look.eat_newline_glitch = on, depending on how and which terminal you use.

Works with both, weechat.look.prefix_align = none and right. Most of the code is about coping with the slight complexities of the latter.

Works with vertical splits too, with limited usefulness.

For reference, this explains the previously available options for viewing long words as continuous text (that are not sufficient for me and some other users): https://weechat.org/files/doc/weechat_faq.en.html#urls
