### PR TITLE
irc: avoid warnings for unsupported WHOX messages

### DIFF
--- a/src/plugins/irc/irc-protocol.c
+++ b/src/plugins/irc/irc-protocol.c
@@ -4272,9 +4272,9 @@ IRC_PROTOCOL_CALLBACK(354)
     struct t_irc_channel *ptr_channel;
     struct t_irc_nick *ptr_nick;
 
-    IRC_PROTOCOL_MIN_ARGS(5);
+    IRC_PROTOCOL_MIN_ARGS(4);
 
-    /* silently ignore malformed 354 message (missing infos) */
+    /* silently ignore 354 messages we don't parse (missing infos) */
     if (argc < 11)
         return WEECHAT_RC_OK;
 


### PR DESCRIPTION
Fixes #376. This avoids warnings for WHOX messages that we do not parse/
understand yet. Previously, IRC_PROTOCOL_MIN_ARGS was 5 where it should
have been 4 (which avoids warnings for WHOX commands only requesting one
WHOX type). Changing the behavior to support all different WHOX types
seems like a bad idea to me, as it's quite hard to figure out which
information was requested with the WHOX command.