### PR TITLE
Add default for Elemental-IRCd +y to be Unreal +q

### DIFF
--- a/src/plugins/irc/irc-config.c
+++ b/src/plugins/irc/irc-config.c
@@ -2891,7 +2891,7 @@ irc_config_init ()
            "found, WeeChat will try with next modes received from server "
            "(\"PREFIX\"); a special mode \"*\" can be used as default color "
            "if no mode has been found in list)"),
-        NULL, 0, 0, "q:lightred;a:lightcyan;o:lightgreen;h:lightmagenta;"
+        NULL, 0, 0, "y:lightred;q:lightred;a:lightcyan;o:lightgreen;h:lightmagenta;"
         "v:yellow;*:lightblue", NULL, 0, NULL, NULL,
         &irc_config_change_color_nick_prefixes, NULL, NULL, NULL);
     irc_config_color_notice = weechat_config_new_option (


### PR DESCRIPTION
Elemental-IRCd has mode +q in use as channel list-like quiet mode. As such it uses +y for owner. This change updates the defaults to reflect this.