### PR TITLE
relay: print value of HTTP Header X-Real-IP

### DIFF
--- a/ChangeLog.asciidoc
+++ b/ChangeLog.asciidoc
@@ -19,6 +19,7 @@ https://weechat.org/files/releasenotes/ReleaseNotes-devel.html[release notes]
 
 === New features
 
+* relay: print value of HTTP Header X-Real-IP for websocket connections
 * core: add signal "signal_sighup"
 
 === Bugs fixed

--- a/src/plugins/relay/relay-client.c
+++ b/src/plugins/relay/relay-client.c
@@ -379,6 +379,17 @@ relay_client_recv_text (struct t_relay_client *client, const char *data)
                             relay_client_set_status (client, RELAY_STATUS_DISCONNECTED);
                         }
 
+                        if (weechat_hashtable_get (client->http_headers, "X-Real-IP")) {
+                            weechat_printf_tags (NULL, "relay_client",
+                                                 _("%s: websocket client %s%s%s has real IP \"%s\""),
+                                                 RELAY_PLUGIN_NAME,
+                                                 RELAY_COLOR_CHAT_CLIENT,
+                                                 client->desc,
+                                                 RELAY_COLOR_CHAT,
+                                                 weechat_hashtable_get (client->http_headers, "X-Real-IP")
+                                                 );
+                        }
+
                         /* remove HTTP headers */
                         weechat_hashtable_free (client->http_headers);
                         client->http_headers = NULL;


### PR DESCRIPTION
When relay plugin gets a new successfull handshake for a relay
connection using websocket it will look for HTTP header X-Real-IP which
is commonly used when proxying connections. This allows users of WeeChat
and proxy to see the client's real IP address instead of the address of
the HTTP proxy.