### PR TITLE
irc: add separate color option for current topic in channel buffer

### DIFF
--- a/src/plugins/irc/irc-color.h
+++ b/src/plugins/irc/irc-color.h
@@ -86,6 +86,7 @@
 #define IRC_COLOR_MESSAGE_JOIN weechat_color(weechat_config_string(irc_config_color_message_join))
 #define IRC_COLOR_MESSAGE_QUIT weechat_color(weechat_config_string(irc_config_color_message_quit))
 #define IRC_COLOR_REASON_QUIT weechat_color(weechat_config_string(irc_config_color_reason_quit))
+#define IRC_COLOR_TOPIC_CURRENT weechat_color(weechat_config_string(irc_config_color_topic_current))
 #define IRC_COLOR_TOPIC_OLD weechat_color(weechat_config_string(irc_config_color_topic_old))
 #define IRC_COLOR_TOPIC_NEW weechat_color(weechat_config_string(irc_config_color_topic_new))
 #define IRC_COLOR_INPUT_NICK weechat_color(weechat_config_string(irc_config_color_input_nick))

--- a/src/plugins/irc/irc-config.c
+++ b/src/plugins/irc/irc-config.c
@@ -125,6 +125,7 @@ struct t_config_option *irc_config_color_mirc_remap;
 struct t_config_option *irc_config_color_nick_prefixes;
 struct t_config_option *irc_config_color_notice;
 struct t_config_option *irc_config_color_reason_quit;
+struct t_config_option *irc_config_color_topic_current;
 struct t_config_option *irc_config_color_topic_new;
 struct t_config_option *irc_config_color_topic_old;
 
@@ -2905,6 +2906,12 @@ irc_config_init ()
         irc_config_file, ptr_section,
         "reason_quit", "color",
         N_("color for reason in part/quit messages"),
+        NULL, -1, 0, "default", NULL, 0, NULL, NULL,
+        NULL, NULL, NULL, NULL);
+    irc_config_color_topic_current = weechat_config_new_option (
+        irc_config_file, ptr_section,
+        "topic_current", "color",
+        N_("color for current channel topic (when joining or using /topic)"),
         NULL, -1, 0, "default", NULL, 0, NULL, NULL,
         NULL, NULL, NULL, NULL);
     irc_config_color_topic_new = weechat_config_new_option (

--- a/src/plugins/irc/irc-config.h
+++ b/src/plugins/irc/irc-config.h
@@ -168,6 +168,7 @@ extern struct t_config_option *irc_config_color_mirc_remap;
 extern struct t_config_option *irc_config_color_nick_prefixes;
 extern struct t_config_option *irc_config_color_notice;
 extern struct t_config_option *irc_config_color_reason_quit;
+extern struct t_config_option *irc_config_color_topic_current;
 extern struct t_config_option *irc_config_color_topic_new;
 extern struct t_config_option *irc_config_color_topic_old;
 

--- a/src/plugins/irc/irc-protocol.c
+++ b/src/plugins/irc/irc-protocol.c
@@ -3475,11 +3475,12 @@ IRC_PROTOCOL_CALLBACK(332)
                 server, NULL, command, NULL, ptr_buffer),
             date,
             irc_protocol_tags (command, "irc_numeric", NULL, NULL),
-            _("%sTopic for %s%s%s is \"%s%s\""),
+            _("%sTopic for %s%s%s is \"%s%s%s\""),
             weechat_prefix ("network"),
             IRC_COLOR_CHAT_CHANNEL,
             argv[3],
             IRC_COLOR_RESET,
+            IRC_COLOR_TOPIC_CURRENT,
             (topic_color) ? topic_color : ((pos_topic) ? pos_topic : ""),
             IRC_COLOR_RESET);
     }


### PR DESCRIPTION
This patch adds an option to change the color which is used to print the current channel topic into the chat buffer when it is shown on join or as reply to `/topic`, making it possible to configure that color just like on topic changes. By default, behavior is identical to before.

*Feature found to be missing by someone at #weechat a while ago.*