### PR TITLE
core: update examples of alias add commands

### DIFF
--- a/doc/en/weechat_dev.en.asciidoc
+++ b/doc/en/weechat_dev.en.asciidoc
@@ -1053,7 +1053,7 @@ Then you can load this script in your WeeChat, and setup path to your '/doc' dir
 Then create this alias to build files:
 
 ----
-/alias doc /perl unload; /python unload; /ruby unload; /lua unload; /tcl unload; /guile unload; /javascript unload; /python load docgen.py; /wait 1ms /docgen
+/alias add doc /perl unload; /python unload; /ruby unload; /lua unload; /tcl unload; /guile unload; /javascript unload; /python load docgen.py; /wait 1ms /docgen
 ----
 
 And use command `/doc` to build all files, for all languages.

--- a/doc/fr/weechat_dev.fr.asciidoc
+++ b/doc/fr/weechat_dev.fr.asciidoc
@@ -1073,7 +1073,7 @@ vers votre répertoire '/doc' :
 Créez alors cet alias pour construire les fichiers :
 
 ----
-/alias doc /perl unload; /python unload; /ruby unload; /lua unload; /tcl unload; /guile unload; /javascript unload; /python load docgen.py; /wait 1ms /docgen
+/alias add doc /perl unload; /python unload; /ruby unload; /lua unload; /tcl unload; /guile unload; /javascript unload; /python load docgen.py; /wait 1ms /docgen
 ----
 
 Et utilisez la commande `/doc` pour construire tous les fichiers, pour toutes

--- a/doc/ja/weechat_dev.ja.asciidoc
+++ b/doc/ja/weechat_dev.ja.asciidoc
@@ -1050,7 +1050,7 @@ $ msgcheck.py xx.po
 ファイルを生成するエイリアスを作ってください:
 
 ----
-/alias doc /perl unload; /python unload; /ruby unload; /lua unload; /tcl unload; /guile unload; /javascript unload; /python load docgen.py; /wait 1ms /docgen
+/alias add doc /perl unload; /python unload; /ruby unload; /lua unload; /tcl unload; /guile unload; /javascript unload; /python load docgen.py; /wait 1ms /docgen
 ----
 
 コマンド `/doc` を使って全ての (全てのプログラミング言語について) 自動生成するファイルを作成してください。

--- a/src/core/wee-command.c
+++ b/src/core/wee-command.c
@@ -7808,7 +7808,7 @@ command_init ()
            "    /set irc.server.oftc.command \"/msg nickserv identify "
            "${sec.data.oftc}\"\n"
            "  alias to ghost the nick \"mynick\":\n"
-           "    /alias ghost /eval /msg -server freenode nickserv ghost mynick "
+           "    /alias add ghost /eval /msg -server freenode nickserv ghost mynick "
            "${sec.data.freenode}"),
         "passphrase -delete"
         " || decrypt -discard"

--- a/src/plugins/alias/alias.c
+++ b/src/plugins/alias/alias.c
@@ -526,7 +526,7 @@ alias_hook_command (struct t_alias *alias)
     /*
      * if alias has no custom completion, then default is to complete with
      * completion template of target command, for example if alias is
-     * "/alias test /buffer", then str_completion will be "%%buffer"
+     * "/alias add test /buffer", then str_completion will be "%%buffer"
      */
     str_completion = NULL;
     if (!alias->completion)


### PR DESCRIPTION
Couple of places in the core and docs still contained old `/alias` syntax being used.