### PR TITLE
irc: add multiple targets and -server option to /ctcp (closes #204)

### DIFF
--- a/AUTHORS.asciidoc
+++ b/AUTHORS.asciidoc
@@ -81,7 +81,7 @@ Alphabetically:
 * Ryuunosuke Ayanokouzi
 * Sergio Durigan Junior
 * Shawn Smith
-* Simmo Saan
+* Simmo Saan (sim642)
 * Simon Arlott
 * Simon Kuhnle
 * Stefano Pigozzi


### PR DESCRIPTION
This makes `/ctcp` syntax like `/msg`'s.

*Also includes my nickname in AUTHORS :)*