### PR TITLE
core: fix /uptime output for 0 days

### DIFF
--- a/src/core/wee-command.c
+++ b/src/core/wee-command.c
@@ -6215,7 +6215,7 @@ COMMAND_CALLBACK(uptime)
         snprintf (string, sizeof (string),
                   "WeeChat uptime: %d %s %02d:%02d:%02d, started on %s",
                   day,
-                  (day > 1) ? "days" : "day",
+                  (day != 1) ? "days" : "day",
                   hour,
                   min,
                   sec,


### PR DESCRIPTION
Applies to `/uptime -o` which doesn't use translations and handles singular/plural itself directly.