### PR TITLE
trigger: add support for one-time triggers (closes #399)

### DIFF
--- a/doc/en/weechat_user.en.asciidoc
+++ b/doc/en/weechat_user.en.asciidoc
@@ -3006,6 +3006,11 @@ A trigger has the following options (names are
 | return_code | `ok`, `ok_eat`, `error` |
   The return code of callback (default is `ok`, which should be used in almost
   all triggers, the other values are rarely used).
+
+| once_action | `none`, `disable`, `delete` |
+  Action to take with the trigger after the trigger executes once (default is
+  `none` which should be used in almost all triggers, the other values are
+  rarely used).
 |===
 
 For example, the default 'beep' trigger has following options:
@@ -3018,6 +3023,7 @@ trigger.trigger.beep.conditions = "${tg_highlight} || ${tg_msg_pv}"
 trigger.trigger.beep.regex = ""
 trigger.trigger.beep.command = "/print -beep"
 trigger.trigger.beep.return_code = ok
+trigger.trigger.beep.once_action = none
 ----
 
 [[trigger_execution]]
@@ -3030,6 +3036,8 @@ order, if triggers are globally enabled and if the trigger itself is enabled:
 . replace text in trigger using regular expression(s)
 . execute command(s)
 . exit with a return code (except for hooks 'modifier' and 'focus').
+. perform once action (when not `none`)
+
 
 [[trigger_hook_arguments]]
 ==== Hook arguments

--- a/src/plugins/trigger/trigger-callback.h
+++ b/src/plugins/trigger/trigger-callback.h
@@ -64,6 +64,18 @@
     if (extra_vars)                                             \
         weechat_hashtable_free (extra_vars);                    \
     trigger->hook_running = 0;                                  \
+    switch (weechat_config_integer (                            \
+                trigger->options[TRIGGER_OPTION_ONCE_ACTION]))  \
+    {                                                           \
+        case TRIGGER_ONCE_DISABLE:                              \
+            weechat_config_option_set (                         \
+                trigger->options[TRIGGER_OPTION_ENABLED],       \
+                "off", 1);                                      \
+            break;                                              \
+        case TRIGGER_ONCE_DELETE:                               \
+            trigger_free (trigger);                             \
+            break;                                              \
+    }                                                           \
     return __rc;
 
 extern int trigger_callback_signal_cb (void *data, const char *signal,

--- a/src/plugins/trigger/trigger-completion.c
+++ b/src/plugins/trigger/trigger-completion.c
@@ -412,6 +412,32 @@ trigger_completion_hook_rc_cb (void *data, const char *completion_item,
 }
 
 /*
+ * Adds default once actions to completion list.
+ */
+
+int
+trigger_completion_once_cb (void *data, const char *completion_item,
+                            struct t_gui_buffer *buffer,
+                            struct t_gui_completion *completion)
+{
+    int i;
+
+    /* make C compiler happy */
+    (void) data;
+    (void) completion_item;
+    (void) buffer;
+
+    for (i = 0; i < TRIGGER_NUM_ONCE_ACTIONS; i++)
+    {
+        weechat_hook_completion_list_add (completion,
+            trigger_once_action_string[i], 0, WEECHAT_LIST_POS_END);
+    }
+
+    return WEECHAT_RC_OK;
+}
+
+
+/*
  * Hooks completions.
  */
 
@@ -451,4 +477,7 @@ trigger_completion_init ()
     weechat_hook_completion ("trigger_hook_rc",
                              N_("default return codes for hook callback"),
                              &trigger_completion_hook_rc_cb, NULL);
+    weechat_hook_completion ("trigger_once",
+                             N_("trigger once actions"),
+                             &trigger_completion_once_cb, NULL);
 }

--- a/src/plugins/trigger/trigger-config.c
+++ b/src/plugins/trigger/trigger-config.c
@@ -42,6 +42,7 @@ struct t_config_option *trigger_config_color_flag_command;
 struct t_config_option *trigger_config_color_flag_conditions;
 struct t_config_option *trigger_config_color_flag_regex;
 struct t_config_option *trigger_config_color_flag_return_code;
+struct t_config_option *trigger_config_color_flag_once_action;
 struct t_config_option *trigger_config_color_regex;
 struct t_config_option *trigger_config_color_replace;
 struct t_config_option *trigger_config_color_trigger;
@@ -56,7 +57,8 @@ char *trigger_config_default_list[][1 + TRIGGER_NUM_OPTIONS] =
       "${tg_displayed} && (${tg_highlight} || ${tg_msg_pv})",
       "",
       "/print -beep",
-      "ok" },
+      "ok",
+      "" },
     /* hide passwords in commands */
     { "cmd_pass", "on",
       "modifier",
@@ -72,6 +74,7 @@ char *trigger_config_default_list[][1 + TRIGGER_NUM_OPTIONS] =
       "(.*)"
       "==${re:1}${hide:*,${re:+}}",
       "",
+      "",
       "" },
     /* hide password in IRC auth message displayed */
     { "msg_auth", "on",
@@ -80,6 +83,7 @@ char *trigger_config_default_list[][1 + TRIGGER_NUM_OPTIONS] =
       "",
       "==^(.*(id|identify|register|ghost +[^ ]+|release +[^ ]+) +)(.*)"
       "==${re:1}${hide:*,${re:+}}",
+      "",
       "",
       "" },
     /* hide server password in commands /server and /connect */
@@ -90,8 +94,9 @@ char *trigger_config_default_list[][1 + TRIGGER_NUM_OPTIONS] =
       "==^(/(server|connect) .*-(sasl_)?password=)([^ ]+)(.*)"
       "==${re:1}${hide:*,${re:4}}${re:5}"
       "",
+      "",
       "" },
-    { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL },
+    { NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL },
 };
 
 
@@ -339,6 +344,14 @@ trigger_config_create_trigger_option (const char *trigger_name, int index_option
                    "know where ok_eat/error can be used efficiently)"),
                 "ok|ok_eat|error", 0, 0, value, NULL, 0,
                 NULL, NULL, NULL, NULL, NULL, NULL);
+            break;
+        case TRIGGER_OPTION_ONCE_ACTION:
+            ptr_option = weechat_config_new_option (
+                trigger_config_file, trigger_config_section_trigger,
+                option_name, "integer",
+                N_("action to take after execution"),
+                "none|disable|delete", 0, 0, value, NULL, 0, NULL, NULL,
+                NULL, NULL, NULL, NULL);
             break;
         case TRIGGER_NUM_OPTIONS:
             break;
@@ -637,6 +650,12 @@ trigger_config_init ()
         "flag_return_code", "color",
         N_("text color for return code flag (in /trigger list)"),
         NULL, 0, 0, "lightmagenta", NULL, 0,
+        NULL, NULL, NULL, NULL, NULL, NULL);
+    trigger_config_color_flag_once_action = weechat_config_new_option (
+        trigger_config_file, ptr_section,
+        "flag_once_action", "color",
+        N_("text color for once action flag (in /trigger list)"),
+        NULL, 0, 0, "lightblue", NULL, 0,
         NULL, NULL, NULL, NULL, NULL, NULL);
     trigger_config_color_regex = weechat_config_new_option (
         trigger_config_file, ptr_section,

--- a/src/plugins/trigger/trigger-config.h
+++ b/src/plugins/trigger/trigger-config.h
@@ -33,6 +33,7 @@ extern struct t_config_option *trigger_config_color_flag_command;
 extern struct t_config_option *trigger_config_color_flag_conditions;
 extern struct t_config_option *trigger_config_color_flag_regex;
 extern struct t_config_option *trigger_config_color_flag_return_code;
+extern struct t_config_option *trigger_config_color_flag_once_action;
 extern struct t_config_option *trigger_config_color_regex;
 extern struct t_config_option *trigger_config_color_replace;
 extern struct t_config_option *trigger_config_color_trigger;

--- a/src/plugins/trigger/trigger.h
+++ b/src/plugins/trigger/trigger.h
@@ -38,6 +38,7 @@ enum t_trigger_option
     TRIGGER_OPTION_REGEX,              /* replace text with 1 or more regex */
     TRIGGER_OPTION_COMMAND,            /* command run if conditions are OK  */
     TRIGGER_OPTION_RETURN_CODE,        /* return code for hook callback     */
+    TRIGGER_OPTION_ONCE_ACTION,        /* action to take after execution    */
     /* number of trigger options */
     TRIGGER_NUM_OPTIONS,
 };
@@ -55,6 +56,15 @@ enum t_trigger_hook_type
     TRIGGER_HOOK_FOCUS,
     /* number of hook types */
     TRIGGER_NUM_HOOK_TYPES,
+};
+
+enum t_trigger_once_action
+{
+    TRIGGER_ONCE_NONE = 0,
+    TRIGGER_ONCE_DISABLE,
+    TRIGGER_ONCE_DELETE,
+    /* number of once actions */
+    TRIGGER_NUM_ONCE_ACTIONS,
 };
 
 enum t_trigger_return_code
@@ -112,6 +122,7 @@ extern char *trigger_hook_option_values;
 extern char *trigger_hook_default_arguments[];
 extern char *trigger_hook_default_rc[];
 extern char *trigger_hook_regex_default_var[];
+extern char *trigger_once_action_string[];
 extern char *trigger_return_code_string[];
 extern int trigger_return_code[];
 extern struct t_trigger *triggers;
@@ -124,6 +135,7 @@ extern int trigger_enabled;
 extern int trigger_search_option (const char *option_name);
 extern int trigger_search_hook_type (const char *type);
 extern int trigger_search_return_code (const char *return_code);
+extern int trigger_search_once_action (const char *once_action);
 extern struct t_trigger *trigger_search (const char *name);
 extern struct t_trigger *trigger_search_with_option (struct t_config_option *option);
 extern void trigger_regex_free (int *regex_count,
@@ -149,7 +161,8 @@ extern struct t_trigger *trigger_new (const char *name,
                                       const char *conditions,
                                       const char *replace,
                                       const char *command,
-                                      const char *return_code);
+                                      const char *return_code,
+                                      const char *once_action);
 extern void trigger_create_default ();
 extern int trigger_rename (struct t_trigger *trigger, const char *name);
 extern struct t_trigger *trigger_copy (struct t_trigger *trigger,


### PR DESCRIPTION
This patch adds a new option `once_action` to triggers, which by default is `none` but also allows `disable` (to disable the trigger after it executes) and `delete` (to delete the trigger after it executes). This action is run after stopping the trigger so it can be deleted.