### PR TITLE
FindIconv: Stop hardcoding the library name.

### DIFF
--- a/cmake/FindIconv.cmake
+++ b/cmake/FindIconv.cmake
@@ -48,9 +48,8 @@ find_library(ICONV_LIBRARY
 
 if(ICONV_INCLUDE_PATH)
   if(ICONV_LIBRARY)
-    string(REGEX REPLACE "/[^/]*$" "" ICONV_LIB_PATH "${ICONV_LIBRARY}")
-    check_library_exists(iconv libiconv_open ${ICONV_LIB_PATH} LIBICONV_OPEN_FOUND)
-    check_library_exists(iconv iconv_open ${ICONV_LIB_PATH} ICONV_OPEN_FOUND)
+    check_library_exists("${ICONV_LIBRARY}" libiconv_open "" LIBICONV_OPEN_FOUND)
+    check_library_exists("${ICONV_LIBRARY}" iconv_open "" ICONV_OPEN_FOUND)
     if(LIBICONV_OPEN_FOUND OR ICONV_OPEN_FOUND)
        set(ICONV_FOUND TRUE)
     endif()


### PR DESCRIPTION
Instead of splitting ${ICONV_LIBRARY}'s path and then assuming the
library is called "libiconv.so", use ${ICONV_LIBRARY}'s entire value in
the calls to check_library_exists().

If that is not done, the iconv detection fails if one sets ICONV_LIBRARY
to, for example, /usr/lib/libc.so, as the previous calls would still
pass "-liconv" to the linker instead of the chosen value.