### PR TITLE
doc: fix "I have SSL problems"

### DIFF
--- a/doc/en/weechat_faq.en.asciidoc
+++ b/doc/en/weechat_faq.en.asciidoc
@@ -500,14 +500,21 @@ If you see errors about gnutls handshake, you can try to use a smaller
 Diffie-Hellman key (default is 2048):
 
 ----
-/set irc.server.freenode.ssl_dhkey_size 1024
+/set irc.server.example.ssl_dhkey_size 1024
 ----
 
 If you see errors about certificate, you can disable "ssl_verify" (be careful,
 connection will be less secure by doing that):
 
 ----
-/set irc.server.freenode.ssl_verify off
+/set irc.server.example.ssl_verify off
+----
+
+If the network has invalid certificate and you know what the certificate
+should be, you can specify the fingerprint SHA-512, SHA-256 or SHA-1 sum:
+
+----
+/set irc.server.example.ssl_fingerprint 0c06e399d3c3597511dc8550848bfd2a502f0ce19883b728b73f6b7e8604243b
 ----
 
 [[irc_ssl_handshake_error]]


### PR DESCRIPTION
1. Freenode supports DH size 2048 nowadays, so change the network to
   example.
2. Freenode has valid SSL certificate, so also change that network to
   example.
3. Mention irc.server.example.ssl_fingerprint. I used SHA512 sum of
   weechat.org's certificate as it was the first one to come to mind.