### PR TITLE
trigger: only return trigger's return code when condition evaluates to true

### DIFF
--- a/src/plugins/trigger/trigger-callback.c
+++ b/src/plugins/trigger/trigger-callback.c
@@ -330,9 +330,13 @@ trigger_callback_run_command (struct t_trigger *trigger,
  *   2. check conditions (if false, exit)
  *   3. replace text with regex
  *   4. execute command(s)
+ *
+ * Returns:
+ *   1: conditions were true (or no condition set in trigger)
+ *   0: conditions were false
  */
 
-void
+int
 trigger_callback_execute (struct t_trigger *trigger,
                           struct t_gui_buffer *buffer,
                           struct t_hashtable *pointers,
@@ -358,7 +362,11 @@ trigger_callback_execute (struct t_trigger *trigger,
         /* execute command(s) */
         trigger_callback_run_command (trigger, buffer, pointers, extra_vars,
                                       display_monitor);
+
+        return 1;
     }
+
+    return 0;
 }
 
 /*
@@ -452,7 +460,8 @@ trigger_callback_signal_cb (void *data, const char *signal,
     weechat_hashtable_set (extra_vars, "tg_signal_data", ptr_signal_data);
 
     /* execute the trigger (conditions, regex, command) */
-    trigger_callback_execute (trigger, NULL, pointers, extra_vars);
+    if (!trigger_callback_execute (trigger, NULL, pointers, extra_vars))
+        trigger_rc = WEECHAT_RC_OK;
 
 end:
     TRIGGER_CALLBACK_CB_END(trigger_rc);
@@ -499,7 +508,8 @@ trigger_callback_hsignal_cb (void *data, const char *signal,
     weechat_hashtable_set (extra_vars, "tg_signal", signal);
 
     /* execute the trigger (conditions, regex, command) */
-    trigger_callback_execute (trigger, NULL, pointers, extra_vars);
+    if (!trigger_callback_execute (trigger, NULL, pointers, extra_vars))
+        trigger_rc = WEECHAT_RC_OK;
 
 end:
     TRIGGER_CALLBACK_CB_END(trigger_rc);
@@ -755,7 +765,8 @@ trigger_callback_print_cb  (void *data, struct t_gui_buffer *buffer,
         goto end;
 
     /* execute the trigger (conditions, regex, command) */
-    trigger_callback_execute (trigger, buffer, pointers, extra_vars);
+    if (!trigger_callback_execute (trigger, buffer, pointers, extra_vars))
+        trigger_rc = WEECHAT_RC_OK;
 
 end:
     TRIGGER_CALLBACK_CB_END(trigger_rc);
@@ -788,7 +799,8 @@ trigger_callback_command_cb  (void *data, struct t_gui_buffer *buffer,
     }
 
     /* execute the trigger (conditions, regex, command) */
-    trigger_callback_execute (trigger, buffer, pointers, extra_vars);
+    if (!trigger_callback_execute (trigger, buffer, pointers, extra_vars))
+        trigger_rc = WEECHAT_RC_OK;
 
 end:
     TRIGGER_CALLBACK_CB_END(trigger_rc);
@@ -812,7 +824,8 @@ trigger_callback_command_run_cb  (void *data, struct t_gui_buffer *buffer,
     weechat_hashtable_set (extra_vars, "tg_command", command);
 
     /* execute the trigger (conditions, regex, command) */
-    trigger_callback_execute (trigger, buffer, pointers, extra_vars);
+    if (!trigger_callback_execute (trigger, buffer, pointers, extra_vars))
+        trigger_rc = WEECHAT_RC_OK;
 
 end:
     TRIGGER_CALLBACK_CB_END(trigger_rc);
@@ -859,7 +872,8 @@ trigger_callback_timer_cb  (void *data, int remaining_calls)
     }
 
     /* execute the trigger (conditions, regex, command) */
-    trigger_callback_execute (trigger, NULL, pointers, extra_vars);
+    if (!trigger_callback_execute (trigger, NULL, pointers, extra_vars))
+        trigger_rc = WEECHAT_RC_OK;
 
 end:
     TRIGGER_CALLBACK_CB_END(trigger_rc);
@@ -881,7 +895,8 @@ trigger_callback_config_cb  (void *data, const char *option, const char *value)
     weechat_hashtable_set (extra_vars, "tg_value", value);
 
     /* execute the trigger (conditions, regex, command) */
-    trigger_callback_execute (trigger, NULL, pointers, extra_vars);
+    if (!trigger_callback_execute (trigger, NULL, pointers, extra_vars))
+        trigger_rc = WEECHAT_RC_OK;
 
 end:
     TRIGGER_CALLBACK_CB_END(trigger_rc);


### PR DESCRIPTION
Previously all pieces of trigger documentation (user guide and `/help trigger`) suggested that the processing of a trigger is immediately stopped if the condition (if given) evaluates to false. This makes it seem like it should never reach the point of returning the desired return code. Actually the behavior was different and always returned the given return code.

This patch fixes that behavior to be like the documentation describes for all hook types which can return a given return code. It allows for triggers to actually conditionally return `ok_eat` because previously it wasn't possible to conditionally stop a hook from propagating.

This has the potential to break current triggers but that happening is extremely unlikely as return codes are so rarely used and if they are, they most definitely weren't conditional before. In the case that such trigger actually broke it's possible to create two triggers in the new case, one for conditionally running the command and the other unconditionally returning the return code.
