### PR TITLE
Fixed instructions about getting correct CA file on Mac OS X

### DIFF
--- a/doc/en/weechat_faq.en.asciidoc
+++ b/doc/en/weechat_faq.en.asciidoc
@@ -492,11 +492,12 @@ you have to use key[alt] instead of key[shift]).
 [[irc_ssl_connection]]
 === I have some problems when connecting to a server using SSL, what can I do?
 
-If you are using Mac OS X, you must install `curl-ca-bundle` and set the path
-to certificates in WeeChat:
+If you are using Mac OS X, you must install `openssl` from Homebrew. A CA file
+will be bootstrapped using certificates from the system keychain. And set the
+path to certificates in WeeChat:
 
 ----
-/set weechat.network.gnutls_ca_file "/usr/local/opt/curl-ca-bundle/share/ca-bundle.crt"
+/set weechat.network.gnutls_ca_file "/usr/local/etc/openssl/cert.pem"
 ----
 
 If you see errors about gnutls handshake, you can try to use a smaller


### PR DESCRIPTION
curl-ca-bundle was removed from Homebrew as insecure: https://github.com/Homebrew/homebrew/pull/28658 so here is the alternative version of getting correct and secure CA file.