### PR TITLE
irc: make command characters optional in server's command option

### DIFF
--- a/src/plugins/irc/irc-protocol.c
+++ b/src/plugins/irc/irc-protocol.c
@@ -2455,7 +2455,7 @@ IRC_PROTOCOL_CALLBACK(wallops)
 IRC_PROTOCOL_CALLBACK(001)
 {
     char *server_command, **commands, **ptr_command, *vars_replaced, *away_msg;
-    char *usermode;
+    char *usermode, *slash_command;
 
     IRC_PROTOCOL_MIN_ARGS(3);
 
@@ -2523,8 +2523,23 @@ IRC_PROTOCOL_CALLBACK(001)
             {
                 vars_replaced = irc_message_replace_vars (server, NULL,
                                                           *ptr_command);
-                weechat_command (server->buffer,
-                                 (vars_replaced) ? vars_replaced : *ptr_command);
+                if (weechat_string_is_command_char (*ptr_command))
+                {
+                    weechat_command (server->buffer,
+                                     (vars_replaced) ? vars_replaced : *ptr_command);
+                }
+                else
+                {
+                    slash_command = malloc (1 + strlen((vars_replaced) ? vars_replaced : *ptr_command) + 1);
+                    if (slash_command)
+                    {
+                        strcpy (slash_command, "/");
+                        strcat (slash_command, (vars_replaced) ? vars_replaced : *ptr_command);
+                        weechat_command (server->buffer, slash_command);
+                        free (slash_command);
+                    }
+                }
+
                 if (vars_replaced)
                     free (vars_replaced);
             }


### PR DESCRIPTION
The motivation for this patch came from aliases which allow specifying commands with and without the command character. Server `.command` variables could easily do the same without negative consequences because previously without the command character it would simply attempt to send text into the server buffer, only to end up with an error message.
