### PR TITLE
irc: add support for IRCv3.2 Client Capability Negotiation (closes #586)

### DIFF
--- a/doc/en/weechat_plugin_api.en.adoc
+++ b/doc/en/weechat_plugin_api.en.adoc
@@ -4846,6 +4846,51 @@ weechat_hashtable_add_to_infolist (hashtable, infolist_item, "testhash");
 [NOTE]
 This function is not available in scripting API.
 
+==== hashtable_add_from_infolist
+
+_WeeChat ≥ x.y.z._
+
+Add hashtable items from an infolist.
+
+Prototype:
+
+[source,C]
+----
+int weechat_hashtable_add_from_infolist (struct t_hashtable *hashtable,
+                                         struct t_infolist *infolist,
+                                         const char *prefix);
+----
+
+Arguments:
+
+* 'hashtable': hashtable pointer
+* 'infolist': infolist pointer
+* 'prefix': string used as prefix for names in infolist
+
+Return value:
+
+* 1 if OK, 0 if error
+
+C example:
+
+[source,C]
+----
+weechat_hashtable_add_from_infolist (hashtable, infolist, "testhash");
+
+/* if infolist contains:
+     "testhash_name_00000"  = "key1"
+     "testhash_value_00000" = "value 1"
+     "testhash_name_00001"  = "key2"
+     "testhash_value_00001" = "value 2"
+   then following variables will be added to hashtable:
+     "key1" => "value 1"
+     "key2" => "value 2"
+*/
+----
+
+[NOTE]
+This function is not available in scripting API.
+
 ==== hashtable_remove
 
 _WeeChat ≥ 0.3.3._

--- a/src/core/wee-hashtable.c
+++ b/src/core/wee-hashtable.c
@@ -1062,6 +1062,8 @@ hashtable_add_to_infolist (struct t_hashtable *hashtable,
                                           hashtable_to_string (hashtable->type_keys,
                                                                ptr_item->key)))
                 return 0;
+            /* TODO: implement other key types */
+
             snprintf (option_name, sizeof (option_name),
                       "%s_value_%05d", prefix, item_number);
             switch (hashtable->type_values)
@@ -1098,6 +1100,96 @@ hashtable_add_to_infolist (struct t_hashtable *hashtable,
             item_number++;
         }
     }
+    return 1;
+}
+
+/*
+ * Adds hashtable keys and values from an infolist.
+ *
+ * Returns:
+ *   1: OK
+ *   0: error
+ */
+
+int
+hashtable_add_from_infolist (struct t_hashtable *hashtable,
+                             struct t_infolist *infolist,
+                             const char *prefix)
+{
+    struct t_infolist_item *infolist_item;
+    struct t_infolist_var *ptr_name, *ptr_value;
+    void *value;
+    char prefix_name[128], option_value[128];
+    int prefix_length;
+
+    if (!hashtable || !infolist || !prefix)
+        return 0;
+
+    infolist_item = infolist->ptr_item;
+    if (!infolist_item)
+        return 0;
+
+    if (hashtable->type_keys != HASHTABLE_STRING)
+        return 0;
+    /* TODO: implement other key types */
+
+    snprintf (prefix_name, sizeof (prefix_name),
+              "%s_name_", prefix);
+    prefix_length = strlen (prefix_name);
+
+    for (ptr_name = infolist_item->vars; ptr_name; ptr_name = ptr_name->next_var)
+    {
+        if (string_strncasecmp (ptr_name->name, prefix_name, prefix_length) == 0)
+        {
+            snprintf (option_value, sizeof (option_value),
+                      "%s_value_%s", prefix, ptr_name->name + prefix_length);
+
+            for (ptr_value = infolist_item->vars; ptr_value; ptr_value = ptr_value->next_var)
+            {
+                if (string_strcasecmp (ptr_value->name, option_value) == 0)
+                {
+                    switch (hashtable->type_values)
+                    {
+                        case HASHTABLE_INTEGER:
+                            if (ptr_value->type != INFOLIST_INTEGER)
+                                return 0;
+
+                            value = ptr_value->value;
+                            break;
+                        case HASHTABLE_STRING:
+                            if (ptr_value->type != INFOLIST_STRING)
+                                return 0;
+
+                            value = ptr_value->value;
+                            break;
+                        case HASHTABLE_POINTER:
+                            if (ptr_value->type != INFOLIST_POINTER)
+                                return 0;
+
+                            value = ptr_value->value;
+                            break;
+                        case HASHTABLE_BUFFER:
+                            if (ptr_value->type != INFOLIST_BUFFER)
+                                return 0;
+
+                            value = ptr_value->value; /* TODO: implement size */
+                            break;
+                        case HASHTABLE_TIME:
+                            if (ptr_value->type != INFOLIST_TIME)
+                                return 0;
+
+                            value = ptr_value->value;
+                            break;
+                        case HASHTABLE_NUM_TYPES:
+                            break;
+                    }
+                    hashtable_set (hashtable, ptr_name->value, value);
+                    break;
+                }
+            }
+        }
+    }
+
     return 1;
 }
 

--- a/src/core/wee-hashtable.h
+++ b/src/core/wee-hashtable.h
@@ -22,6 +22,7 @@
 
 struct t_hashtable;
 struct t_infolist_item;
+struct t_infolist;
 
 typedef unsigned long long (t_hashtable_hash_key)(struct t_hashtable *hashtable,
                                                   const void *key);
@@ -149,6 +150,9 @@ extern void hashtable_set_pointer (struct t_hashtable *hashtable,
 extern int hashtable_add_to_infolist (struct t_hashtable *hashtable,
                                       struct t_infolist_item *infolist_item,
                                       const char *prefix);
+extern int hashtable_add_from_infolist (struct t_hashtable *hashtable,
+                                        struct t_infolist *infolist,
+                                        const char *prefix);
 extern void hashtable_remove (struct t_hashtable *hashtable, const void *key);
 extern void hashtable_remove_all (struct t_hashtable *hashtable);
 extern void hashtable_free (struct t_hashtable *hashtable);

--- a/src/plugins/irc/irc-channel.c
+++ b/src/plugins/irc/irc-channel.c
@@ -689,8 +689,8 @@ irc_channel_check_whox (struct t_irc_server *server,
 {
     if ((channel->type == IRC_CHANNEL_TYPE_CHANNEL) && channel->nicks)
     {
-        if (server->cap_away_notify
-            || server->cap_account_notify
+        if (weechat_hashtable_has_key (server->cap_list, "away-notify")
+            || weechat_hashtable_has_key (server->cap_list, "account-notify")
             || ((IRC_SERVER_OPTION_INTEGER(server, IRC_SERVER_OPTION_AWAY_CHECK) > 0)
                 && ((IRC_SERVER_OPTION_INTEGER(server, IRC_SERVER_OPTION_AWAY_CHECK_MAX_NICKS) == 0)
                     || (channel->nicks_count <= IRC_SERVER_OPTION_INTEGER(server, IRC_SERVER_OPTION_AWAY_CHECK_MAX_NICKS)))))

--- a/src/plugins/irc/irc-command.c
+++ b/src/plugins/irc/irc-command.c
@@ -1221,7 +1221,7 @@ IRC_COMMAND_CALLBACK(cap)
         if ((weechat_strcasecmp (argv[1], "ls") == 0) && !argv_eol[2])
         {
             irc_server_sendf (ptr_server, IRC_SERVER_SEND_OUTQ_PRIO_HIGH, NULL,
-                              "CAP LS 302");
+                              "CAP LS " IRC_SERVER_VERSION_CAP);
         }
         else
         {
@@ -1241,7 +1241,7 @@ IRC_COMMAND_CALLBACK(cap)
          * enabled
          */
         irc_server_sendf (ptr_server, IRC_SERVER_SEND_OUTQ_PRIO_HIGH, NULL,
-                          "CAP LS 302");
+                          "CAP LS " IRC_SERVER_VERSION_CAP);
         irc_server_sendf (ptr_server, IRC_SERVER_SEND_OUTQ_PRIO_HIGH, NULL,
                           "CAP LIST");
     }

--- a/src/plugins/irc/irc-command.c
+++ b/src/plugins/irc/irc-command.c
@@ -1223,7 +1223,7 @@ IRC_COMMAND_CALLBACK(cap)
          * enabled
          */
         irc_server_sendf (ptr_server, IRC_SERVER_SEND_OUTQ_PRIO_HIGH, NULL,
-                          "CAP LS");
+                          "CAP LS 302");
         irc_server_sendf (ptr_server, IRC_SERVER_SEND_OUTQ_PRIO_HIGH, NULL,
                           "CAP LIST");
     }

--- a/src/plugins/irc/irc-command.c
+++ b/src/plugins/irc/irc-command.c
@@ -1201,6 +1201,8 @@ IRC_COMMAND_CALLBACK(ban)
 
 IRC_COMMAND_CALLBACK(cap)
 {
+    char *cap_cmd;
+
     IRC_BUFFER_GET_SERVER(buffer);
     IRC_COMMAND_CHECK_SERVER("cap", 1);
 
@@ -1210,11 +1212,27 @@ IRC_COMMAND_CALLBACK(cap)
 
     if (argc > 1)
     {
-        irc_server_sendf (ptr_server, IRC_SERVER_SEND_OUTQ_PRIO_HIGH, NULL,
-                          "CAP %s%s%s",
-                          argv[1],
-                          (argv_eol[2]) ? " :" : "",
-                          (argv_eol[2]) ? argv_eol[2] : "");
+        cap_cmd = strdup (argv[1]);
+        if (!cap_cmd)
+            WEECHAT_COMMAND_ERROR;
+
+        weechat_string_toupper (cap_cmd);
+
+        if ((weechat_strcasecmp (argv[1], "ls") == 0) && !argv_eol[2])
+        {
+            irc_server_sendf (ptr_server, IRC_SERVER_SEND_OUTQ_PRIO_HIGH, NULL,
+                              "CAP LS 302");
+        }
+        else
+        {
+            irc_server_sendf (ptr_server, IRC_SERVER_SEND_OUTQ_PRIO_HIGH, NULL,
+                              "CAP %s%s%s",
+                              cap_cmd,
+                              (argv_eol[2]) ? " :" : "",
+                              (argv_eol[2]) ? argv_eol[2] : "");
+        }
+
+        free (cap_cmd);
     }
     else
     {

--- a/src/plugins/irc/irc-nick.c
+++ b/src/plugins/irc/irc-nick.c
@@ -755,7 +755,7 @@ irc_nick_set_away (struct t_irc_server *server, struct t_irc_channel *channel,
                    struct t_irc_nick *nick, int is_away)
 {
     if (!is_away
-        || server->cap_away_notify
+        || weechat_hashtable_has_key (server->cap_list, "away-notify")
         || ((IRC_SERVER_OPTION_INTEGER(server, IRC_SERVER_OPTION_AWAY_CHECK) > 0)
             && ((IRC_SERVER_OPTION_INTEGER(server, IRC_SERVER_OPTION_AWAY_CHECK_MAX_NICKS) == 0)
                 || (channel->nicks_count <= IRC_SERVER_OPTION_INTEGER(server, IRC_SERVER_OPTION_AWAY_CHECK_MAX_NICKS)))))

--- a/src/plugins/irc/irc-server.c
+++ b/src/plugins/irc/irc-server.c
@@ -3544,7 +3544,7 @@ irc_server_login (struct t_irc_server *server)
 
     if (irc_server_sasl_enabled (server) || (capabilities && capabilities[0]))
     {
-        irc_server_sendf (server, 0, NULL, "CAP LS 302");
+        irc_server_sendf (server, 0, NULL, "CAP LS " IRC_SERVER_VERSION_CAP);
     }
 
     username2 = (username && username[0]) ?

--- a/src/plugins/irc/irc-server.c
+++ b/src/plugins/irc/irc-server.c
@@ -1167,11 +1167,13 @@ irc_server_alloc (const char *name)
     new_server->nick_alternate_number = -1;
     new_server->nick = NULL;
     new_server->nick_modes = NULL;
+    new_server->checking_cap_ls = 0;
     new_server->cap_ls = weechat_hashtable_new (32,
                                                 WEECHAT_HASHTABLE_STRING,
                                                 WEECHAT_HASHTABLE_STRING,
                                                 NULL,
                                                 NULL);
+    new_server->checking_cap_list = 0;
     new_server->cap_list = weechat_hashtable_new (32,
                                                   WEECHAT_HASHTABLE_STRING,
                                                   WEECHAT_HASHTABLE_STRING,
@@ -3542,7 +3544,7 @@ irc_server_login (struct t_irc_server *server)
 
     if (irc_server_sasl_enabled (server) || (capabilities && capabilities[0]))
     {
-        irc_server_sendf (server, 0, NULL, "CAP LS");
+        irc_server_sendf (server, 0, NULL, "CAP LS 302");
     }
 
     username2 = (username && username[0]) ?
@@ -4896,7 +4898,9 @@ irc_server_disconnect (struct t_irc_server *server, int switch_address,
         weechat_bar_item_update ("input_prompt");
         weechat_bar_item_update ("irc_nick_modes");
     }
+    server->checking_cap_ls = 0;
     weechat_hashtable_remove_all (server->cap_ls);
+    server->checking_cap_list = 0;
     weechat_hashtable_remove_all (server->cap_list);
     server->is_away = 0;
     server->away_time = 0;
@@ -5446,7 +5450,9 @@ irc_server_hdata_server_cb (const void *pointer, void *data,
         WEECHAT_HDATA_VAR(struct t_irc_server, nick_alternate_number, INTEGER, 0, NULL, NULL);
         WEECHAT_HDATA_VAR(struct t_irc_server, nick, STRING, 0, NULL, NULL);
         WEECHAT_HDATA_VAR(struct t_irc_server, nick_modes, STRING, 0, NULL, NULL);
+        WEECHAT_HDATA_VAR(struct t_irc_server, checking_cap_ls, INTEGER, 0, NULL, NULL);
         WEECHAT_HDATA_VAR(struct t_irc_server, cap_ls, HASHTABLE, 0, NULL, NULL);
+        WEECHAT_HDATA_VAR(struct t_irc_server, checking_cap_list, INTEGER, 0, NULL, NULL);
         WEECHAT_HDATA_VAR(struct t_irc_server, cap_list, HASHTABLE, 0, NULL, NULL);
         WEECHAT_HDATA_VAR(struct t_irc_server, isupport, STRING, 0, NULL, NULL);
         WEECHAT_HDATA_VAR(struct t_irc_server, prefix_modes, STRING, 0, NULL, NULL);
@@ -5669,7 +5675,11 @@ irc_server_add_to_infolist (struct t_infolist *infolist,
         return 0;
     if (!weechat_infolist_new_var_string (ptr_item, "nick_modes", server->nick_modes))
         return 0;
+    if (!weechat_infolist_new_var_integer (ptr_item, "checking_cap_ls", server->checking_cap_ls))
+        return 0;
     if (!weechat_hashtable_add_to_infolist (server->cap_ls, ptr_item, "cap_ls"))
+        return 0;
+    if (!weechat_infolist_new_var_integer (ptr_item, "checking_cap_list", server->checking_cap_list))
         return 0;
     if (!weechat_hashtable_add_to_infolist (server->cap_list, ptr_item, "cap_list"))
         return 0;
@@ -6051,9 +6061,11 @@ irc_server_print_log ()
         weechat_log_printf ("  nick_alternate_number: %d",    ptr_server->nick_alternate_number);
         weechat_log_printf ("  nick . . . . . . . . : '%s'",  ptr_server->nick);
         weechat_log_printf ("  nick_modes . . . . . : '%s'",  ptr_server->nick_modes);
+        weechat_log_printf ("  checking_cap_ls. . . : %d",    ptr_server->checking_cap_ls);
         weechat_log_printf ("  cap_ls . . . . . . . : 0x%lx (hashtable: '%s')",
                             ptr_server->cap_ls,
                             weechat_hashtable_get_string (ptr_server->cap_ls, "keys_values"));
+        weechat_log_printf ("  checking_cap_list. . : %d",    ptr_server->checking_cap_list);
         weechat_log_printf ("  cap_list . . . . . . : 0x%lx (hashtable: '%s')",
                             ptr_server->cap_list,
                             weechat_hashtable_get_string (ptr_server->cap_list, "keys_values"));

--- a/src/plugins/irc/irc-server.c
+++ b/src/plugins/irc/irc-server.c
@@ -1167,9 +1167,16 @@ irc_server_alloc (const char *name)
     new_server->nick_alternate_number = -1;
     new_server->nick = NULL;
     new_server->nick_modes = NULL;
-    new_server->cap_away_notify = 0;
-    new_server->cap_account_notify = 0;
-    new_server->cap_extended_join = 0;
+    new_server->cap_ls = weechat_hashtable_new (32,
+                                                WEECHAT_HASHTABLE_STRING,
+                                                WEECHAT_HASHTABLE_STRING,
+                                                NULL,
+                                                NULL);
+    new_server->cap_list = weechat_hashtable_new (32,
+                                                  WEECHAT_HASHTABLE_STRING,
+                                                  WEECHAT_HASHTABLE_STRING,
+                                                  NULL,
+                                                  NULL);
     new_server->isupport = NULL;
     new_server->prefix_modes = NULL;
     new_server->prefix_chars = NULL;
@@ -3216,7 +3223,7 @@ irc_server_timer_cb (const void *pointer, void *data, int remaining_calls)
                 /* check away (only if lag check was not done) */
                 away_check = IRC_SERVER_OPTION_INTEGER(
                     ptr_server, IRC_SERVER_OPTION_AWAY_CHECK);
-                if (!ptr_server->cap_away_notify
+                if (!weechat_hashtable_has_key (ptr_server->cap_list, "away-notify")
                     && (away_check > 0)
                     && ((ptr_server->last_away_check == 0)
                         || (current_time >= ptr_server->last_away_check + (away_check * 60))))
@@ -4889,9 +4896,8 @@ irc_server_disconnect (struct t_irc_server *server, int switch_address,
         weechat_bar_item_update ("input_prompt");
         weechat_bar_item_update ("irc_nick_modes");
     }
-    server->cap_away_notify = 0;
-    server->cap_account_notify = 0;
-    server->cap_extended_join = 0;
+    weechat_hashtable_remove_all (server->cap_ls);
+    weechat_hashtable_remove_all (server->cap_list);
     server->is_away = 0;
     server->away_time = 0;
     server->lag = 0;
@@ -5440,9 +5446,8 @@ irc_server_hdata_server_cb (const void *pointer, void *data,
         WEECHAT_HDATA_VAR(struct t_irc_server, nick_alternate_number, INTEGER, 0, NULL, NULL);
         WEECHAT_HDATA_VAR(struct t_irc_server, nick, STRING, 0, NULL, NULL);
         WEECHAT_HDATA_VAR(struct t_irc_server, nick_modes, STRING, 0, NULL, NULL);
-        WEECHAT_HDATA_VAR(struct t_irc_server, cap_away_notify, INTEGER, 0, NULL, NULL);
-        WEECHAT_HDATA_VAR(struct t_irc_server, cap_account_notify, INTEGER, 0, NULL, NULL);
-        WEECHAT_HDATA_VAR(struct t_irc_server, cap_extended_join, INTEGER, 0, NULL, NULL);
+        WEECHAT_HDATA_VAR(struct t_irc_server, cap_ls, HASHTABLE, 0, NULL, NULL);
+        WEECHAT_HDATA_VAR(struct t_irc_server, cap_list, HASHTABLE, 0, NULL, NULL);
         WEECHAT_HDATA_VAR(struct t_irc_server, isupport, STRING, 0, NULL, NULL);
         WEECHAT_HDATA_VAR(struct t_irc_server, prefix_modes, STRING, 0, NULL, NULL);
         WEECHAT_HDATA_VAR(struct t_irc_server, prefix_chars, STRING, 0, NULL, NULL);
@@ -5664,11 +5669,9 @@ irc_server_add_to_infolist (struct t_infolist *infolist,
         return 0;
     if (!weechat_infolist_new_var_string (ptr_item, "nick_modes", server->nick_modes))
         return 0;
-    if (!weechat_infolist_new_var_integer (ptr_item, "cap_away_notify", server->cap_away_notify))
+    if (!weechat_hashtable_add_to_infolist (server->cap_ls, ptr_item, "cap_ls"))
         return 0;
-    if (!weechat_infolist_new_var_integer (ptr_item, "cap_account_notify", server->cap_account_notify))
-        return 0;
-    if (!weechat_infolist_new_var_integer (ptr_item, "cap_extended_join", server->cap_extended_join))
+    if (!weechat_hashtable_add_to_infolist (server->cap_list, ptr_item, "cap_list"))
         return 0;
     if (!weechat_infolist_new_var_string (ptr_item, "isupport", server->isupport))
         return 0;
@@ -6048,9 +6051,12 @@ irc_server_print_log ()
         weechat_log_printf ("  nick_alternate_number: %d",    ptr_server->nick_alternate_number);
         weechat_log_printf ("  nick . . . . . . . . : '%s'",  ptr_server->nick);
         weechat_log_printf ("  nick_modes . . . . . : '%s'",  ptr_server->nick_modes);
-        weechat_log_printf ("  cap_away_notify. . . : %d",    ptr_server->cap_away_notify);
-        weechat_log_printf ("  cap_account_notify . : %d",    ptr_server->cap_account_notify);
-        weechat_log_printf ("  cap_extended_join. . : %d",    ptr_server->cap_extended_join);
+        weechat_log_printf ("  cap_ls . . . . . . . : 0x%lx (hashtable: '%s')",
+                            ptr_server->cap_ls,
+                            weechat_hashtable_get_string (ptr_server->cap_ls, "keys_values"));
+        weechat_log_printf ("  cap_list . . . . . . : 0x%lx (hashtable: '%s')",
+                            ptr_server->cap_list,
+                            weechat_hashtable_get_string (ptr_server->cap_list, "keys_values"));
         weechat_log_printf ("  isupport . . . . . . : '%s'",  ptr_server->isupport);
         weechat_log_printf ("  prefix_modes . . . . : '%s'",  ptr_server->prefix_modes);
         weechat_log_printf ("  prefix_chars . . . . : '%s'",  ptr_server->prefix_chars);

--- a/src/plugins/irc/irc-server.h
+++ b/src/plugins/irc/irc-server.h
@@ -188,9 +188,8 @@ struct t_irc_server
                                     /* (nick____1, nick____2, ...)           */
     char *nick;                     /* current nickname                      */
     char *nick_modes;               /* nick modes                            */
-    int cap_away_notify;            /* 1 if capability away-notify is enabled*/
-    int cap_account_notify;         /* 1 if CAP account-notify is enabled    */
-    int cap_extended_join;          /* 1 if CAP extended-join is enabled     */
+    struct t_hashtable *cap_ls;     /* list of supported capabilities        */
+    struct t_hashtable *cap_list;   /* list of enabled capabilities          */
     char *isupport;                 /* copy of message 005 (ISUPPORT)        */
     char *prefix_modes;             /* prefix modes from msg 005 (eg "ohv")  */
     char *prefix_chars;             /* prefix chars from msg 005 (eg "@%+")  */

--- a/src/plugins/irc/irc-server.h
+++ b/src/plugins/irc/irc-server.h
@@ -121,6 +121,9 @@ enum t_irc_server_option
 #define IRC_SERVER_SEND_OUTQ_PRIO_LOW    2
 #define IRC_SERVER_SEND_RETURN_HASHTABLE 4
 
+/* version strings */
+#define IRC_SERVER_VERSION_CAP "302"
+
 /* casemapping (string comparisons for nicks/channels) */
 enum t_irc_server_casemapping
 {

--- a/src/plugins/irc/irc-server.h
+++ b/src/plugins/irc/irc-server.h
@@ -188,7 +188,9 @@ struct t_irc_server
                                     /* (nick____1, nick____2, ...)           */
     char *nick;                     /* current nickname                      */
     char *nick_modes;               /* nick modes                            */
+    int checking_cap_ls;            /* 1 if checking supported capabilities  */
     struct t_hashtable *cap_ls;     /* list of supported capabilities        */
+    int checking_cap_list;          /* 1 if checking enabled capabilities    */
     struct t_hashtable *cap_list;   /* list of enabled capabilities          */
     char *isupport;                 /* copy of message 005 (ISUPPORT)        */
     char *prefix_modes;             /* prefix modes from msg 005 (eg "ohv")  */

--- a/src/plugins/irc/irc-upgrade.c
+++ b/src/plugins/irc/irc-upgrade.c
@@ -375,9 +375,15 @@ irc_upgrade_read_cb (const void *pointer, void *data,
                     str = weechat_infolist_string (infolist, "nick_modes");
                     if (str)
                         irc_upgrade_current_server->nick_modes = strdup (str);
-                    irc_upgrade_current_server->cap_away_notify = weechat_infolist_integer (infolist, "cap_away_notify");
-                    irc_upgrade_current_server->cap_account_notify = weechat_infolist_integer (infolist, "cap_account_notify");
-                    irc_upgrade_current_server->cap_extended_join = weechat_infolist_integer (infolist, "cap_extended_join");
+                    /* TODO: "cap_list" is new in WeeChat x.y.z */
+                    if (weechat_infolist_integer (infolist, "cap_away_notify"))
+                        weechat_hashtable_set (irc_upgrade_current_server->cap_list, "away-notify", NULL);
+                    if (weechat_infolist_integer (infolist, "cap_account_notify"))
+                        weechat_hashtable_set (irc_upgrade_current_server->cap_list, "account-notify", NULL);
+                    if (weechat_infolist_integer (infolist, "cap_extended_join"))
+                        weechat_hashtable_set (irc_upgrade_current_server->cap_list, "extended-join", NULL);
+                    /* TODO: transfer all of "cap_ls" and "cap_list" */
+
                     str = weechat_infolist_string (infolist, "isupport");
                     if (str)
                         irc_upgrade_current_server->isupport = strdup (str);

--- a/src/plugins/irc/irc-upgrade.c
+++ b/src/plugins/irc/irc-upgrade.c
@@ -375,14 +375,26 @@ irc_upgrade_read_cb (const void *pointer, void *data,
                     str = weechat_infolist_string (infolist, "nick_modes");
                     if (str)
                         irc_upgrade_current_server->nick_modes = strdup (str);
-                    /* TODO: "cap_list" is new in WeeChat x.y.z */
+                    /* "cap_ls" and "cap_list" replace "cap_away_notify" and "cap_account_notify" in WeeChat x.y.z */
                     if (weechat_infolist_integer (infolist, "cap_away_notify"))
+                    {
+                        weechat_hashtable_set (irc_upgrade_current_server->cap_ls, "away-notify", NULL);
                         weechat_hashtable_set (irc_upgrade_current_server->cap_list, "away-notify", NULL);
+                    }
                     if (weechat_infolist_integer (infolist, "cap_account_notify"))
+                    {
+                        weechat_hashtable_set (irc_upgrade_current_server->cap_ls, "account-notify", NULL);
                         weechat_hashtable_set (irc_upgrade_current_server->cap_list, "account-notify", NULL);
+                    }
                     if (weechat_infolist_integer (infolist, "cap_extended_join"))
+                    {
+                        weechat_hashtable_set (irc_upgrade_current_server->cap_ls, "extended-join", NULL);
                         weechat_hashtable_set (irc_upgrade_current_server->cap_list, "extended-join", NULL);
-                    /* TODO: transfer all of "cap_ls" and "cap_list" */
+                    }
+                    weechat_hashtable_add_from_infolist (
+                        irc_upgrade_current_server->cap_ls, infolist, "cap_ls");
+                    weechat_hashtable_add_from_infolist (
+                        irc_upgrade_current_server->cap_list, infolist, "cap_list");
 
                     str = weechat_infolist_string (infolist, "isupport");
                     if (str)

--- a/src/plugins/plugin.c
+++ b/src/plugins/plugin.c
@@ -711,6 +711,7 @@ plugin_load (const char *filename, int init_plugin, int argc, char **argv)
         new_plugin->hashtable_get_string = &hashtable_get_string;
         new_plugin->hashtable_set_pointer = &hashtable_set_pointer;
         new_plugin->hashtable_add_to_infolist = &hashtable_add_to_infolist;
+        new_plugin->hashtable_add_from_infolist = &hashtable_add_from_infolist;
         new_plugin->hashtable_remove = &hashtable_remove;
         new_plugin->hashtable_remove_all = &hashtable_remove_all;
         new_plugin->hashtable_free = &hashtable_free;

--- a/src/plugins/weechat-plugin.h
+++ b/src/plugins/weechat-plugin.h
@@ -66,7 +66,7 @@ struct timeval;
  * please change the date with current one; for a second change at same
  * date, increment the 01, otherwise please keep 01.
  */
-#define WEECHAT_PLUGIN_API_VERSION "20170530-02"
+#define WEECHAT_PLUGIN_API_VERSION "20170617-01"
 
 /* macros for defining plugin infos */
 #define WEECHAT_PLUGIN_NAME(__name)                                     \
@@ -465,6 +465,9 @@ struct t_weechat_plugin
     int (*hashtable_add_to_infolist) (struct t_hashtable *hashtable,
                                       struct t_infolist_item *infolist_item,
                                       const char *prefix);
+    int (*hashtable_add_from_infolist) (struct t_hashtable *hashtable,
+                                        struct t_infolist *infolist,
+                                        const char *prefix);
     void (*hashtable_remove) (struct t_hashtable *hashtable, const void *key);
     void (*hashtable_remove_all) (struct t_hashtable *hashtable);
     void (*hashtable_free) (struct t_hashtable *hashtable);
@@ -1396,6 +1399,11 @@ extern int weechat_plugin_end (struct t_weechat_plugin *plugin);
     (weechat_plugin->hashtable_add_to_infolist)(__hashtable,            \
                                                 __infolist_item,        \
                                                 __prefix)
+#define weechat_hashtable_add_from_infolist(__hashtable, __infolist,    \
+                                            __prefix)                   \
+    (weechat_plugin->hashtable_add_from_infolist)(__hashtable,          \
+                                                  __infolist,           \
+                                                  __prefix)
 #define weechat_hashtable_remove(__hashtable, __key)                    \
     (weechat_plugin->hashtable_remove)(__hashtable, __key)
 #define weechat_hashtable_remove_all(__hashtable)                       \

--- a/tests/unit/core/test-hashtable.cpp
+++ b/tests/unit/core/test-hashtable.cpp
@@ -359,6 +359,7 @@ TEST(Hashtable, Properties)
 /*
  * Tests functions:
  *   hashtable_add_to_infolist
+ *   hashtable_add_from_infolist
  */
 
 TEST(Hashtable, Infolist)


### PR DESCRIPTION
In addition to implementing required changes to support capabilities with values and `CAP LS`/`CAP LIST` split across multiple lines, this patch also adds client-side tracking of all capabilities. This means that weechat/plugins/scripts/triggers can easily check if some capability is available or enabled, instead of having to somehow check itself.

This also modifies `/cap` command to uppercase the subcommand which it can autocomplete because servers may require it to be uppercase.

API was changed to allow keeping track of server capabilities across upgrading so the hashtable needs to be restored from an infolist.

There's a few places with comments like `WeeChat x.y.z` which need to be updated to the proper WeeChat version this gets merged into.

_NB! This patch is in conflict with #580. I would merge this before as it's a more core change. I could modify #580 to easily merge on top of this once this gets merged._
