### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/plugins/javascript/weechat-js-api.cpp
+++ b/src/plugins/javascript/weechat-js-api.cpp
@@ -25,6 +25,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <string>
+#include <time.h>
 
 extern "C"
 {


### PR DESCRIPTION
The error message is as follows:
```
/usr/ports/irc/weechat/work/weechat-1.3/src/plugins/javascript/weechat-js-api.cpp:4206:16: error: use of undeclared identifier
      'localtime'
    date_tmp = localtime (&time);
               ^
/usr/ports/irc/weechat/work/weechat-1.3/src/plugins/javascript/weechat-js-api.cpp:4208:9: error: use of undeclared identifier
      'strftime'
        strftime (timebuffer, sizeof (timebuffer), "%F %T", date_tmp);
        ^
```