### PR TITLE
core: add hash seed to nick colors to allow for reshuffling of colors

### DIFF
--- a/src/core/wee-config.c
+++ b/src/core/wee-config.c
@@ -152,6 +152,7 @@ struct t_config_option *config_look_mouse;
 struct t_config_option *config_look_mouse_timer_delay;
 struct t_config_option *config_look_nick_color_force;
 struct t_config_option *config_look_nick_color_hash;
+struct t_config_option *config_look_nick_color_hash_seed;
 struct t_config_option *config_look_nick_color_stop_chars;
 struct t_config_option *config_look_nick_prefix;
 struct t_config_option *config_look_nick_suffix;
@@ -3140,6 +3141,13 @@ config_weechat_init_options ()
            "of djb2 (position of letters matters: anagrams of a nick have "
            "different color), sum = sum of letters"),
         "djb2|sum", 0, 0, "djb2", NULL, 0,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+    config_look_nick_color_hash_seed = config_file_new_option (
+        weechat_config_file, ptr_section,
+        "nick_color_hash_seed", "string",
+        N_("seed to be used with the hash algorithm used for nick colors; "
+           "modifying this shuffles nick colors"),
+        NULL, 0, 0, "", NULL, 0,
         NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
     config_look_nick_color_stop_chars = config_file_new_option (
         weechat_config_file, ptr_section,

--- a/src/core/wee-config.c
+++ b/src/core/wee-config.c
@@ -152,7 +152,7 @@ struct t_config_option *config_look_mouse;
 struct t_config_option *config_look_mouse_timer_delay;
 struct t_config_option *config_look_nick_color_force;
 struct t_config_option *config_look_nick_color_hash;
-struct t_config_option *config_look_nick_color_hash_seed;
+struct t_config_option *config_look_nick_color_hash_salt;
 struct t_config_option *config_look_nick_color_stop_chars;
 struct t_config_option *config_look_nick_prefix;
 struct t_config_option *config_look_nick_suffix;
@@ -3142,10 +3142,10 @@ config_weechat_init_options ()
            "different color), sum = sum of letters"),
         "djb2|sum", 0, 0, "djb2", NULL, 0,
         NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-    config_look_nick_color_hash_seed = config_file_new_option (
+    config_look_nick_color_hash_salt = config_file_new_option (
         weechat_config_file, ptr_section,
-        "nick_color_hash_seed", "string",
-        N_("seed to be used with the hash algorithm used for nick colors; "
+        "nick_color_hash_salt", "string",
+        N_("salt to be used with the hash algorithm used for nick colors; "
            "modifying this shuffles nick colors"),
         NULL, 0, 0, "", NULL, 0,
         NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/src/core/wee-config.h
+++ b/src/core/wee-config.h
@@ -203,6 +203,7 @@ extern struct t_config_option *config_look_mouse;
 extern struct t_config_option *config_look_mouse_timer_delay;
 extern struct t_config_option *config_look_nick_color_force;
 extern struct t_config_option *config_look_nick_color_hash;
+extern struct t_config_option *config_look_nick_color_hash_seed;
 extern struct t_config_option *config_look_nick_color_stop_chars;
 extern struct t_config_option *config_look_nick_prefix;
 extern struct t_config_option *config_look_nick_suffix;

--- a/src/core/wee-config.h
+++ b/src/core/wee-config.h
@@ -203,7 +203,7 @@ extern struct t_config_option *config_look_mouse;
 extern struct t_config_option *config_look_mouse_timer_delay;
 extern struct t_config_option *config_look_nick_color_force;
 extern struct t_config_option *config_look_nick_color_hash;
-extern struct t_config_option *config_look_nick_color_hash_seed;
+extern struct t_config_option *config_look_nick_color_hash_salt;
 extern struct t_config_option *config_look_nick_color_stop_chars;
 extern struct t_config_option *config_look_nick_prefix;
 extern struct t_config_option *config_look_nick_suffix;

--- a/src/gui/gui-nick.c
+++ b/src/gui/gui-nick.c
@@ -59,16 +59,16 @@ gui_nick_hash_color (const char *nickname)
     if (config_num_nick_colors == 0)
         return 0;
 
-    /* avoid unnecessary allocation and string operations with empty seed */
-    if (CONFIG_STRING(config_look_nick_color_hash_seed))
+    /* avoid unnecessary allocation and string operations with empty salt */
+    if (CONFIG_STRING(config_look_nick_color_hash_salt))
     {
-        length = strlen (CONFIG_STRING(config_look_nick_color_hash_seed)) +
+        length = strlen (CONFIG_STRING(config_look_nick_color_hash_salt)) +
                  strlen (nickname) + 1;
         str = malloc (length);
         if (str)
         {
             snprintf (str, length, "%s%s",
-                      CONFIG_STRING(config_look_nick_color_hash_seed),
+                      CONFIG_STRING(config_look_nick_color_hash_salt),
                       nickname);
             ptr_nick = str;
         }

--- a/src/gui/gui-nick.c
+++ b/src/gui/gui-nick.c
@@ -59,15 +59,23 @@ gui_nick_hash_color (const char *nickname)
     if (config_num_nick_colors == 0)
         return 0;
 
-    length = strlen (CONFIG_STRING(config_look_nick_color_hash_seed)) +
-             strlen (nickname) + 1;
-    str = malloc (length);
-    if (str)
+    /* avoid unnecessary allocation and string operations with empty seed */
+    if (CONFIG_STRING(config_look_nick_color_hash_seed))
     {
-        snprintf (str, length, "%s%s",
-                  CONFIG_STRING(config_look_nick_color_hash_seed),
-                  nickname);
-        ptr_nick = str;
+        length = strlen (CONFIG_STRING(config_look_nick_color_hash_seed)) +
+                 strlen (nickname) + 1;
+        str = malloc (length);
+        if (str)
+        {
+            snprintf (str, length, "%s%s",
+                      CONFIG_STRING(config_look_nick_color_hash_seed),
+                      nickname);
+            ptr_nick = str;
+        }
+        else
+        {
+            ptr_nick = nickname;
+        }
     }
     else
     {

--- a/src/gui/gui-nick.c
+++ b/src/gui/gui-nick.c
@@ -46,6 +46,8 @@ int
 gui_nick_hash_color (const char *nickname)
 {
     unsigned long color;
+    int length;
+    char *str;
     const char *ptr_nick;
 
     if (!nickname || !nickname[0])
@@ -57,7 +59,21 @@ gui_nick_hash_color (const char *nickname)
     if (config_num_nick_colors == 0)
         return 0;
 
-    ptr_nick = nickname;
+    length = strlen (CONFIG_STRING(config_look_nick_color_hash_seed)) +
+             strlen (nickname) + 1;
+    str = malloc (length);
+    if (str)
+    {
+        snprintf (str, length, "%s%s",
+                  CONFIG_STRING(config_look_nick_color_hash_seed),
+                  nickname);
+        ptr_nick = str;
+    }
+    else
+    {
+        ptr_nick = nickname;
+    }
+
     color = 0;
 
     switch (CONFIG_INTEGER(config_look_nick_color_hash))
@@ -81,6 +97,9 @@ gui_nick_hash_color (const char *nickname)
             }
             break;
     }
+
+    if (str)
+        free (str);
 
     return (color % config_num_nick_colors);
 }


### PR DESCRIPTION
This patch adds the possibility of shuffling nick colors without having to choose a different hash algorithm or adding/removing colors in `chat_nick_colors`. The seed option's string is prepended to the nick before it's hashed. The default of an empty string means that by default, nothing gets changed from previous versions.

_Feature requested by m_ben in #weechat._
