### PR TITLE
Add extern keyword several places to link in osx

### DIFF
--- a/src/plugins/trigger/trigger-buffer.h
+++ b/src/plugins/trigger/trigger-buffer.h
@@ -22,7 +22,7 @@
 
 #define TRIGGER_BUFFER_NAME "monitor"
 
-struct t_gui_buffer *trigger_buffer;
+extern struct t_gui_buffer *trigger_buffer;
 
 extern void trigger_buffer_set_callbacks ();
 extern void trigger_buffer_open (const char *filter, int switch_to_buffer);

--- a/src/plugins/xfer/xfer-config.h
+++ b/src/plugins/xfer/xfer-config.h
@@ -42,9 +42,9 @@ extern struct t_config_option *xfer_config_network_port_range;
 extern struct t_config_option *xfer_config_network_speed_limit;
 extern struct t_config_option *xfer_config_network_timeout;
 
-struct t_config_option *xfer_config_file_auto_accept_chats;
-struct t_config_option *xfer_config_file_auto_accept_files;
-struct t_config_option *xfer_config_file_auto_accept_nicks;
+extern struct t_config_option *xfer_config_file_auto_accept_chats;
+extern struct t_config_option *xfer_config_file_auto_accept_files;
+extern struct t_config_option *xfer_config_file_auto_accept_nicks;
 extern struct t_config_option *xfer_config_file_auto_rename;
 extern struct t_config_option *xfer_config_file_auto_resume;
 extern struct t_config_option *xfer_config_file_auto_check_crc32;


### PR DESCRIPTION
This was causing trouble in osx linking

    duplicate symbol _trigger_buffer in:
        .libs/trigger.o
        .libs/trigger-buffer.o

and others (same error)