### PR TITLE
Another non-extern bad global declaration.

### DIFF
--- a/src/plugins/xfer/xfer-config.h
+++ b/src/plugins/xfer/xfer-config.h
@@ -42,9 +42,9 @@ extern struct t_config_option *xfer_config_network_port_range;
 extern struct t_config_option *xfer_config_network_speed_limit;
 extern struct t_config_option *xfer_config_network_timeout;
 
-struct t_config_option *xfer_config_file_auto_accept_chats;
-struct t_config_option *xfer_config_file_auto_accept_files;
-struct t_config_option *xfer_config_file_auto_accept_nicks;
+extern struct t_config_option *xfer_config_file_auto_accept_chats;
+extern struct t_config_option *xfer_config_file_auto_accept_files;
+extern struct t_config_option *xfer_config_file_auto_accept_nicks;
 extern struct t_config_option *xfer_config_file_auto_rename;
 extern struct t_config_option *xfer_config_file_auto_resume;
 extern struct t_config_option *xfer_config_file_auto_check_crc32;


### PR DESCRIPTION
Se pull request #656 

another non-extern declared global variable leads to multiple defined symbols on linking.  Perhaps some dependencies for header files must be checked?