### PR TITLE
Encode decode from server is misordered

### DIFF
--- a/src/plugins/irc/irc-config.c
+++ b/src/plugins/irc/irc-config.c
@@ -134,7 +134,6 @@ struct t_config_option *irc_config_color_topic_old;
 struct t_config_option *irc_config_network_autoreconnect_delay_growing;
 struct t_config_option *irc_config_network_autoreconnect_delay_max;
 struct t_config_option *irc_config_network_ban_mask_default;
-struct t_config_option *irc_config_network_channel_encode;
 struct t_config_option *irc_config_network_colors_receive;
 struct t_config_option *irc_config_network_colors_send;
 struct t_config_option *irc_config_network_lag_check;
@@ -2979,14 +2978,6 @@ irc_config_init ()
             "default mask is used only if WeeChat knows the host for the nick"),
         NULL, 0, 0, "*!$ident@$host", NULL, 0, NULL, NULL,
         NULL, NULL, NULL, NULL);
-    irc_config_network_channel_encode = weechat_config_new_option (
-        irc_config_file, ptr_section,
-        "channel_encode", "boolean",
-        N_("decode/encode channel name inside messages using charset options; "
-           "it is recommended to keep that off if you use only UTF-8 in "
-           "channel names; you can enable this option if you are using an "
-           "exotic charset like ISO in channel names"),
-        NULL, 0, 0, "off", NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL);
     irc_config_network_colors_receive = weechat_config_new_option (
         irc_config_file, ptr_section,
         "colors_receive", "boolean",

--- a/src/plugins/irc/irc-message.c
+++ b/src/plugins/irc/irc-message.c
@@ -27,6 +27,7 @@
 #include "irc.h"
 #include "irc-server.h"
 #include "irc-channel.h"
+#include "irc-message.h"
 
 
 /*
@@ -419,33 +420,11 @@ irc_message_parse_to_hashtable (struct t_irc_server *server,
  */
 
 char *
-irc_message_convert_charset (const char *message, int pos_start,
+irc_message_convert_charset (const char *message,
                              const char *modifier, const char *modifier_data)
 {
-    char *text, *msg_result;
-    int length;
-
-    text = weechat_hook_modifier_exec (modifier, modifier_data,
-                                       message + pos_start);
-    if (!text)
-        return NULL;
-
-    length = pos_start + strlen (text) + 1;
-    msg_result = malloc (length);
-    if (msg_result)
-    {
-        msg_result[0] = '\0';
-        if (pos_start > 0)
-        {
-            memcpy (msg_result, message, pos_start);
-            msg_result[pos_start] = '\0';
-        }
-        strcat (msg_result, text);
-    }
-
-    free (text);
-
-    return msg_result;
+    return weechat_hook_modifier_exec (
+            modifier, modifier_data, message);
 }
 
 

--- a/src/plugins/irc/irc-message.h
+++ b/src/plugins/irc/irc-message.h
@@ -32,7 +32,6 @@ extern void irc_message_parse (struct t_irc_server *server, const char *message,
 extern struct t_hashtable *irc_message_parse_to_hashtable (struct t_irc_server *server,
                                                            const char *message);
 extern char *irc_message_convert_charset (const char *message,
-                                          int pos_start,
                                           const char *modifier,
                                           const char *modifier_data);
 extern const char *irc_message_get_nick_from_host (const char *host);

--- a/src/plugins/irc/irc-server.c
+++ b/src/plugins/irc/irc-server.c
@@ -2070,7 +2070,6 @@ irc_server_send_one_msg (struct t_irc_server *server, int flags,
     char *new_msg, *pos, *tags_to_send, *msg_encoded;
     char str_modifier[128], modifier_data[256];
     int rc, queue_msg, add_to_queue, first_message, anti_flood;
-    int pos_channel, pos_text, pos_encode;
     time_t time_now;
     struct t_irc_redirect *ptr_redirect;
 
@@ -2098,34 +2097,26 @@ irc_server_send_one_msg (struct t_irc_server *server, int flags,
         ptr_msg = (new_msg) ? new_msg : message;
 
         msg_encoded = NULL;
-        irc_message_parse (server, ptr_msg, NULL, NULL, NULL, NULL, NULL, NULL,
-                           NULL, NULL, NULL, NULL, &pos_channel, &pos_text);
-        if (weechat_config_boolean (irc_config_network_channel_encode))
-            pos_encode = (pos_channel >= 0) ? pos_channel : pos_text;
-        else
-            pos_encode = pos_text;
-        if (pos_encode >= 0)
+        ptr_chan_nick = (channel) ? channel : nick;
+        if (ptr_chan_nick)
         {
-            ptr_chan_nick = (channel) ? channel : nick;
-            if (ptr_chan_nick)
-            {
-                snprintf (modifier_data, sizeof (modifier_data),
-                          "%s.%s.%s",
-                          weechat_plugin->name,
-                          server->name,
-                          ptr_chan_nick);
-            }
-            else
-            {
-                snprintf (modifier_data, sizeof (modifier_data),
-                          "%s.%s",
-                          weechat_plugin->name,
-                          server->name);
-            }
-            msg_encoded = irc_message_convert_charset (ptr_msg, pos_encode,
-                                                       "charset_encode",
-                                                       modifier_data);
+            snprintf (modifier_data, sizeof (modifier_data),
+                      "%s.%s.%s",
+                      weechat_plugin->name,
+                      server->name,
+                      ptr_chan_nick);
         }
+        else
+        {
+            snprintf (modifier_data, sizeof (modifier_data),
+                      "%s.%s",
+                      weechat_plugin->name,
+                      server->name);
+        }
+        msg_encoded = irc_message_convert_charset (
+                ptr_msg,
+                "charset_encode",
+                modifier_data);
 
         if (msg_encoded)
             ptr_msg = msg_encoded;
@@ -2643,8 +2634,9 @@ irc_server_msgq_flush ()
                                     }
                                 }
                                 msg_decoded = irc_message_convert_charset (
-                                    ptr_msg, pos_decode,
-                                    "charset_decode", modifier_data);
+                                    ptr_msg,
+                                    "charset_decode",
+                                    modifier_data);
                             }
 
                             /* replace WeeChat internal color codes by "?" */

--- a/src/plugins/irc/irc-server.c
+++ b/src/plugins/irc/irc-server.c
@@ -2589,37 +2589,14 @@ irc_server_msgq_flush ()
                             }
 
                             msg_decoded = NULL;
+
                             /* convert charset for message */
-                            if (channel
-                                && irc_channel_is_channel (irc_recv_msgq->server,
-                                                           channel))
-                            {
-                                snprintf (modifier_data, sizeof (modifier_data),
-                                          "%s.%s.%s",
-                                          weechat_plugin->name,
-                                          irc_recv_msgq->server->name,
-                                          channel);
-                            }
-                            else
-                            {
-                                if (nick && (!host || (strcmp (nick, host) != 0)))
-                                {
-                                    snprintf (modifier_data,
-                                              sizeof (modifier_data),
-                                              "%s.%s.%s",
-                                              weechat_plugin->name,
-                                              irc_recv_msgq->server->name,
-                                              nick);
-                                }
-                                else
-                                {
-                                    snprintf (modifier_data,
-                                              sizeof (modifier_data),
-                                              "%s.%s",
-                                              weechat_plugin->name,
-                                              irc_recv_msgq->server->name);
-                                }
-                            }
+                            snprintf (modifier_data,
+                                      sizeof (modifier_data),
+                                      "%s.%s",
+                                      weechat_plugin->name,
+                                      irc_recv_msgq->server->name);
+
                             msg_decoded = irc_message_convert_charset (
                                 ptr_msg,
                                 "charset_decode",

--- a/src/plugins/irc/irc-server.c
+++ b/src/plugins/irc/irc-server.c
@@ -2528,7 +2528,6 @@ irc_server_msgq_flush ()
     char *tags, *nick, *host, *command, *channel, *arguments;
     char *msg_decoded, *msg_decoded_without_color;
     char str_modifier[128], modifier_data[256];
-    int pos_channel, pos_text, pos_decode;
 
     while (irc_recv_msgq)
     {
@@ -2589,55 +2588,49 @@ irc_server_msgq_flush ()
                                     ptr_msg);
                             }
 
+                            msg_decoded = NULL;
+                            /* convert charset for message */
+                            if (channel
+                                && irc_channel_is_channel (irc_recv_msgq->server,
+                                                           channel))
+                            {
+                                snprintf (modifier_data, sizeof (modifier_data),
+                                          "%s.%s.%s",
+                                          weechat_plugin->name,
+                                          irc_recv_msgq->server->name,
+                                          channel);
+                            }
+                            else
+                            {
+                                if (nick && (!host || (strcmp (nick, host) != 0)))
+                                {
+                                    snprintf (modifier_data,
+                                              sizeof (modifier_data),
+                                              "%s.%s.%s",
+                                              weechat_plugin->name,
+                                              irc_recv_msgq->server->name,
+                                              nick);
+                                }
+                                else
+                                {
+                                    snprintf (modifier_data,
+                                              sizeof (modifier_data),
+                                              "%s.%s",
+                                              weechat_plugin->name,
+                                              irc_recv_msgq->server->name);
+                                }
+                            }
+                            msg_decoded = irc_message_convert_charset (
+                                ptr_msg,
+                                "charset_decode",
+                                modifier_data);
+
                             irc_message_parse (irc_recv_msgq->server, ptr_msg,
                                                &tags, NULL, &nick, &host,
                                                &command, &channel, &arguments,
                                                NULL, NULL, NULL,
-                                               &pos_channel, &pos_text);
+                                               NULL, NULL);
 
-                            msg_decoded = NULL;
-                            if (weechat_config_boolean (irc_config_network_channel_encode))
-                                pos_decode = (pos_channel >= 0) ? pos_channel : pos_text;
-                            else
-                                pos_decode = pos_text;
-                            if (pos_decode >= 0)
-                            {
-                                /* convert charset for message */
-                                if (channel
-                                    && irc_channel_is_channel (irc_recv_msgq->server,
-                                                               channel))
-                                {
-                                    snprintf (modifier_data, sizeof (modifier_data),
-                                              "%s.%s.%s",
-                                              weechat_plugin->name,
-                                              irc_recv_msgq->server->name,
-                                              channel);
-                                }
-                                else
-                                {
-                                    if (nick && (!host || (strcmp (nick, host) != 0)))
-                                    {
-                                        snprintf (modifier_data,
-                                                  sizeof (modifier_data),
-                                                  "%s.%s.%s",
-                                                  weechat_plugin->name,
-                                                  irc_recv_msgq->server->name,
-                                                  nick);
-                                    }
-                                    else
-                                    {
-                                        snprintf (modifier_data,
-                                                  sizeof (modifier_data),
-                                                  "%s.%s",
-                                                  weechat_plugin->name,
-                                                  irc_recv_msgq->server->name);
-                                    }
-                                }
-                                msg_decoded = irc_message_convert_charset (
-                                    ptr_msg,
-                                    "charset_decode",
-                                    modifier_data);
-                            }
 
                             /* replace WeeChat internal color codes by "?" */
                             msg_decoded_without_color =

--- a/src/plugins/xfer/xfer-config.h
+++ b/src/plugins/xfer/xfer-config.h
@@ -42,9 +42,9 @@ extern struct t_config_option *xfer_config_network_port_range;
 extern struct t_config_option *xfer_config_network_speed_limit;
 extern struct t_config_option *xfer_config_network_timeout;
 
-extern struct t_config_option *xfer_config_file_auto_accept_chats;
-extern struct t_config_option *xfer_config_file_auto_accept_files;
-extern struct t_config_option *xfer_config_file_auto_accept_nicks;
+struct t_config_option *xfer_config_file_auto_accept_chats;
+struct t_config_option *xfer_config_file_auto_accept_files;
+struct t_config_option *xfer_config_file_auto_accept_nicks;
 extern struct t_config_option *xfer_config_file_auto_rename;
 extern struct t_config_option *xfer_config_file_auto_resume;
 extern struct t_config_option *xfer_config_file_auto_check_crc32;


### PR DESCRIPTION
the charset encoder/decoder is broken.  When encoding to server, we first construct the message and just before sending we encode it, so all masks and channels are encoded in weechat in utf-8 and to the server in its charset.  On receiving, messages are first parsed and then partially decoded, making the masks and targets to remain in the native charset of the server, which is incorrect.  I have patched the receiving code to allow for server charset masks (irc-hispano allows to fix the domain and allows iso-8859-15 chars in virtual addresses, also in channel names)  making unnecessary the config parameter **irc.network.channel_encode** and allowing only the `irc.<server>` modifier (no more allowance to `irc.<server>.<channel_or_nick>` modifiers in charset decoding)