### PR TITLE
xfer: Compute speed/eta with microsecond precision

### DIFF
--- a/src/plugins/xfer/xfer-command.c
+++ b/src/plugins/xfer/xfer-command.c
@@ -165,7 +165,7 @@ xfer_command_xfer_list (int full)
                                     ptr_xfer->remote_address_str,
                                     ptr_xfer->port);
                     date[0] = '\0';
-                    date_tmp = localtime (&(ptr_xfer->start_transfer));
+                    date_tmp = localtime (&(ptr_xfer->start_transfer.tv_sec));
                     if (date_tmp)
                     {
                         strftime (date, sizeof (date),

--- a/src/plugins/xfer/xfer-file.c
+++ b/src/plugins/xfer/xfer-file.c
@@ -168,37 +168,38 @@ xfer_file_find_filename (struct t_xfer *xfer)
 void
 xfer_file_calculate_speed (struct t_xfer *xfer, int ended)
 {
-    time_t local_time, elapsed;
+    struct timeval local_time;
+    long long elapsed_us;
     unsigned long long bytes_per_sec_total;
 
-    local_time = time (NULL);
-    if (ended || local_time > xfer->last_check_time)
+    gettimeofday(&local_time, NULL);
+    if (ended || weechat_util_timeval_cmp(&local_time, &xfer->last_check_time) > 0)
     {
         if (ended)
         {
             /* calculate bytes per second (global) */
-            elapsed = local_time - xfer->start_transfer;
-            if (elapsed == 0)
-                elapsed = 1;
-            xfer->bytes_per_sec = (xfer->pos - xfer->start_resume) / elapsed;
+            elapsed_us = weechat_util_timeval_diff(&xfer->start_transfer, &local_time);
+            if (elapsed_us == 0)
+                elapsed_us = 1;
+            xfer->bytes_per_sec = ((xfer->pos - xfer->start_resume) * 1000000.0) / elapsed_us;
             xfer->eta = 0;
         }
         else
         {
             /* calculate ETA */
-            elapsed = local_time - xfer->start_transfer;
-            if (elapsed == 0)
-                elapsed = 1;
-            bytes_per_sec_total = (xfer->pos - xfer->start_resume) / elapsed;
+            elapsed_us = weechat_util_timeval_diff(&xfer->start_transfer, &local_time);
+            if (elapsed_us == 0)
+                elapsed_us = 1;
+            bytes_per_sec_total = ((xfer->pos - xfer->start_resume) * 1000000.0) / elapsed_us;
             if (bytes_per_sec_total == 0)
                 bytes_per_sec_total = 1;
             xfer->eta = (xfer->size - xfer->pos) / bytes_per_sec_total;
 
             /* calculate bytes per second (since last check time) */
-            elapsed = local_time - xfer->last_check_time;
-            if (elapsed == 0)
-                elapsed = 1;
-            xfer->bytes_per_sec = (xfer->pos - xfer->last_check_pos) / elapsed;
+            elapsed_us = weechat_util_timeval_diff(&xfer->last_check_time, &local_time);
+            if (elapsed_us == 0)
+                elapsed_us = 1;
+            xfer->bytes_per_sec = ((xfer->pos - xfer->last_check_pos) * 1000000.0) / elapsed_us;
         }
         xfer->last_check_time = local_time;
         xfer->last_check_pos = xfer->pos;

--- a/src/plugins/xfer/xfer-network.c
+++ b/src/plugins/xfer/xfer-network.c
@@ -178,8 +178,8 @@ xfer_network_child_read_cb (void *arg_xfer, int fd)
                 {
                     /* connection was successful by child, init transfer times */
                     xfer->status = XFER_STATUS_ACTIVE;
-                    xfer->start_transfer = time (NULL);
-                    xfer->last_check_time = time (NULL);
+                    gettimeofday(&xfer->start_transfer, NULL);
+                    xfer->last_check_time = xfer->start_transfer;
                     xfer_buffer_refresh (WEECHAT_HOTLIST_MESSAGE);
                 }
                 else
@@ -427,7 +427,7 @@ xfer_network_fd_cb (void *arg_xfer, int fd)
             xfer_set_remote_address (xfer, (struct sockaddr *)&addr, length,
                                      str_address);
             xfer->status = XFER_STATUS_ACTIVE;
-            xfer->start_transfer = time (NULL);
+            gettimeofday(&xfer->start_transfer, NULL);
             xfer_buffer_refresh (WEECHAT_HOTLIST_MESSAGE);
             xfer_network_send_file_fork (xfer);
         }

--- a/src/plugins/xfer/xfer.c
+++ b/src/plugins/xfer/xfer.c
@@ -483,7 +483,7 @@ xfer_alloc ()
     new_xfer->fast_send = weechat_config_boolean (xfer_config_network_fast_send);
     new_xfer->blocksize = weechat_config_integer (xfer_config_network_blocksize);
     new_xfer->start_time = time_now;
-    new_xfer->start_transfer = time_now;
+    gettimeofday(&new_xfer->start_transfer, NULL);
     new_xfer->sock = -1;
     new_xfer->child_pid = 0;
     new_xfer->child_read = -1;
@@ -498,7 +498,7 @@ xfer_alloc ()
     new_xfer->pos = 0;
     new_xfer->ack = 0;
     new_xfer->start_resume = 0;
-    new_xfer->last_check_time = time_now;
+    new_xfer->last_check_time = new_xfer->start_transfer;
     new_xfer->last_check_pos = time_now;
     new_xfer->last_activity = 0;
     new_xfer->bytes_per_sec = 0;
@@ -1604,7 +1604,7 @@ xfer_add_to_infolist (struct t_infolist *infolist, struct t_xfer *xfer)
         return 0;
     if (!weechat_infolist_new_var_time (ptr_item, "start_time", xfer->start_time))
         return 0;
-    if (!weechat_infolist_new_var_time (ptr_item, "start_transfer", xfer->start_transfer))
+    if (!weechat_infolist_new_var_time (ptr_item, "start_transfer", xfer->start_transfer.tv_sec))
         return 0;
     if (!weechat_infolist_new_var_integer (ptr_item, "sock", xfer->sock))
         return 0;
@@ -1637,7 +1637,7 @@ xfer_add_to_infolist (struct t_infolist *infolist, struct t_xfer *xfer)
     snprintf (value, sizeof (value), "%llu", xfer->start_resume);
     if (!weechat_infolist_new_var_string (ptr_item, "start_resume", value))
         return 0;
-    if (!weechat_infolist_new_var_time (ptr_item, "last_check_time", xfer->last_check_time))
+    if (!weechat_infolist_new_var_time (ptr_item, "last_check_time", xfer->last_check_time.tv_sec))
         return 0;
     snprintf (value, sizeof (value), "%llu", xfer->last_check_pos);
     if (!weechat_infolist_new_var_string (ptr_item, "last_check_pos", value))
@@ -1703,7 +1703,7 @@ xfer_print_log ()
         weechat_log_printf ("  fast_send . . . . . . . : %d",    ptr_xfer->fast_send);
         weechat_log_printf ("  blocksize . . . . . . . : %d",    ptr_xfer->blocksize);
         weechat_log_printf ("  start_time. . . . . . . : %ld",   ptr_xfer->start_time);
-        weechat_log_printf ("  start_transfer. . . . . : %ld",   ptr_xfer->start_transfer);
+        weechat_log_printf ("  start_transfer. . . . . : %ld",   ptr_xfer->start_transfer.tv_sec);
         weechat_log_printf ("  sock. . . . . . . . . . : %d",    ptr_xfer->sock);
         weechat_log_printf ("  child_pid . . . . . . . : %d",    ptr_xfer->child_pid);
         weechat_log_printf ("  child_read. . . . . . . : %d",    ptr_xfer->child_read);
@@ -1718,7 +1718,7 @@ xfer_print_log ()
         weechat_log_printf ("  pos . . . . . . . . . . : %llu",  ptr_xfer->pos);
         weechat_log_printf ("  ack . . . . . . . . . . : %llu",  ptr_xfer->ack);
         weechat_log_printf ("  start_resume. . . . . . : %llu",  ptr_xfer->start_resume);
-        weechat_log_printf ("  last_check_time . . . . : %ld",   ptr_xfer->last_check_time);
+        weechat_log_printf ("  last_check_time . . . . : %ld",   ptr_xfer->last_check_time.tv_sec);
         weechat_log_printf ("  last_check_pos. . . . . : %llu",  ptr_xfer->last_check_pos);
         weechat_log_printf ("  last_activity . . . . . : %ld",   ptr_xfer->last_activity);
         weechat_log_printf ("  bytes_per_sec . . . . . : %llu",  ptr_xfer->bytes_per_sec);

--- a/src/plugins/xfer/xfer.h
+++ b/src/plugins/xfer/xfer.h
@@ -156,7 +156,7 @@ struct t_xfer
     int fast_send;                     /* fast send file: does not wait ACK */
     int blocksize;                     /* block size for sending file       */
     time_t start_time;                 /* time when xfer started            */
-    time_t start_transfer;             /* time when xfer transfer started   */
+    struct timeval start_transfer;     /* time when xfer transfer started   */
     int sock;                          /* socket for connection             */
     pid_t child_pid;                   /* pid of child process (send/recv)  */
     int child_read;                    /* to read into child pipe           */
@@ -171,7 +171,7 @@ struct t_xfer
     unsigned long long pos;            /* number of bytes received/sent     */
     unsigned long long ack;            /* number of bytes received OK       */
     unsigned long long start_resume;   /* start of resume (in bytes)        */
-    time_t last_check_time;            /* last time we checked bytes snt/rcv*/
+    struct timeval last_check_time;    /* last time we checked bytes snt/rcv*/
     unsigned long long last_check_pos; /* bytes sent/recv at last check     */
     time_t last_activity;              /* time of last byte received/sent   */
     unsigned long long bytes_per_sec;  /* bytes per second                  */


### PR DESCRIPTION
Am trying to get rid of the sometimes-reported 2592352 TB/s (or some other enormous value) when just starting a file xfer.

It also seems to make the periodic updates a little more stable, but maybe I am imagining that.