### PR TITLE
Python plugin shared libraries missing

### DIFF
--- a/cmake/FindPython.cmake
+++ b/cmake/FindPython.cmake
@@ -57,7 +57,7 @@ if(PYTHON_EXECUTABLE)
     )
 
   execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} -c "import sys; from distutils.sysconfig import *; sys.stdout.write(get_config_var('LINKFORSHARED'))"
+    COMMAND ${PYTHON_EXECUTABLE} -c "import sys; from distutils.sysconfig import *; sys.stdout.write(get_config_var('LIBS') + ' ' + get_config_var('LINKFORSHARED'))"
     OUTPUT_VARIABLE PYTHON_LFLAGS
     )
 


### PR DESCRIPTION
When linking against a python with shared libraries, this script ONLY asked for the LD flags, not any additional libraries.  This could result in a condition where required libraries (such as libutil on Centos 6.7 against Python 2.7) are not loaded and the load of the plugin thus fails.  This change asks the python being linked against which libraries it was linked using, and then ensures those are also linked against by the python plugin for weechat.