### PR TITLE
xfer: ignore signals when polling socket during file receive (closes #677)

### DIFF
--- a/src/plugins/xfer/xfer-dcc.c
+++ b/src/plugins/xfer/xfer-dcc.c
@@ -368,9 +368,14 @@ xfer_dcc_recv_file_child (struct t_xfer *xfer)
         ready = poll (&poll_fd, 1, -1);
         if (ready <= 0)
         {
-            xfer_network_write_pipe (xfer, XFER_STATUS_FAILED,
-                                     XFER_ERROR_RECV_BLOCK);
-            return;
+            if ((errno == EINTR) || (errno == EAGAIN))
+                continue;
+            else
+            {
+                xfer_network_write_pipe (xfer, XFER_STATUS_FAILED,
+                                         XFER_ERROR_RECV_BLOCK);
+                return;
+            }
         }
 
         /* read maximum data on socket (until nothing is available) */


### PR DESCRIPTION
When signals (e.g. `SIGWINCH` for terminal resize) are fired they cause poll to fail with `EINTR`, erroring file receival even when there wasn't a problem with it.

This patch adds additional checks for `EINTR` and `EAGAIN` that cause retry of poll, since both are unrelated to actual file receival.