### PR TITLE
irc: add option irc.network.sasl_fail_unavailable (closes #600)

### DIFF
--- a/src/plugins/irc/irc-config.c
+++ b/src/plugins/irc/irc-config.c
@@ -142,6 +142,7 @@ struct t_config_option *irc_config_network_lag_reconnect;
 struct t_config_option *irc_config_network_lag_refresh_interval;
 struct t_config_option *irc_config_network_notify_check_ison;
 struct t_config_option *irc_config_network_notify_check_whois;
+struct t_config_option *irc_config_network_sasl_fail_unavailable;
 struct t_config_option *irc_config_network_send_unknown_commands;
 struct t_config_option *irc_config_network_whois_double_nick;
 
@@ -3004,6 +3005,12 @@ irc_config_init ()
            "(in minutes)"),
         NULL, 1, 60 * 24 * 7, "5", NULL, 0, NULL, NULL,
         &irc_config_change_network_notify_check_whois, NULL, NULL, NULL);
+    irc_config_network_sasl_fail_unavailable = weechat_config_new_option (
+        irc_config_file, ptr_section,
+        "sasl_fail_unavailable", "boolean",
+        N_("cause SASL authentication failure when SASL is requested but "
+           "unavailable"),
+        NULL, 0, 0, "on", NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL);
     irc_config_network_send_unknown_commands = weechat_config_new_option (
         irc_config_file, ptr_section,
         "send_unknown_commands", "boolean",

--- a/src/plugins/irc/irc-config.h
+++ b/src/plugins/irc/irc-config.h
@@ -183,6 +183,7 @@ extern struct t_config_option *irc_config_network_lag_reconnect;
 extern struct t_config_option *irc_config_network_lag_refresh_interval;
 extern struct t_config_option *irc_config_network_notify_check_ison;
 extern struct t_config_option *irc_config_network_notify_check_whois;
+extern struct t_config_option *irc_config_network_sasl_fail_unavailable;
 extern struct t_config_option *irc_config_network_send_unknown_commands;
 extern struct t_config_option *irc_config_network_whois_double_nick;
 

--- a/src/plugins/irc/irc-protocol.c
+++ b/src/plugins/irc/irc-protocol.c
@@ -345,7 +345,7 @@ IRC_PROTOCOL_CALLBACK(cap)
     const char *ptr_cap_option;
     int num_caps_supported, num_caps_requested, num_caps_added;
     int num_caps_removed, sasl_requested, sasl_to_do, sasl_mechanism;
-    int i, j, timeout, length;
+    int sasl_fail, i, j, timeout, length;
 
     IRC_PROTOCOL_MIN_ARGS(4);
 
@@ -429,6 +429,19 @@ IRC_PROTOCOL_CALLBACK(cap)
                             server->buffer,
                             _("%s%s: client capability: SASL not supported"),
                             weechat_prefix ("network"), IRC_PLUGIN_NAME);
+
+                        if (weechat_config_boolean (irc_config_network_sasl_fail_unavailable))
+                        {
+                            /* same handling as for sasl_end_fail */
+                            sasl_fail = IRC_SERVER_OPTION_INTEGER(server, IRC_SERVER_OPTION_SASL_FAIL);
+                            if ((sasl_fail == IRC_SERVER_SASL_FAIL_RECONNECT)
+                                || (sasl_fail == IRC_SERVER_SASL_FAIL_DISCONNECT))
+                            {
+                                irc_server_disconnect (
+                                    server, 0,
+                                    (sasl_fail == IRC_SERVER_SASL_FAIL_RECONNECT) ? 1 : 0);
+                            }
+                        }
                     }
                 }
                 if (cap_option)


### PR DESCRIPTION
Previously SASL did not fail when it was set up for the server but wasn't supported by it. This makes no difference when the server's sasl_fail is set to "continue" but might make a difference if set to "disconnect" or "reconnect".
To make sure server connection is not made under such circumstances, this patch adds an extra configurable ("on" by default) check to trigger SASL failure when it is set up but not supported by the server. Although not directly a SASL failure, this makes SASL not-authenticated scenarios all handled consistently, while providing extra security by not silently ignoring not being authenticated as requested.