### PR TITLE
core: fix the hardcoded separator in string_split_command

### DIFF
--- a/src/core/wee-string.c
+++ b/src/core/wee-string.c
@@ -2118,7 +2118,7 @@ string_split_command (const char *command, char separator)
     while(*ptr != '\0')
     {
         type = 0;
-        if (*ptr == ';')
+        if (*ptr == separator)
         {
             if (ptr == command)
                 type = 1;

--- a/tests/unit/core/test-string.cpp
+++ b/tests/unit/core/test-string.cpp
@@ -942,6 +942,16 @@ TEST(String, SplitCommand)
 
     string_free_split_command (argv);
 
+    /* separator other than ';' */
+    argv = string_split_command ("abc,de,fghi", ',');
+    CHECK(argv);
+    STRCMP_EQUAL("abc", argv[0]);
+    STRCMP_EQUAL("de", argv[1]);
+    STRCMP_EQUAL("fghi", argv[2]);
+    POINTERS_EQUAL(NULL, argv[3]);
+
+    string_free_split_command (argv);
+
     /* free split with NULL */
     string_free_split_command (NULL);
 }


### PR DESCRIPTION
The separator for string_split_command was hardcoded (`;`) instead of using the one from the function's arguments.
Not only did it not split strings with a different separator, it crashed WeeChat when `;` existed somewhere in the string.
It probably went unnoticed because in WeeChat's codebase it is only used with `;` as a separator.
I have modified the unit test to check whether it works with separator different than `;`.