### PR TITLE
gui: allow bar background color configuration in inactive windows

### DIFF
--- a/src/core/wee-config.c
+++ b/src/core/wee-config.c
@@ -97,6 +97,7 @@ struct t_config_option *config_look_buffer_search_regex;
 struct t_config_option *config_look_buffer_search_where;
 struct t_config_option *config_look_buffer_time_format;
 struct t_config_option *config_look_color_basic_force_bold;
+struct t_config_option *config_look_color_inactive_bar;
 struct t_config_option *config_look_color_inactive_buffer;
 struct t_config_option *config_look_color_inactive_message;
 struct t_config_option *config_look_color_inactive_prefix;
@@ -195,6 +196,7 @@ struct t_config_option *config_look_word_chars_input;
 
 /* config, colors section */
 
+struct t_config_option *config_color_bar_inactive_window;
 struct t_config_option *config_color_bar_more;
 struct t_config_option *config_color_chat;
 struct t_config_option *config_color_chat_bg;
@@ -2547,6 +2549,15 @@ config_weechat_init_options ()
         NULL, NULL, NULL,
         &config_change_color, NULL, NULL,
         NULL, NULL, NULL);
+    config_look_color_inactive_bar = config_file_new_option (
+        weechat_config_file, ptr_section,
+        "color_inactive_bar", "boolean",
+        N_("use a different color for bars in inactive window (when window "
+           "is not current window)"),
+        NULL, 0, 0, "off", NULL, 0,
+        NULL, NULL, NULL,
+        &config_change_buffers, NULL, NULL,
+        NULL, NULL, NULL);
     config_look_color_inactive_buffer = config_file_new_option (
         weechat_config_file, ptr_section,
         "color_inactive_buffer", "boolean",
@@ -3459,6 +3470,15 @@ config_weechat_init_options ()
     weechat_config_section_color = ptr_section;
 
     /* bar colors */
+    config_color_bar_inactive_window = config_file_new_option (
+        weechat_config_file, ptr_section,
+        "bar_inactive_window", "color",
+        N_("background color for bar when window is inactive (not current selected "
+           "window)"),
+        NULL, -1, 0, "darkgray", NULL, 0,
+        NULL, NULL, NULL,
+        &config_change_color, NULL, NULL,
+        NULL, NULL, NULL);
     config_color_bar_more = config_file_new_option (
         weechat_config_file, ptr_section,
         "bar_more", "color",

--- a/src/core/wee-config.h
+++ b/src/core/wee-config.h
@@ -148,6 +148,7 @@ extern struct t_config_option *config_look_buffer_search_regex;
 extern struct t_config_option *config_look_buffer_search_where;
 extern struct t_config_option *config_look_buffer_time_format;
 extern struct t_config_option *config_look_color_basic_force_bold;
+extern struct t_config_option *config_look_color_inactive_bar;
 extern struct t_config_option *config_look_color_inactive_buffer;
 extern struct t_config_option *config_look_color_inactive_message;
 extern struct t_config_option *config_look_color_inactive_prefix;
@@ -243,6 +244,7 @@ extern struct t_config_option *config_look_window_title;
 extern struct t_config_option *config_look_word_chars_highlight;
 extern struct t_config_option *config_look_word_chars_input;
 
+extern struct t_config_option *config_color_bar_inactive_window;
 extern struct t_config_option *config_color_bar_more;
 extern struct t_config_option *config_color_chat;
 extern struct t_config_option *config_color_chat_bg;

--- a/src/gui/curses/gui-curses-bar-window.c
+++ b/src/gui/curses/gui-curses-bar-window.c
@@ -163,6 +163,7 @@ gui_bar_window_create_win (struct t_gui_bar_window *bar_window)
 
 int
 gui_bar_window_print_string (struct t_gui_bar_window *bar_window,
+                             struct t_gui_window *window,
                              enum t_gui_bar_filling filling,
                              int *x, int *y,
                              const char *string,
@@ -170,7 +171,7 @@ gui_bar_window_print_string (struct t_gui_bar_window *bar_window,
                              int hide_chars_if_scrolling,
                              int *index_item, int *index_subitem, int *index_line)
 {
-    int x_with_hidden, size_on_screen, low_char, hidden;
+    int x_with_hidden, size_on_screen, low_char, hidden, color_bg;
     char utf_char[16], *next_char, *output;
 
     if (!bar_window || !string || !string[0])
@@ -178,11 +179,20 @@ gui_bar_window_print_string (struct t_gui_bar_window *bar_window,
 
     wmove (GUI_BAR_WINDOW_OBJECTS(bar_window)->win_bar, *y, *x);
 
+    color_bg = CONFIG_COLOR(bar_window->bar->options[GUI_BAR_OPTION_COLOR_BG]);
+    if (window
+        && (window != gui_current_window)
+        && CONFIG_BOOLEAN(config_look_color_inactive_bar)
+        && (color_bg != gui_color_search("default")))
+    {
+        color_bg = CONFIG_COLOR(config_color_bar_inactive_window);
+    }
+
     if (reset_color_before_display)
     {
         gui_window_set_custom_color_fg_bg (GUI_BAR_WINDOW_OBJECTS(bar_window)->win_bar,
                                            CONFIG_COLOR(bar_window->bar->options[GUI_BAR_OPTION_COLOR_FG]),
-                                           CONFIG_COLOR(bar_window->bar->options[GUI_BAR_OPTION_COLOR_BG]),
+                                           color_bg,
                                            1);
     }
 
@@ -241,7 +251,7 @@ gui_bar_window_print_string (struct t_gui_bar_window *bar_window,
                                 /* bar background */
                                 string += 2;
                                 gui_window_set_custom_color_bg (GUI_BAR_WINDOW_OBJECTS(bar_window)->win_bar,
-                                                                CONFIG_COLOR(bar_window->bar->options[GUI_BAR_OPTION_COLOR_BG]));
+                                                                color_bg);
                                 break;
                             case GUI_COLOR_BAR_START_INPUT_CHAR:
                                 string += 2;
@@ -303,7 +313,7 @@ gui_bar_window_print_string (struct t_gui_bar_window *bar_window,
                         string++;
                         gui_window_set_custom_color_fg_bg (GUI_BAR_WINDOW_OBJECTS(bar_window)->win_bar,
                                                            CONFIG_COLOR(bar_window->bar->options[GUI_BAR_OPTION_COLOR_FG]),
-                                                           CONFIG_COLOR(bar_window->bar->options[GUI_BAR_OPTION_COLOR_BG]),
+                                                           color_bg,
                                                            0);
                         break;
                     default:
@@ -328,7 +338,7 @@ gui_bar_window_print_string (struct t_gui_bar_window *bar_window,
                                                A_ALL_ATTR);
                 gui_window_set_custom_color_fg_bg (GUI_BAR_WINDOW_OBJECTS(bar_window)->win_bar,
                                                    CONFIG_COLOR(bar_window->bar->options[GUI_BAR_OPTION_COLOR_FG]),
-                                                   CONFIG_COLOR(bar_window->bar->options[GUI_BAR_OPTION_COLOR_BG]),
+                                                   color_bg,
                                                    1);
                 break;
             default:
@@ -423,6 +433,7 @@ gui_bar_window_draw (struct t_gui_bar_window *bar_window,
     int diff, max_length, optimal_number_of_lines;
     int some_data_not_displayed;
     int index_item, index_subitem, index_line;
+    int color_bg;
 
     if (!gui_init_ok)
         return;
@@ -451,6 +462,15 @@ gui_bar_window_draw (struct t_gui_bar_window *bar_window,
                   GUI_COLOR_COLOR_CHAR,
                   GUI_COLOR_BAR_CHAR,
                   GUI_COLOR_BAR_MOVE_CURSOR_CHAR);
+    }
+
+    color_bg = CONFIG_COLOR(bar_window->bar->options[GUI_BAR_OPTION_COLOR_BG]);
+    if (window
+        && (window != gui_current_window)
+        && CONFIG_BOOLEAN(config_look_color_inactive_bar)
+        && (color_bg != gui_color_search("default")))
+    {
+        color_bg = CONFIG_COLOR(config_color_bar_inactive_window);
     }
 
     /*
@@ -493,7 +513,7 @@ gui_bar_window_draw (struct t_gui_bar_window *bar_window,
                 gui_bar_window_set_current_size (bar_window, window, 1);
             gui_window_clear (GUI_BAR_WINDOW_OBJECTS(bar_window)->win_bar,
                               CONFIG_COLOR(bar_window->bar->options[GUI_BAR_OPTION_COLOR_FG]),
-                              CONFIG_COLOR(bar_window->bar->options[GUI_BAR_OPTION_COLOR_BG]));
+                              color_bg);
         }
         else
         {
@@ -548,7 +568,7 @@ gui_bar_window_draw (struct t_gui_bar_window *bar_window,
 
             gui_window_clear (GUI_BAR_WINDOW_OBJECTS(bar_window)->win_bar,
                               CONFIG_COLOR(bar_window->bar->options[GUI_BAR_OPTION_COLOR_FG]),
-                              CONFIG_COLOR(bar_window->bar->options[GUI_BAR_OPTION_COLOR_BG]));
+                              color_bg);
             x = 0;
             y = 0;
             some_data_not_displayed = 0;
@@ -641,7 +661,7 @@ gui_bar_window_draw (struct t_gui_bar_window *bar_window,
                 if ((bar_window->scroll_y == 0)
                     || (line >= bar_window->scroll_y))
                 {
-                    if (!gui_bar_window_print_string (bar_window, filling,
+                    if (!gui_bar_window_print_string (bar_window, window, filling,
                                                       &x, &y,
                                                       items[line], 1, 1,
                                                       &index_item,
@@ -657,7 +677,7 @@ gui_bar_window_draw (struct t_gui_bar_window *bar_window,
                         {
                             gui_window_set_custom_color_fg_bg (GUI_BAR_WINDOW_OBJECTS(bar_window)->win_bar,
                                                                CONFIG_COLOR(bar_window->bar->options[GUI_BAR_OPTION_COLOR_FG]),
-                                                               CONFIG_COLOR(bar_window->bar->options[GUI_BAR_OPTION_COLOR_BG]),
+                                                               color_bg,
                                                                1);
                             gui_window_remove_color_style (GUI_BAR_WINDOW_OBJECTS(bar_window)->win_bar,
                                                            A_ALL_ATTR);
@@ -670,7 +690,7 @@ gui_bar_window_draw (struct t_gui_bar_window *bar_window,
                         }
                         while (x < bar_window->width)
                         {
-                            gui_bar_window_print_string (bar_window, filling,
+                            gui_bar_window_print_string (bar_window, window, filling,
                                                          &x, &y, " ", 0, 0,
                                                          &index_item,
                                                          &index_subitem,
@@ -702,7 +722,7 @@ gui_bar_window_draw (struct t_gui_bar_window *bar_window,
                 {
                     gui_window_set_custom_color_fg_bg (GUI_BAR_WINDOW_OBJECTS(bar_window)->win_bar,
                                                        CONFIG_COLOR(config_color_bar_more),
-                                                       CONFIG_COLOR(bar_window->bar->options[GUI_BAR_OPTION_COLOR_BG]),
+                                                       color_bg,
                                                        1);
                     mvwaddstr (GUI_BAR_WINDOW_OBJECTS(bar_window)->win_bar,
                                y, x, ptr_string);
@@ -722,7 +742,7 @@ gui_bar_window_draw (struct t_gui_bar_window *bar_window,
                 {
                     gui_window_set_custom_color_fg_bg (GUI_BAR_WINDOW_OBJECTS(bar_window)->win_bar,
                                                        CONFIG_COLOR(config_color_bar_more),
-                                                       CONFIG_COLOR(bar_window->bar->options[GUI_BAR_OPTION_COLOR_BG]),
+                                                       color_bg,
                                                        1);
                     mvwaddstr (GUI_BAR_WINDOW_OBJECTS(bar_window)->win_bar,
                                y, x, ptr_string);
@@ -739,7 +759,7 @@ gui_bar_window_draw (struct t_gui_bar_window *bar_window,
             gui_bar_window_set_current_size (bar_window, window, 1);
         gui_window_clear (GUI_BAR_WINDOW_OBJECTS(bar_window)->win_bar,
                           CONFIG_COLOR(bar_window->bar->options[GUI_BAR_OPTION_COLOR_FG]),
-                          CONFIG_COLOR(bar_window->bar->options[GUI_BAR_OPTION_COLOR_BG]));
+                          color_bg);
     }
 
     /*


### PR DESCRIPTION
This patch adds the (non-default) option to change background color (also modifiable via option) for bars in inactive windows (if enabled by an existing option). If enabled, it does not affect root bars or bars with `default` background color (to keep the look of input bar). Foreground colors remain as before.

_Feature requested by passbe in #weechat:_

```
< passbe> Is there anyway to switch the color of a bar when the window the bar is shown
          in is inactive? Documentation doesn't show anything. Would this even be
          possible as what would happen when you have 2 windows showing the same buffer...
```
