### PR TITLE
irc: fix NULL pointer dereference in 734 command callback

### DIFF
--- a/src/plugins/irc/irc-protocol.c
+++ b/src/plugins/irc/irc-protocol.c
@@ -5384,7 +5384,12 @@ IRC_PROTOCOL_CALLBACK(733)
 
 IRC_PROTOCOL_CALLBACK(734)
 {
+    char *pos_args;
+
     IRC_PROTOCOL_MIN_ARGS(5);
+
+    pos_args = (argc > 5) ?
+        ((argv_eol[5][0] == ':') ? argv_eol[5] + 1 : argv_eol[5]) : NULL;
 
     weechat_printf_date_tags (
         irc_msgbuffer_get_target_buffer (
@@ -5393,7 +5398,7 @@ IRC_PROTOCOL_CALLBACK(734)
         irc_protocol_tags (command, "irc_numeric", NULL, NULL),
         "%s%s (%s)",
         weechat_prefix ("error"),
-        (argv_eol[5][0] == ':') ? argv_eol[5] + 1 : argv_eol[5],
+        (pos_args && pos_args[0]) ? pos_args : "",
         argv[3]);
 
     return WEECHAT_RC_OK;


### PR DESCRIPTION
The following server command makes weechat crash: ``:blah 734 a b c\r\n``. This patch (which is copy/paste of ``IRC_PROTOCOL_CALLBACK(733)``) should fix this issue.