### PR TITLE
doc: OSX gnutls path for Freenode

### DIFF
--- a/doc/en/weechat_faq.en.adoc
+++ b/doc/en/weechat_faq.en.adoc
@@ -544,6 +544,11 @@ Set option _weechat.network.gnutls_ca_file_ to file with certificates:
 Check that you have this file on your system (commonly brought by package
 "ca-certificates").
 
+Alternatively when running OSX with homebrew openssl installed, set:
+----
+/set weechat.network.gnutls_ca_file "/usr/local/etc/openssl/cert.pem"
+----
+
 Setup server port, SSL, then connect:
 
 ----


### PR DESCRIPTION
The default Freenode SSL fix does not work in OSX.  However, when the homebrew openssl package is installed (common in osx environments), a pem file containing the necessary certs is available.
