### PR TITLE
locale-sensitive dates (ONLY IF IT HAS TZ) #754

### DIFF
--- a/doc/de/autogen/user/irc_options.adoc
+++ b/doc/de/autogen/user/irc_options.adoc
@@ -115,7 +115,7 @@
 * [[option_irc.look.ctcp_time_format]] *irc.look.ctcp_time_format*
 ** Beschreibung: pass:none[Format für die Zeitanzeige die bei einer CTCP TIME Anfrage zurückgesendet wird (siehe man strftime, welche Platzhalter für das Datum und die Uhrzeit verwendet werden)]
 ** Typ: Zeichenkette
-** Werte: beliebige Zeichenkette (Standardwert: `+"%a, %d %b %Y %T %z"+`)
+** Werte: beliebige Zeichenkette (Standardwert: `+"%c"+`)
 
 * [[option_irc.look.display_away]] *irc.look.display_away*
 ** Beschreibung: pass:none[zeigt eine Nachricht an, sobald der Abwesenheitsstatus ein- bzw. ausgeschaltet wird (off: zeigt/sendet keine Nachricht, local: eine Nachricht wird lokal angezeigt, channel: sendet eine Nachricht an die Channels)]

--- a/doc/en/autogen/user/irc_options.adoc
+++ b/doc/en/autogen/user/irc_options.adoc
@@ -115,7 +115,7 @@
 * [[option_irc.look.ctcp_time_format]] *irc.look.ctcp_time_format*
 ** description: pass:none[time format used in answer to message CTCP TIME (see man strftime for date/time specifiers)]
 ** type: string
-** values: any string (default value: `+"%a, %d %b %Y %T %z"+`)
+** values: any string (default value: `+"%c"+`)
 
 * [[option_irc.look.display_away]] *irc.look.display_away*
 ** description: pass:none[display message when (un)marking as away (off: do not display/send anything, local: display locally, channel: send action to channels)]

--- a/doc/fr/autogen/user/irc_options.adoc
+++ b/doc/fr/autogen/user/irc_options.adoc
@@ -115,7 +115,7 @@
 * [[option_irc.look.ctcp_time_format]] *irc.look.ctcp_time_format*
 ** description: pass:none[format de date/heure utilisé pour la réponse au message CTCP TIME (voir man strftime pour le format de date/heure)]
 ** type: chaîne
-** valeurs: toute chaîne (valeur par défaut: `+"%a, %d %b %Y %T %z"+`)
+** valeurs: toute chaîne (valeur par défaut: `+"%c"+`)
 
 * [[option_irc.look.display_away]] *irc.look.display_away*
 ** description: pass:none[afficher un message pour l'absence/retour (off : ne rien afficher/envoyer, local : afficher en local, channel : envoyer l'action aux canaux)]

--- a/doc/it/autogen/user/irc_options.adoc
+++ b/doc/it/autogen/user/irc_options.adoc
@@ -115,7 +115,7 @@
 * [[option_irc.look.ctcp_time_format]] *irc.look.ctcp_time_format*
 ** descrizione: pass:none[formato dell'ora in risposta al messaggio CTCP TIME (consultare man strftime per i dettagli su data/ora)]
 ** tipo: stringa
-** valori: qualsiasi stringa (valore predefinito: `+"%a, %d %b %Y %T %z"+`)
+** valori: qualsiasi stringa (valore predefinito: `+"%c"+`)
 
 * [[option_irc.look.display_away]] *irc.look.display_away*
 ** descrizione: pass:none[mostra messaggio quando (non) si risulta assenti (off: non mostra/invia nulla, local: mostra localmente, channel: invia azioni ai canali)]

--- a/doc/ja/autogen/user/irc_options.adoc
+++ b/doc/ja/autogen/user/irc_options.adoc
@@ -115,7 +115,7 @@
 * [[option_irc.look.ctcp_time_format]] *irc.look.ctcp_time_format*
 ** 説明: pass:none[CTCP TIME メッセージに対する応答に利用される時間書式 (日付/時間指定子は strftime の man を参照)]
 ** タイプ: 文字列
-** 値: 未制約文字列 (デフォルト値: `+"%a, %d %b %Y %T %z"+`)
+** 値: 未制約文字列 (デフォルト値: `+"%c"+`)
 
 * [[option_irc.look.display_away]] *irc.look.display_away*
 ** 説明: pass:none[離席状態が変更されたらメッセージを表示 (off: 何も表示/送信しない、local: ローカルに表示、channel: チャンネルにアクションを送信)]

--- a/doc/pl/autogen/user/irc_options.adoc
+++ b/doc/pl/autogen/user/irc_options.adoc
@@ -115,7 +115,7 @@
 * [[option_irc.look.ctcp_time_format]] *irc.look.ctcp_time_format*
 ** opis: pass:none[format czasu używany w odpowiedzi na wiadomość CTCP TIME (zobacz man strftime dla specyfikatorów daty/czasu)]
 ** typ: ciąg
-** wartości: dowolny ciąg (domyślna wartość: `+"%a, %d %b %Y %T %z"+`)
+** wartości: dowolny ciąg (domyślna wartość: `+"%c"+`)
 
 * [[option_irc.look.display_away]] *irc.look.display_away*
 ** opis: pass:none[wyświetl wiadomość, kiedy w(y)łączamy tryb oddalenia (off: nie wyświetlaj/wysyłaj nic, local: wyświetl lokalnie, channel: wyślij akcję na kanały)]

--- a/src/plugins/irc/irc-config.c
+++ b/src/plugins/irc/irc-config.c
@@ -2537,7 +2537,7 @@ irc_config_init ()
         "ctcp_time_format", "string",
         N_("time format used in answer to message CTCP TIME (see man strftime "
            "for date/time specifiers)"),
-        NULL, 0, 0, "%a, %d %b %Y %T %z", NULL, 0,
+        NULL, 0, 0, "%c", NULL, 0,
         NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
     irc_config_look_display_away = weechat_config_new_option (
         irc_config_file, ptr_section,

--- a/src/plugins/relay/relay-buffer.c
+++ b/src/plugins/relay/relay-buffer.c
@@ -97,7 +97,7 @@ relay_buffer_refresh (const char *hotlist)
             if (date_tmp)
             {
                 strftime (str_date_start, sizeof (str_date_start),
-                          "%a, %d %b %Y %H:%M:%S", date_tmp);
+                          "%a, %d %b %Y %T", date_tmp);
             }
             str_date_end[0] = '-';
             str_date_end[1] = '\0';
@@ -107,7 +107,7 @@ relay_buffer_refresh (const char *hotlist)
                 if (date_tmp)
                 {
                     strftime (str_date_end, sizeof (str_date_end),
-                              "%a, %d %b %Y %H:%M:%S", date_tmp);
+                              "%a, %d %b %Y %T", date_tmp);
                 }
             }
 

--- a/src/plugins/relay/relay-command.c
+++ b/src/plugins/relay/relay-command.c
@@ -67,7 +67,7 @@ relay_command_client_list (int full)
         if (date_tmp)
         {
             strftime (date_start, sizeof (date_start),
-                      "%a, %d %b %Y %H:%M:%S", date_tmp);
+                      "%a, %d %b %Y %T", date_tmp);
         }
 
         date_activity[0] = '\0';
@@ -75,7 +75,7 @@ relay_command_client_list (int full)
         if (date_tmp)
         {
             strftime (date_activity, sizeof (date_activity),
-                      "%a, %d %b %Y %H:%M:%S", date_tmp);
+                      "%a, %d %b %Y %T", date_tmp);
         }
 
         if (full)
@@ -157,7 +157,7 @@ relay_command_server_list ()
                 if (date_tmp)
                 {
                     strftime (date_start, sizeof (date_start),
-                              "%a, %d %b %Y %H:%M:%S", date_tmp);
+                              "%a, %d %b %Y %T", date_tmp);
                 }
                 weechat_printf (
                     NULL,

--- a/src/plugins/xfer/xfer-buffer.c
+++ b/src/plugins/xfer/xfer-buffer.c
@@ -149,7 +149,7 @@ xfer_buffer_refresh (const char *hotlist)
                 if (date_tmp)
                 {
                     strftime (date, sizeof (date),
-                              "%a, %d %b %Y %H:%M:%S", date_tmp);
+                              "%a, %d %b %Y %T", date_tmp);
                 }
                 weechat_printf_y (xfer_buffer, (line * 2) + 3,
                                   "%s%s%s %s%s%s%s%s",

--- a/src/plugins/xfer/xfer-command.c
+++ b/src/plugins/xfer/xfer-command.c
@@ -135,7 +135,7 @@ xfer_command_xfer_list (int full)
                 if (date_tmp)
                 {
                     strftime (date, sizeof (date),
-                              "%a, %d %b %Y %H:%M:%S", date_tmp);
+                              "%a, %d %b %Y %T", date_tmp);
                 }
                 weechat_printf (NULL,
                                 /* TRANSLATORS: "%s" after "started on" is a date */
@@ -172,7 +172,7 @@ xfer_command_xfer_list (int full)
                     if (date_tmp)
                     {
                         strftime (date, sizeof (date),
-                                  "%a, %d %b %Y %H:%M:%S", date_tmp);
+                                  "%a, %d %b %Y %T", date_tmp);
                     }
                     weechat_printf (NULL,
                                     /* TRANSLATORS: "%s" after "started on" is a date */


### PR DESCRIPTION
in regards to #754, replace full date strings that have timezone with `%c` which has timezone

date strings without timezone remain locale-insensitive
