### PR TITLE
Use res_init before getaddrinfo.

### DIFF
--- a/src/plugins/irc/irc-server.c
+++ b/src/plugins/irc/irc-server.c
@@ -38,6 +38,7 @@
 #endif /* _WIN32 */
 #include <sys/types.h>
 #include <netdb.h>
+#include <resolv.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
 
@@ -5132,7 +5133,8 @@ irc_server_xfer_send_ready_cb (const void *pointer, void *data,
                                                          "local_address");
                 if (local_address)
                 {
-                    rc = getaddrinfo (local_address, NULL, NULL, &ainfo);
+		    if ((rc = res_init()) == 0)
+			rc = getaddrinfo (local_address, NULL, NULL, &ainfo);
                     if ((rc == 0) && ainfo && ainfo->ai_addr)
                     {
                         if (ainfo->ai_family == AF_INET)

--- a/src/plugins/xfer/xfer.c
+++ b/src/plugins/xfer/xfer.c
@@ -30,6 +30,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netdb.h>
+#include <resolv.h>
 #include <gcrypt.h>
 #include <arpa/inet.h>
 
@@ -966,6 +967,8 @@ xfer_resolve_addr (const char *str_address, const char *str_port,
     hints.ai_addr = NULL;
     hints.ai_next = NULL;
 
+    if (res_init() != 0)
+        return 0;
     rc = getaddrinfo (str_address, str_port, &hints, &ainfo);
     if ((rc == 0) && ainfo && ainfo->ai_addr)
     {


### PR DESCRIPTION
With weechat, if the network changes in anyway that causes resolv.conf
to be updated, that is not picked up, resulting in

    irc: connecting to server XXXX.com/1026 (SSL)...
    irc: address "XXX.com" not found
    irc: error: Name or service not known
    irc: reconnecting to server in 30 seconds

This happens, especially when one connects to an irc server behind a
VPN.

This can also happen when there is no network connectivity weechat was started
but later network is connected to.

The fix is simple, it relies on calling  res_init (3) before getaddrinfo in
network_connect_child and other places.

res_init reloads the resolv.conf and getaddrinfo does not fail with
address resolution error.