### PR TITLE
core: Allow for multiple gnutls CA files (closes #569)

### DIFF
--- a/src/core/wee-network.c
+++ b/src/core/wee-network.c
@@ -107,9 +107,32 @@ network_set_gnutls_ca_file ()
         ca_path2 = string_replace (ca_path, "%h", weechat_home);
         if (ca_path2)
         {
-            gnutls_certificate_set_x509_trust_file (gnutls_xcred, ca_path2,
-                                                    GNUTLS_X509_FMT_PEM);
+            char *ca_path3 = ca_path2;
+            char *single_path = malloc (strlen (ca_path3) + 1);
+
+            while (1) {
+                if (strchr (ca_path3, ':') == NULL)
+                {
+                    /* If there is no colon, just use the whole string and 
+                     * return. */
+                    gnutls_certificate_set_x509_trust_file (gnutls_xcred,
+                            ca_path3, GNUTLS_X509_FMT_PEM);
+                    break;
+                }
+                else
+                {
+                    /* If there is a colon in ca_path3, use the path up to the
+                     * colon, and feed it to the function */
+                    strncpy (single_path, ca_path3, 
+                            strchr (ca_path3, ':') - ca_path3);
+                    gnutls_certificate_set_x509_trust_file (gnutls_xcred,
+                            single_path, GNUTLS_X509_FMT_PEM);
+                    /* Then advance ca_path3 to the character after the colon */
+                    ca_path3 = strchr (ca_path3, ':') + 1;
+                }
+            };
             free (ca_path2);
+            free (single_path);
         }
         free (ca_path);
     }

--- a/src/core/wee-string.c
+++ b/src/core/wee-string.c
@@ -478,26 +478,47 @@ string_match (const char *string, const char *mask, int case_sensitive)
 char *
 string_expand_home (const char *path)
 {
-    char *ptr_home, *str;
-    int length;
+    char *ptr_home, *str, *d;
+    const char *c;
+    int path_start, replacements;
 
     if (!path)
         return NULL;
 
-    if (!path[0] || (path[0] != '~')
-        || ((path[1] && path[1] != DIR_SEPARATOR_CHAR)))
-    {
-        return strdup (path);
-    }
-
     ptr_home = getenv ("HOME");
 
-    length = strlen (ptr_home) + strlen (path + 1) + 1;
-    str = malloc (length);
-    if (!str)
-        return strdup (path);
+    /* 
+     * Count the parts separated by colons...
+     * a:b => parts = 2
+     * a => parts = 1
+     */
+    path_start = 1;
+    replacements = 0;
 
-    snprintf (str, length, "%s%s", ptr_home, path + 1);
+    for (c = path; *c != '\0'; c++)
+    {
+        if (path_start && strncmp(c, "~/", 2) == 0)
+            replacements++;
+        path_start = (*c == ':');
+    }
+
+    str = malloc (strlen (path) + 1
+                  + replacements * (strlen (ptr_home) - strlen ("~")));
+    str[0] = '\0';
+    d = str;
+    path_start = 1;
+
+    for (c = path; *c != '\0'; c++)
+    {
+        if (path_start && strncmp(c, "~/", 2) == 0)
+        {
+            strcpy (d, ptr_home);
+            d += strlen (ptr_home);
+        }
+        else
+            *d++ = *c;
+        path_start = (*c == ':');
+    }
 
     return str;
 }


### PR DESCRIPTION
This has been tested with two CA files, the merged one from my default SSL certificate store and the Hackint certificate, which is also my use case for this feature.

For specifying multiple CA files in weechat.conf, separate CA files with a colon in between. They will be added to the trusted certificates at start-up time (upon the call to `network_set_gnutls_ca_file`). I additionally amended `string_expand_home` in such a fashion that it is now able to replace `~/` with `/home/...` not only at the beginning of the string, but also after each colon in the string.

I propose to add some unit tests for the additional functionality of `string_expand_home` in a separate commit.