### PR TITLE
Fix for unclosed/leaking sockets from issue #358

### DIFF
--- a/src/plugins/irc/irc-server.c
+++ b/src/plugins/irc/irc-server.c
@@ -3504,12 +3504,13 @@ irc_server_connect_cb (const void *pointer, void *data,
     proxy = IRC_SERVER_OPTION_STRING(server, IRC_SERVER_OPTION_PROXY);
 
     server->hook_connect = NULL;
+    /* set socket */
+    server->sock = sock;
 
     switch (status)
     {
         case WEECHAT_HOOK_CONNECT_OK:
-            /* set socket and IP */
-            server->sock = sock;
+            /* set IP */
             if (server->current_ip)
                 free (server->current_ip);
             server->current_ip = (ip_address) ? strdup (ip_address) : NULL;


### PR DESCRIPTION
The issue was server->sock not being set unless the connection was successful. In the case of SSL connections, a connection could be established but not be successful because it wasn't an SSL port or the SSL certificate did not validate.  In those cases irc_server_close_connection() was called, but it was checking for server->sock != -1 before calling gnutls_bye() or close().  Since close() was never called for the socket, it would get stuck in the CLOSE_WAIT state until weechat was closed.

This will also fix issue #573 when the unclosed sockets exceed the fd limit.