### PR TITLE
tests: add wattr_get/set to fake

### DIFF
--- a/tests/ncurses-fake.c
+++ b/tests/ncurses-fake.c
@@ -91,6 +91,26 @@ wattr_off (WINDOW *win, attr_t attrs, void *opts)
 }
 
 int
+wattr_get (WINDOW *win, attr_t *attrs, short *pair, void *opts)
+{
+    (void) win;
+    (void) attrs;
+    (void) pair;
+    (void) opts;
+    return OK;
+}
+
+int
+wattr_set (WINDOW *win, attr_t *attrs, short *pair, void *opts)
+{
+    (void) win;
+    (void) attrs;
+    (void) pair;
+    (void) opts;
+    return OK;
+}
+
+int
 waddnstr(WINDOW *win, const char *str, int n)
 {
     (void) win;


### PR DESCRIPTION
I get this error compiling 1.7-dev on Fedora 24:

[ 98%] Built target weechat
[100%] Creating symbolic link weechat-curses
[100%] Built target weechat-curses
../src/gui/curses/libweechat_gui_curses.a(gui-curses-window.o): In function `gui_window_save_style':
gui-curses-window.c:(.text+0x44c): undefined reference to `wattr_get'
../src/gui/curses/libweechat_gui_curses.a(gui-curses-window.o): In function `gui_window_restore_style':
gui-curses-window.c:(.text+0x518): undefined reference to `wattr_set'
../src/gui/curses/libweechat_gui_curses.a(gui-curses-window.o): In function `gui_window_emphasize':
gui-curses-window.c:(.text+0xe50): undefined reference to `wattr_get'
collect2: error: ld returned 1 exit status
tests/CMakeFiles/tests.dir/build.make:108: recipe for target 'tests/tests' failed
make[2]: *** [tests/tests] Error 1
CMakeFiles/Makefile2:1977: recipe for target 'tests/CMakeFiles/tests.dir/all' failed
make[1]: *** [tests/CMakeFiles/tests.dir/all] Error 2
Makefile:160: recipe for target 'all' failed
make: *** [all] Error 2
