### PR TITLE
core: fix build with netbsd-curses [0]

### DIFF
--- a/src/gui/curses/gui-curses-term.c
+++ b/src/gui/curses/gui-curses-term.c
@@ -45,7 +45,7 @@
 void
 gui_term_set_eat_newline_glitch (int value)
 {
-#ifdef HAVE_EAT_NEWLINE_GLITCH
+#if defined(NCURSES_VERSION) && defined(HAVE_EAT_NEWLINE_GLITCH)
     eat_newline_glitch = value;
 #else
     /* make C compiler happy */


### PR DESCRIPTION
eat_newline_glitch is read-only on netbsd curses, so doing an assignment
breaks the build.
fix it by checking if we're using ncurses, which is obviously what the code's
author targeted.

[0] https://github.com/sabotage-linux/netbsd-curses
