### PR TITLE
api: fix string_expand_home SIGSEGV when HOME environment variable unset

### DIFF
--- a/src/core/wee-string.c
+++ b/src/core/wee-string.c
@@ -503,6 +503,8 @@ string_expand_home (const char *path)
     }
 
     ptr_home = getenv ("HOME");
+    if (!ptr_home)
+        return NULL;
 
     length = strlen (ptr_home) + strlen (path + 1) + 1;
     str = malloc (length);


### PR DESCRIPTION
When `HOME` is unset but `WEECHAT_HOME` is set (or provided by `-d` flag) and xfer plugin gets loaded and `xfer.file.upload_path` has the default value of `~` then a SIGSEGV occurs.

Bug found by garbas in #weechat.
```
< garbas> hey, i'm trying to run weechat in tmux via systemd. weechat crashes after i type in the password to uncrypt the secrets. any idea what am i going on? http://sprunge.us/cdLJ   
< garbas> i must be missing something in PATH or some variable is expected but not there                                                                                                 
< garbas> maybe somebody else is aware of some runtime dependency that is causing this crash                                                                                             
< sim642> the stacktrace isn't too useful in a non-debug setup                                                                                                                           
< sim642> but it says "xfer_create_directories"                                                                                                                                          
< garbas> sim642: sry i just found https://weechat.org/files/doc/devel/weechat_user.en.html#report_crashes and i'm getting proper crash report                                           
< sim642> if you can run all the necessary debugging tools however you're trying to run weechat, it'd be useful                                                                          
< sim642> do you have HOME env variable set there?                                                                                                                                       
< garbas> sim642: no, should i?                                                                                                                                                          
< sim642> Try setting it and seeing if it still crashes                                                                                                                                  
< sim642> if it doesn't, I know where the bug is                                                                                                                                         
< sim642> and I can suggest a workaround                                                                                                                                                 
< sim642> xfer.file.upload_path is "~" by default, which requires HOME env variable                                                                                                      
< sim642> if you change that path to something else, you should be fine                                                                                                                  
< garbas> ok i will change xfer.file.upload_path and see if this works... will be back in a second                                                                                       
<-- garbas (~garbas@81.4.127.29) has quit (Quit: WeeChat 1.6)                                                                                                                            
--> garbas (~garbas@81.4.127.29) has joined #weechat                                                                                                                                     
< garbas> sim642: that was it. setting xfer.file.upload_path fixed it                                                                                                                    
```