### PR TITLE
lua: Use lua_pushinteger for integer values in Lua 5.3+

### DIFF
--- a/src/plugins/lua/weechat-lua-api.c
+++ b/src/plugins/lua/weechat-lua-api.c
@@ -82,13 +82,21 @@
     if (__string)                                                       \
         free (__string);                                                \
     return 1
+#if LUA_VERSION_NUM >= 503
+#define API_RETURN_INT(__int)                                           \
+    lua_pushinteger (L, __int);                                          \
+    return 1
+#define API_RETURN_LONG(__long)                                         \
+    lua_pushinteger (L, __long);                                         \
+    return 1
+#else
 #define API_RETURN_INT(__int)                                           \
     lua_pushnumber (L, __int);                                          \
     return 1
 #define API_RETURN_LONG(__long)                                         \
     lua_pushnumber (L, __long);                                         \
     return 1
-
+#endif /* LUA_VERSION_NUM >= 503 */
 
 /*
  * Registers a lua script.

--- a/src/plugins/lua/weechat-lua.c
+++ b/src/plugins/lua/weechat-lua.c
@@ -188,7 +188,11 @@ weechat_lua_exec (struct t_plugin_script *script, int ret_type,
                     lua_pushstring (lua_current_interpreter, (char *)argv[i]);
                     break;
                 case 'i': /* integer */
+#if LUA_VERSION_NUM >= 503
+                    lua_pushinteger (lua_current_interpreter, *((int *)argv[i]));
+#else
                     lua_pushnumber (lua_current_interpreter, *((int *)argv[i]));
+#endif /* LUA_VERSION_NUM >= 503 */
                     break;
                 case 'h': /* hash */
                     weechat_lua_pushhashtable (lua_current_interpreter,
@@ -267,7 +271,11 @@ weechat_lua_add_constant (lua_State *L, struct t_lua_const *ptr_const)
     if (ptr_const->str_value)
         lua_pushstring (L, ptr_const->str_value);
     else
+#if LUA_VERSION_NUM >= 503
+        lua_pushinteger (L, ptr_const->int_value);
+#else
         lua_pushnumber (L, ptr_const->int_value);
+#endif /* LUA_VERSION_NUM >= 503 */
     lua_settable(L, -3);
 }
 


### PR DESCRIPTION
In Lua 5.3+, when displaying values from Weechat functions that return integer the output will have `.0` appended. This is because `lua_pushnumber` since 5.3 only pushes float value and float to string conversion now keeps the fractional part.

To reproduce, build Weechat with Lua 5.3+ and load [this simple script](http://sprunge.us/bVNE). It should print the current buffer number followed by `.0`.

This PR replaces `lua_pushnumber` with `lua_pushinteger` to fix this issue.