### PR TITLE
Simplify memory management

### DIFF
--- a/src/core/wee-config-file.c
+++ b/src/core/wee-config-file.c
@@ -184,7 +184,7 @@ config_file_new (struct t_weechat_plugin *plugin, const char *name,
         new_config_file->name = strdup (name);
         if (!new_config_file->name)
         {
-            free (new_config_file);
+            FREE(new_config_file);
             return NULL;
         }
         length = strlen (name) + 8 + 1;
@@ -193,14 +193,14 @@ config_file_new (struct t_weechat_plugin *plugin, const char *name,
         {
             snprintf (filename, length, "%s.conf", name);
             new_config_file->filename = strdup (filename);
-            free (filename);
+            FREE(filename);
         }
         else
             new_config_file->filename = strdup (name);
         if (!new_config_file->filename)
         {
-            free (new_config_file->name);
-            free (new_config_file);
+            FREE(new_config_file->name);
+            FREE(new_config_file);
             return NULL;
         }
         new_config_file->file = NULL;
@@ -353,7 +353,7 @@ config_file_new_section (struct t_config_file *config_file, const char *name,
         new_section->name = strdup (name);
         if (!new_section->name)
         {
-            free (new_section);
+            FREE(new_section);
             return NULL;
         }
         new_section->user_can_add_options = user_can_add_options;
@@ -492,7 +492,7 @@ config_file_hook_config_exec (struct t_config_option *option)
             else
                 hook_config_exec (option_full_name, NULL);
 
-            free (option_full_name);
+            FREE(option_full_name);
         }
     }
 }
@@ -573,40 +573,9 @@ config_file_option_insert_in_section (struct t_config_option *option)
  */
 
 struct t_config_option *
-config_file_option_malloc ()
+config_file_option_malloc (void)
 {
-    struct t_config_option *new_option;
-
-    new_option = malloc (sizeof (*new_option));
-    if (new_option)
-    {
-        new_option->config_file = NULL;
-        new_option->section = NULL;
-        new_option->name = NULL;
-        new_option->parent_name = NULL;
-        new_option->type = 0;
-        new_option->description = NULL;
-        new_option->string_values = NULL;
-        new_option->min = 0;
-        new_option->max = 0;
-        new_option->default_value = NULL;
-        new_option->value = NULL;
-        new_option->null_value_allowed = 0;
-        new_option->callback_check_value = NULL;
-        new_option->callback_check_value_pointer = NULL;
-        new_option->callback_check_value_data = NULL;
-        new_option->callback_change = NULL;
-        new_option->callback_change_pointer = NULL;
-        new_option->callback_change_data = NULL;
-        new_option->callback_delete = NULL;
-        new_option->callback_delete_pointer = NULL;
-        new_option->callback_delete_data = NULL;
-        new_option->loaded = 0;
-        new_option->prev_option = NULL;
-        new_option->next_option = NULL;
-    }
-
-    return new_option;
+    return calloc(sizeof (struct t_config_option), 1);
 }
 
 /*
@@ -893,15 +862,13 @@ error:
     if (new_option)
     {
         config_file_option_free_data (new_option);
-        free (new_option);
+        FREE(new_option);
         new_option = NULL;
     }
 
 end:
-    if (option_name)
-        free (option_name);
-    if (parent_name)
-        free (parent_name);
+    FREE(option_name);
+    FREE(parent_name);
     return new_option;
 }
 
@@ -1058,10 +1025,8 @@ config_file_search_with_string (const char *option_name,
         }
     }
 
-    if (file_name)
-        free (file_name);
-    if (section_name)
-        free (section_name);
+    FREE(file_name);
+    FREE(section_name);
 
     if (config_file)
         *config_file = ptr_config;
@@ -1196,11 +1161,8 @@ config_file_option_reset (struct t_config_option *option, int run_callback)
                     || (strcmp ((char *)option->value,
                                 (char *)option->default_value) != 0))
                     rc = WEECHAT_CONFIG_OPTION_SET_OK_CHANGED;
-                if (option->value)
-                {
-                    free (option->value);
-                    option->value = NULL;
-                }
+                FREE(option->value);
+                option->value = NULL;
                 option->value = strdup ((char *)option->default_value);
                 if (!option->value)
                     rc = WEECHAT_CONFIG_OPTION_SET_ERROR;
@@ -1234,7 +1196,7 @@ config_file_option_reset (struct t_config_option *option, int run_callback)
         {
             if (option->value)
             {
-                free (option->value);
+                FREE(option->value);
                 option->value = NULL;
                 rc = WEECHAT_CONFIG_OPTION_SET_OK_CHANGED;
             }
@@ -1321,10 +1283,7 @@ config_file_option_set (struct t_config_option *option, const char *value,
                                 rc = WEECHAT_CONFIG_OPTION_SET_OK_CHANGED;
                             }
                             else
-                            {
-                                free (option->value);
-                                option->value = NULL;
-                            }
+                                FREE(option->value);
                         }
                     }
                 }
@@ -1413,8 +1372,7 @@ config_file_option_set (struct t_config_option *option, const char *value,
                         {
                             if (old_value_was_null)
                             {
-                                free (option->value);
-                                option->value = NULL;
+                                FREE(option->value);
                             }
                         }
                     }
@@ -1470,8 +1428,7 @@ config_file_option_set (struct t_config_option *option, const char *value,
                         {
                             if (old_value_was_null)
                             {
-                                free (option->value);
-                                option->value = NULL;
+                                FREE(option->value);
                             }
                         }
                     }
@@ -1482,11 +1439,7 @@ config_file_option_set (struct t_config_option *option, const char *value,
                 if (!option->value
                     || (strcmp (CONFIG_STRING(option), value) != 0))
                     rc = WEECHAT_CONFIG_OPTION_SET_OK_CHANGED;
-                if (option->value)
-                {
-                    free (option->value);
-                    option->value = NULL;
-                }
+                FREE(option->value);
                 option->value = strdup (value);
                 if (!option->value)
                     rc = WEECHAT_CONFIG_OPTION_SET_ERROR;
@@ -1553,8 +1506,7 @@ config_file_option_set (struct t_config_option *option, const char *value,
     {
         if (option->null_value_allowed && option->value)
         {
-            free (option->value);
-            option->value = NULL;
+            FREE(option->value);
             rc = WEECHAT_CONFIG_OPTION_SET_OK_CHANGED;
         }
         else
@@ -1609,8 +1561,7 @@ config_file_option_set_null (struct t_config_option *option, int run_callback)
         else
         {
             /* set option to null */
-            free (option->value);
-            option->value = NULL;
+            FREE(option->value);
             rc = WEECHAT_CONFIG_OPTION_SET_OK_CHANGED;
         }
     }
@@ -1687,7 +1638,7 @@ config_file_option_unset (struct t_config_option *option)
         if (option_full_name)
         {
             hook_config_exec (option_full_name, NULL);
-            free (option_full_name);
+            FREE(option_full_name);
         }
     }
     else
@@ -1746,8 +1697,7 @@ config_file_option_rename (struct t_config_option *option,
         }
 
         /* rename option */
-        if (option->name)
-            free (option->name);
+        FREE(option->name);
         option->name = str_new_name;
 
         /* re-insert option in section */
@@ -1772,7 +1722,7 @@ config_file_option_rename (struct t_config_option *option,
                     if (ptr_option->parent_name
                         && (strcmp (ptr_option->parent_name, full_old_name) == 0))
                     {
-                        free (ptr_option->parent_name);
+                        FREE(ptr_option->parent_name);
                         ptr_option->parent_name = strdup (full_new_name);
                     }
                 }
@@ -1780,10 +1730,8 @@ config_file_option_rename (struct t_config_option *option,
         }
     }
 
-    if (full_old_name)
-        free (full_old_name);
-    if (full_new_name)
-        free (full_new_name);
+    FREE(full_old_name);
+    FREE(full_new_name);
 }
 
 /*
@@ -2374,10 +2322,10 @@ config_file_write_line (struct t_config_file *config_file,
                 rc = string_fprintf (config_file->file, "%s%s = %s\n",
                                      config_file_option_escape (option_name),
                                      option_name, vbuffer);
-                free (vbuffer);
+                FREE(vbuffer);
                 return rc;
             }
-            free (vbuffer);
+            FREE(vbuffer);
         }
     }
 
@@ -2422,7 +2370,7 @@ config_file_write_internal (struct t_config_file *config_file,
     filename2 = malloc (filename_length + 32);
     if (!filename2)
     {
-        free (filename);
+        FREE(filename);
         return WEECHAT_CONFIG_WRITE_MEMORY_ERROR;
     }
     snprintf (filename2, filename_length + 32, "%s.weechattmp", filename);
@@ -2432,11 +2380,11 @@ config_file_write_internal (struct t_config_file *config_file,
     {
         if (strcmp (filename, resolved_path) != 0)
         {
-            free (filename);
+            FREE(filename);
             filename = strdup (resolved_path);
             if (!filename)
             {
-                free (filename2);
+                FREE(filename2);
                 return WEECHAT_CONFIG_WRITE_MEMORY_ERROR;
             }
         }
@@ -2528,8 +2476,8 @@ config_file_write_internal (struct t_config_file *config_file,
     /* rename temp file to target file */
     rc = rename (filename2, filename);
 
-    free (filename);
-    free (filename2);
+    FREE(filename);
+    FREE(filename2);
 
     if (rc != 0)
         return WEECHAT_CONFIG_WRITE_ERROR;
@@ -2549,8 +2497,8 @@ error:
         config_file->file = NULL;
     }
     unlink (filename2);
-    free (filename);
-    free (filename2);
+    FREE(filename);
+    FREE(filename2);
     return WEECHAT_CONFIG_WRITE_ERROR;
 }
 
@@ -2623,7 +2571,7 @@ config_file_read_internal (struct t_config_file *config_file, int reload)
                            "backup this file now)"),
                          gui_chat_prefix[GUI_CHAT_PREFIX_ERROR],
                          filename);
-        free (filename);
+        FREE(filename);
         return WEECHAT_CONFIG_READ_FILE_NOT_FOUND;
     }
 
@@ -2818,14 +2766,13 @@ config_file_read_internal (struct t_config_file *config_file, int reload)
                 }
             }
 
-            if (ptr_line2)
-                free (ptr_line2);
+            FREE(ptr_line2);
         }
     }
 
     fclose (config_file->file);
     config_file->file = NULL;
-    free (filename);
+    FREE(filename);
 
     return WEECHAT_CONFIG_READ_OK;
 }
@@ -2908,24 +2855,16 @@ config_file_reload (struct t_config_file *config_file)
 void
 config_file_option_free_data (struct t_config_option *option)
 {
-    if (option->name)
-        free (option->name);
-    if (option->parent_name)
-        free (option->parent_name);
-    if (option->description)
-        free (option->description);
+    FREE(option->name);
+    FREE(option->parent_name);
+    FREE(option->description);
     if (option->string_values)
         string_free_split (option->string_values);
-    if (option->default_value)
-        free (option->default_value);
-    if (option->value)
-        free (option->value);
-    if (option->callback_check_value_data)
-        free (option->callback_check_value_data);
-    if (option->callback_change_data)
-        free (option->callback_change_data);
-    if (option->callback_delete_data)
-        free (option->callback_delete_data);
+    FREE(option->default_value);
+    FREE(option->value);
+    FREE(option->callback_check_value_data);
+    FREE(option->callback_change_data);
+    FREE(option->callback_delete_data);
 }
 
 /*
@@ -2963,7 +2902,7 @@ config_file_option_free (struct t_config_option *option)
         ptr_section->options = new_options;
     }
 
-    free (option);
+    FREE(option);
 }
 
 /*
@@ -2999,18 +2938,12 @@ config_file_section_free (struct t_config_section *section)
 
     /* free data */
     config_file_section_free_options (section);
-    if (section->name)
-        free (section->name);
-    if (section->callback_read_data)
-        free (section->callback_read_data);
-    if (section->callback_write_data)
-        free (section->callback_write_data);
-    if (section->callback_write_default_data)
-        free (section->callback_write_default_data);
-    if (section->callback_create_option_data)
-        free (section->callback_create_option_data);
-    if (section->callback_delete_option_data)
-        free (section->callback_delete_option_data);
+    FREE(section->name);
+    FREE(section->callback_read_data);
+    FREE(section->callback_write_data);
+    FREE(section->callback_write_default_data);
+    FREE(section->callback_create_option_data);
+    FREE(section->callback_delete_option_data);
 
     /* remove section from list */
     if (ptr_config->last_section == section)
@@ -3026,7 +2959,7 @@ config_file_section_free (struct t_config_section *section)
     if (section->next_section)
         (section->next_section)->prev_section = section->prev_section;
 
-    free (section);
+    FREE(section);
 
     ptr_config->sections = new_sections;
 }
@@ -3048,10 +2981,8 @@ config_file_free (struct t_config_file *config_file)
     {
         config_file_section_free (config_file->sections);
     }
-    if (config_file->name)
-        free (config_file->name);
-    if (config_file->filename)
-        free (config_file->filename);
+    FREE(config_file->name);
+    FREE(config_file->filename);
 
     /* remove configuration file from list */
     if (last_config_file == config_file)
@@ -3068,10 +2999,9 @@ config_file_free (struct t_config_file *config_file)
         (config_file->next_config)->prev_config = config_file->prev_config;
 
     /* free data */
-    if (config_file->callback_reload_data)
-        free (config_file->callback_reload_data);
+    FREE(config_file->callback_reload_data);
 
-    free (config_file);
+    FREE(config_file);
 
     config_files = new_config_files;
 }
@@ -3081,7 +3011,7 @@ config_file_free (struct t_config_file *config_file)
  */
 
 void
-config_file_free_all ()
+config_file_free_all (void)
 {
     while (config_files)
     {
@@ -3295,12 +3225,10 @@ config_file_add_option_to_infolist(struct t_infolist *infolist,
         (const char **)option->string_values, "|");
     if (!infolist_new_var_string (ptr_item, "string_values", string_values))
     {
-        if (string_values)
-            free (string_values);
+        FREE(string_values);
         goto error;
     }
-    if (string_values)
-        free (string_values);
+    FREE(string_values);
     if (!infolist_new_var_integer (ptr_item, "min", option->min))
         goto error;
     if (!infolist_new_var_integer (ptr_item, "max", option->max))
@@ -3334,10 +3262,10 @@ config_file_add_option_to_infolist(struct t_infolist *infolist,
             goto error;
         if (!infolist_new_var_string (ptr_item, "value", value))
         {
-            free (value);
+            FREE(value);
             goto error;
         }
-        free (value);
+        FREE(value);
     }
     if (option->default_value)
     {
@@ -3346,10 +3274,10 @@ config_file_add_option_to_infolist(struct t_infolist *infolist,
             goto error;
         if (!infolist_new_var_string (ptr_item, "default_value", value))
         {
-            free (value);
+            FREE(value);
             goto error;
         }
-        free (value);
+        FREE(value);
     }
     if (option->parent_name)
     {
@@ -3363,10 +3291,10 @@ config_file_add_option_to_infolist(struct t_infolist *infolist,
                 goto error;
             if (!infolist_new_var_string (ptr_item, "parent_value", value))
             {
-                free (value);
+                FREE(value);
                 goto error;
             }
-            free (value);
+            FREE(value);
         }
     }
 
@@ -3376,7 +3304,7 @@ error:
     rc = 0;
 
 end:
-    free (option_full_name);
+    FREE(option_full_name);
     return rc;
 }
 
@@ -3428,7 +3356,7 @@ config_file_add_to_infolist (struct t_infolist *infolist,
  */
 
 void
-config_file_print_log ()
+config_file_print_log (void)
 {
     struct t_config_file *ptr_config_file;
     struct t_config_section *ptr_section;

--- a/src/core/weechat.h
+++ b/src/core/weechat.h
@@ -84,6 +84,8 @@
     #define DIR_SEPARATOR_CHAR  '/'
 #endif /* _WIN32 */
 
+#define FREE(x) (free(x), (x) = NULL)
+
 /* some systems like GNU/Hurd do not define PATH_MAX */
 #ifndef PATH_MAX
     #define PATH_MAX 4096


### PR DESCRIPTION
Many pointers were being compared with NULL before being freed.
This is not required.  One function allocated a struct with
`malloc` and then zeroed out its fields manually; call `calloc`
instead.  Use a macro to automate the `free(x); x = NULL` pattern.