### PR TITLE
gui: add options for scroll bar item prefix and suffix

### DIFF
--- a/src/core/wee-config.c
+++ b/src/core/wee-config.c
@@ -186,6 +186,8 @@ struct t_config_option *config_look_scroll_page_percent;
 struct t_config_option *config_look_search_text_not_found_alert;
 struct t_config_option *config_look_separator_horizontal;
 struct t_config_option *config_look_separator_vertical;
+struct t_config_option *config_look_status_more_prefix;
+struct t_config_option *config_look_status_more_suffix;
 struct t_config_option *config_look_tab_width;
 struct t_config_option *config_look_time_format;
 struct t_config_option *config_look_window_auto_zoom;
@@ -937,6 +939,23 @@ config_change_hotlist_sort (const void *pointer, void *data,
     (void) option;
 
     gui_hotlist_resort ();
+}
+
+/*
+ * Callback for changes on options "weechat.look.status_more_prefix"
+ * and "weechat.look.status_more_suffix".
+ */
+
+void
+config_change_item_scroll (const void *pointer, void *data,
+                           struct t_config_option *option)
+{
+    /* make C compiler happy */
+    (void) pointer;
+    (void) data;
+    (void) option;
+
+    gui_bar_item_update ("scroll");
 }
 
 /*
@@ -3401,6 +3420,22 @@ config_weechat_init_options ()
         NULL, 0, 0, "", NULL, 0,
         &config_check_separator, NULL, NULL,
         &config_change_buffers, NULL, NULL,
+        NULL, NULL, NULL);
+    config_look_status_more_prefix = config_file_new_option (
+        weechat_config_file, ptr_section,
+        "status_more_prefix", "string",
+        N_("text to display before count for buffer with new data (status bar)"),
+        NULL, 0, 0, _("-MORE("), NULL, 0,
+        NULL, NULL, NULL,
+        &config_change_item_scroll, NULL, NULL,
+        NULL, NULL, NULL);
+    config_look_status_more_suffix = config_file_new_option (
+        weechat_config_file, ptr_section,
+        "status_more_suffix", "string",
+        N_("text to display after count for buffer with new data (status bar)"),
+        NULL, 0, 0, ")-", NULL, 0,
+        NULL, NULL, NULL,
+        &config_change_item_scroll, NULL, NULL,
         NULL, NULL, NULL);
     config_look_tab_width = config_file_new_option (
         weechat_config_file, ptr_section,

--- a/src/core/wee-config.h
+++ b/src/core/wee-config.h
@@ -235,6 +235,8 @@ extern struct t_config_option *config_look_scroll_page_percent;
 extern struct t_config_option *config_look_search_text_not_found_alert;
 extern struct t_config_option *config_look_separator_horizontal;
 extern struct t_config_option *config_look_separator_vertical;
+extern struct t_config_option *config_look_status_more_prefix;
+extern struct t_config_option *config_look_status_more_suffix;
 extern struct t_config_option *config_look_tab_width;
 extern struct t_config_option *config_look_time_format;
 extern struct t_config_option *config_look_window_auto_zoom;

--- a/src/gui/gui-bar-item.c
+++ b/src/gui/gui-bar-item.c
@@ -1326,9 +1326,11 @@ gui_bar_item_scroll_cb (const void *pointer, void *data,
     if (!window->scroll->scrolling)
         return NULL;
 
-    snprintf (str_scroll, sizeof (str_scroll), _("%s-MORE(%d)-"),
+    snprintf (str_scroll, sizeof (str_scroll), "%s%s%d%s",
               gui_color_get_custom (gui_color_get_name (CONFIG_COLOR(config_color_status_more))),
-              window->scroll->lines_after);
+              CONFIG_STRING(config_look_status_more_prefix),
+              window->scroll->lines_after,
+              CONFIG_STRING(config_look_status_more_suffix));
 
     return strdup (str_scroll);
 }


### PR DESCRIPTION
Adds options for configuring `scroll` bar item's format runtime to something other than what's specified by the language.

*Feature requested by earnestly in #weechat:*
```
<@nils_2> don't understand what you want archer121
< earnestly> Quick question, for the 'scroll' item, can the display be changed so instead of
             '-MORE(n)-' I can just display 'n'?
<@nils_2> no. its hard-coded.
< earnestly> Ah, okay thanks for confirming.  I quickly scanned the options for anything
             relevant but couldn't find anything and pondered if it was
```
