### PR TITLE
core/gui: added possibility to resize full windows parents

### DIFF
--- a/src/core/wee-command.c
+++ b/src/core/wee-command.c
@@ -6484,7 +6484,9 @@ COMMAND_CALLBACK(wait)
 COMMAND_CALLBACK(window)
 {
     struct t_gui_window *ptr_win;
-    char *error;
+    struct t_gui_window_tree *ptr_tree;
+    char *error, *sizearg;
+    char sign;
     long number;
     int win_args;
 
@@ -6695,25 +6697,36 @@ COMMAND_CALLBACK(window)
     {
         if (argc > win_args)
         {
-            if ((argv[win_args][0] == '+') || (argv[win_args][0] == '-'))
+            sizearg = argv[win_args];
+            sign = 0;
+            if ((sizearg[0] == 'h') || (sizearg[0] == 'v'))
             {
-                error = NULL;
-                number = strtol (argv[win_args] + 1, &error, 10);
-                if (error && !error[0])
-                {
-                    if (argv[win_args][0] == '-')
-                        number *= -1;
-                    gui_window_resize_delta (ptr_win, number);
-                }
+                ptr_tree = gui_window_tree_get_split (ptr_win->ptr_tree,
+                                                      sizearg[0]);
+                sizearg++;
             }
             else
             {
-                error = NULL;
-                number = strtol (argv[win_args], &error, 10);
-                if (error && !error[0]
-                    && (number > 0) && (number < 100))
+                ptr_tree = ptr_win->ptr_tree;
+            }
+            if ((sizearg[0] == '+') || (sizearg[0] == '-'))
+            {
+                sign = sizearg[0];
+                sizearg++;
+            }
+            error = NULL;
+            number = strtol (sizearg, &error, 10);
+            if (error && !error[0])
+            {
+                if (sign)
                 {
-                    gui_window_resize (ptr_win, number);
+                    if (sign == '-')
+                        number *= -1;
+                    gui_window_resize_delta (ptr_tree, number);
+                }
+                else
+                {
+                    gui_window_resize (ptr_tree, number);
                 }
             }
         }

--- a/src/gui/curses/gui-curses-window.c
+++ b/src/gui/curses/gui-curses-window.c
@@ -1874,7 +1874,7 @@ gui_window_split_vertical (struct t_gui_window *window, int percentage)
  */
 
 void
-gui_window_resize (struct t_gui_window *window, int percentage)
+gui_window_resize (struct t_gui_window_tree *node, int percentage)
 {
     struct t_gui_window_tree *parent;
     int old_split_pct, add_bottom, add_top, add_left, add_right;
@@ -1882,12 +1882,12 @@ gui_window_resize (struct t_gui_window *window, int percentage)
     if (!gui_init_ok)
         return;
 
-    parent = window->ptr_tree->parent_node;
+    parent = node->parent_node;
     if (parent)
     {
         old_split_pct = parent->split_pct;
-        if (((parent->split_horizontal) && (window->ptr_tree == parent->child2))
-            || ((!(parent->split_horizontal)) && (window->ptr_tree == parent->child1)))
+        if (((parent->split_horizontal) && (node == parent->child2))
+            || ((!(parent->split_horizontal)) && (node == parent->child1)))
         {
             parent->split_pct = percentage;
         }
@@ -1916,7 +1916,7 @@ gui_window_resize (struct t_gui_window *window, int percentage)
  */
 
 void
-gui_window_resize_delta (struct t_gui_window *window, int delta_percentage)
+gui_window_resize_delta (struct t_gui_window_tree *node, int delta_percentage)
 {
     struct t_gui_window_tree *parent;
     int old_split_pct, add_bottom, add_top, add_left, add_right;
@@ -1924,12 +1924,12 @@ gui_window_resize_delta (struct t_gui_window *window, int delta_percentage)
     if (!gui_init_ok)
         return;
 
-    parent = window->ptr_tree->parent_node;
+    parent = node->parent_node;
     if (parent)
     {
         old_split_pct = parent->split_pct;
-        if (((parent->split_horizontal) && (window->ptr_tree == parent->child2))
-            || ((!(parent->split_horizontal)) && (window->ptr_tree == parent->child1)))
+        if (((parent->split_horizontal) && (node == parent->child2))
+            || ((!(parent->split_horizontal)) && (node == parent->child1)))
         {
             parent->split_pct += delta_percentage;
         }

--- a/src/gui/gui-window.c
+++ b/src/gui/gui-window.c
@@ -344,6 +344,34 @@ gui_window_tree_free (struct t_gui_window_tree **tree)
 }
 
 /*
+ * Searches a parent window which is splitted on given direction.
+ */
+
+struct t_gui_window_tree
+*gui_window_tree_get_split (struct t_gui_window_tree *node,
+                            char direction)
+{
+    struct t_gui_window_tree *parent;
+    if (node->parent_node)
+    {
+        parent = node->parent_node;
+        if (((parent->split_horizontal) && (direction == 'h'))
+            || (!(parent->split_horizontal) && (direction == 'v')))
+        {
+            return node;
+        }
+        else
+        {
+            return gui_window_tree_get_split (parent, direction);
+        }
+    }
+    else
+    {
+        return node;
+    }
+}
+
+/*
  * Searches for a scroll with buffer pointer.
  *
  * Returns pointer to window scroll, NULL if not found.

--- a/src/gui/gui-window.h
+++ b/src/gui/gui-window.h
@@ -146,6 +146,8 @@ extern int gui_window_tree_init (struct t_gui_window *window);
 extern void gui_window_tree_node_to_leaf (struct t_gui_window_tree *node,
                                           struct t_gui_window *window);
 extern void gui_window_tree_free (struct t_gui_window_tree **tree);
+extern struct t_gui_window_tree *gui_window_tree_get_split (struct t_gui_window_tree *node,
+                                                char direction);
 extern void gui_window_scroll_switch (struct t_gui_window *window,
                                       struct t_gui_buffer *buffer);
 extern void gui_window_scroll_remove_buffer (struct t_gui_window *window,
@@ -226,8 +228,8 @@ extern struct t_gui_window *gui_window_split_horizontal (struct t_gui_window *wi
                                                          int percentage);
 extern struct t_gui_window *gui_window_split_vertical (struct t_gui_window *window,
                                                        int percentage);
-extern void gui_window_resize (struct t_gui_window *window, int percentage);
-extern void gui_window_resize_delta (struct t_gui_window *window,
+extern void gui_window_resize (struct t_gui_window_tree *window, int percentage);
+extern void gui_window_resize_delta (struct t_gui_window_tree *window,
                                      int delta_percentage);
 extern int gui_window_merge (struct t_gui_window *window);
 extern void gui_window_merge_all (struct t_gui_window *window);


### PR DESCRIPTION
This PR improves the `/window resize` function:
when specifying `v` (vertically) or `h` (horizontally) before the value, this will affect the size of the nearest window parent that can be resized in the given direction.

For instance:
```
/window resize h+10
/window resize v20
```
Of course, the existing usage of `/window resize` is respected.