### PR TITLE
/build should be included by the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 ABOUT-NLS
 autom4te*
 build*/*
+!build/*
 compile
 config.guess
 config.h

--- a/README.adoc
+++ b/README.adoc
@@ -68,7 +68,6 @@ autotools if you are not able to use CMake. +
 Building with autotools requires more dependencies and is slower than with CMake.
 
 ----
-$ mkdir build
 $ cd build
 $ cmake .. -DCMAKE_INSTALL_PREFIX=/path/to/directory
 $ make


### PR DESCRIPTION
This is the one of idea :smile:

I think /build should be included, because it is more natural when an user builds.
