### PR TITLE
irc: add the per-server password_cmd option.

### DIFF
--- a/src/plugins/irc/irc-command.c
+++ b/src/plugins/irc/irc-command.c
@@ -4588,6 +4588,14 @@ irc_command_display_server (struct t_irc_server *server, int with_detail)
             weechat_printf (NULL, "  password . . . . . . : %s%s",
                             IRC_COLOR_CHAT_VALUE,
                             _("(hidden)"));
+        /* password_cmd */
+        if (weechat_config_option_is_null (server->options[IRC_SERVER_OPTION_PASSWORD_CMD]))
+            weechat_printf (NULL, "  password_cmd . . . . :   %s",
+                            _("null"));
+        else
+            weechat_printf (NULL, "  password_cmd . . . . : %s%s",
+                            IRC_COLOR_CHAT_VALUE,
+                            weechat_config_string (server->options[IRC_SERVER_OPTION_PASSWORD_CMD]));
         /* client capabilities */
         if (weechat_config_option_is_null (server->options[IRC_SERVER_OPTION_CAPABILITIES]))
             weechat_printf (NULL, "  capabilities . . . . :   ('%s')",

--- a/src/plugins/irc/irc-config.c
+++ b/src/plugins/irc/irc-config.c
@@ -1705,6 +1705,23 @@ irc_config_server_new_option (struct t_config_file *config_file,
                 callback_change_data,
                 NULL, NULL, NULL);
             break;
+        case IRC_SERVER_OPTION_PASSWORD_CMD:
+            new_option = weechat_config_new_option (
+                config_file, section,
+                option_name, "string",
+                N_("password command to be executed for server "
+                   "(note: content is evaluated, see /help eval)"),
+                NULL, 0, 0,
+                default_value, value,
+                null_value_allowed,
+                callback_check_value,
+                callback_check_value_pointer,
+                callback_check_value_data,
+                callback_change,
+                callback_change_pointer,
+                callback_change_data,
+                NULL, NULL, NULL);
+            break;
         case IRC_SERVER_OPTION_CAPABILITIES:
             new_option = weechat_config_new_option (
                 config_file, section,

--- a/src/plugins/irc/irc-server.h
+++ b/src/plugins/irc/irc-server.h
@@ -54,6 +54,7 @@ enum t_irc_server_option
     IRC_SERVER_OPTION_SSL_FINGERPRINT, /* SHA1 fingerprint of certificate    */
     IRC_SERVER_OPTION_SSL_VERIFY,    /* check if the connection is trusted   */
     IRC_SERVER_OPTION_PASSWORD,      /* password for server                  */
+    IRC_SERVER_OPTION_PASSWORD_CMD,  /* command run to retrieve password     */
     IRC_SERVER_OPTION_CAPABILITIES,  /* client capabilities to enable        */
     IRC_SERVER_OPTION_SASL_MECHANISM,/* mechanism for SASL authentication    */
     IRC_SERVER_OPTION_SASL_USERNAME, /* username for SASL authentication     */


### PR DESCRIPTION
This is my initial solution to tackle #141. An alternative I considered was adding a shell type variable in the `/eval` function. I decided against this because perhaps in the future (if we deem this is a good idea), we can add support for different "passphrase plugins". For example, different plugins to interface with `gnome-keyring` or just pulling in a straight password via `pinentry`, although in hindsight I suppose those can go into eval as well.