### PR TITLE
doc: fix examples with localvar_del

### DIFF
--- a/doc/en/weechat_plugin_api.en.adoc
+++ b/doc/en/weechat_plugin_api.en.adoc
@@ -11369,7 +11369,7 @@ weechat_buffer_set (my_buffer, "name", "my_new_name");
 weechat_buffer_set (my_buffer, "localvar_set_toto", "abc");
 
 /* remove local variable "toto" */
-weechat_buffer_set (my_buffer, "localvar_del_toto", NULL);
+weechat_buffer_set (my_buffer, "localvar_del_toto", "");
 ----
 
 Script (Python):

--- a/doc/fr/weechat_plugin_api.fr.adoc
+++ b/doc/fr/weechat_plugin_api.fr.adoc
@@ -11622,7 +11622,7 @@ weechat_buffer_set (mon_tampon, "name", "nouveau_nom");
 weechat_buffer_set (mon_tampon, "localvar_set_toto", "abc");
 
 /* supprimer la variable locale "toto" */
-weechat_buffer_set (mon_tampon, "localvar_del_toto", NULL);
+weechat_buffer_set (mon_tampon, "localvar_del_toto", "");
 ----
 
 Script (Python) :

--- a/doc/it/weechat_plugin_api.it.adoc
+++ b/doc/it/weechat_plugin_api.it.adoc
@@ -11794,7 +11794,7 @@ weechat_buffer_set (my_buffer, "name", "my_new_name");
 weechat_buffer_set (my_buffer, "localvar_set_tizio", "abc");
 
 /* rimuove la variabile locale "tizio" */
-weechat_buffer_set (my_buffer, "localvar_del_tizio", NULL);
+weechat_buffer_set (my_buffer, "localvar_del_tizio", "");
 ----
 
 Script (Python):

--- a/doc/ja/weechat_plugin_api.ja.adoc
+++ b/doc/ja/weechat_plugin_api.ja.adoc
@@ -11372,7 +11372,7 @@ weechat_buffer_set (my_buffer, "name", "my_new_name");
 weechat_buffer_set (my_buffer, "localvar_set_toto", "abc");
 
 /* remove local variable "toto" */
-weechat_buffer_set (my_buffer, "localvar_del_toto", NULL);
+weechat_buffer_set (my_buffer, "localvar_del_toto", "");
 ----
 
 スクリプト (Python) での使用例:


### PR DESCRIPTION
The docs provide the following example for deleting localvars on buffers:

    /* remove local variable "toto" */
    weechat_buffer_set (my_buffer, "localvar_del_toto", NULL);

This does not work, because [`gui_buffer_set`][1] exits immediately if one of the arguments are `NULL`. This PR simply updates the documentation to reflect this, providing the following example instead:

    /* remove local variable "toto" */
    weechat_buffer_set (my_buffer, "localvar_del_toto", "");

[1]: https://github.com/weechat/weechat/blob/master/src/gui/gui-buffer.c#L1795