### PR TITLE
Add weechat.look.prefix_same_nick_more

### DIFF
--- a/src/core/wee-config.c
+++ b/src/core/wee-config.c
@@ -171,6 +171,7 @@ struct t_config_option *config_look_prefix_buffer_align_max;
 struct t_config_option *config_look_prefix_buffer_align_more;
 struct t_config_option *config_look_prefix_buffer_align_more_after;
 struct t_config_option *config_look_prefix_same_nick;
+struct t_config_option *config_look_prefix_same_nick_more;
 struct t_config_option *config_look_prefix_suffix;
 struct t_config_option *config_look_quote_nick_prefix;
 struct t_config_option *config_look_quote_nick_suffix;
@@ -300,6 +301,7 @@ struct t_config_option *config_plugin_save_config_on_unload;
 
 int config_length_nick_prefix_suffix = 0;
 int config_length_prefix_same_nick = 0;
+int config_length_prefix_same_nick_more = 0;
 struct t_hook *config_day_change_timer = NULL;
 int config_day_change_old_day = -1;
 int config_emphasized_attributes = 0;
@@ -774,6 +776,26 @@ config_change_prefix_same_nick (const void *pointer, void *data,
 
     config_length_prefix_same_nick =
         gui_chat_strlen_screen (CONFIG_STRING(config_look_prefix_same_nick));
+
+    config_compute_prefix_max_length_all_buffers ();
+    gui_window_ask_refresh (1);
+}
+
+/*
+ * Callback for changes on option "weechat.look.prefix_same_nick_more".
+ */
+
+void
+config_change_prefix_same_nick_more (const void *pointer, void *data,
+                                     struct t_config_option *option)
+{
+    /* make C compiler happy */
+    (void) pointer;
+    (void) data;
+    (void) option;
+
+    config_length_prefix_same_nick_more =
+        gui_chat_strlen_screen (CONFIG_STRING(config_look_prefix_same_nick_more));
 
     config_compute_prefix_max_length_all_buffers ();
     gui_window_ask_refresh (1);
@@ -3276,12 +3298,23 @@ config_weechat_init_options ()
         weechat_config_file, ptr_section,
         "prefix_same_nick", "string",
         N_("prefix displayed for a message with same nick as previous "
-           "message: use a space \" \" to hide prefix, another string to "
-           "display this string instead of prefix, or an empty string to "
-           "disable feature (display prefix)"),
+           "but not next message: use a space \" \" to hide prefix, another "
+           "string to display this string instead of prefix, or an empty "
+           "string to disable feature (display prefix)"),
         NULL, 0, 0, "", NULL, 0,
         NULL, NULL, NULL,
         &config_change_prefix_same_nick, NULL, NULL,
+        NULL, NULL, NULL);
+    config_look_prefix_same_nick_more = config_file_new_option (
+        weechat_config_file, ptr_section,
+        "prefix_same_nick_more", "string",
+        N_("prefix displayed for a message with same nick as previous "
+           "and next message: use a space \" \" to hide prefix, another "
+           "string to display this string instead of prefix, or an empty "
+           "string to disable feature (display prefix)"),
+        NULL, 0, 0, "", NULL, 0,
+        NULL, NULL, NULL,
+        &config_change_prefix_same_nick_more, NULL, NULL,
         NULL, NULL, NULL);
     config_look_prefix_suffix = config_file_new_option (
         weechat_config_file, ptr_section,

--- a/src/core/wee-config.h
+++ b/src/core/wee-config.h
@@ -221,6 +221,7 @@ extern struct t_config_option *config_look_prefix_buffer_align_max;
 extern struct t_config_option *config_look_prefix_buffer_align_more;
 extern struct t_config_option *config_look_prefix_buffer_align_more_after;
 extern struct t_config_option *config_look_prefix_same_nick;
+extern struct t_config_option *config_look_prefix_same_nick_more;
 extern struct t_config_option *config_look_prefix_suffix;
 extern struct t_config_option *config_look_quote_nick_prefix;
 extern struct t_config_option *config_look_quote_nick_suffix;
@@ -338,6 +339,7 @@ extern struct t_config_option *config_plugin_save_config_on_unload;
 
 extern int config_length_nick_prefix_suffix;
 extern int config_length_prefix_same_nick;
+extern int config_length_prefix_same_nick_more;
 extern int config_emphasized_attributes;
 extern regex_t *config_highlight_regex;
 extern char ***config_highlight_tags;

--- a/src/gui/gui-line.c
+++ b/src/gui/gui-line.c
@@ -175,6 +175,60 @@ gui_line_prefix_is_same_nick_as_previous (struct t_gui_line *line)
 }
 
 /*
+ * Checks if prefix on line is a nick and is the same as nick on next line.
+ *
+ * Returns:
+ *   1: prefix is a nick and same as nick on next line
+ *   0: prefix is not a nick, or different from nick on next line
+ */
+
+int
+gui_line_prefix_is_same_nick_as_next (struct t_gui_line *line)
+{
+    const char *nick, *nick_next;
+    struct t_gui_line *next_line;
+
+    /*
+     * if line is not displayed, has a highlight, or does not have a tag
+     * beginning with "prefix_nick" => display standard prefix
+     */
+    if (!line->data->displayed || line->data->highlight
+        || !gui_line_search_tag_starting_with (line, "prefix_nick"))
+        return 0;
+
+    /* no nick on line => display standard prefix */
+    nick = gui_line_get_nick_tag (line);
+    if (!nick)
+        return 0;
+
+    /*
+     * next line is not found => display standard prefix
+     */
+    next_line = gui_line_get_next_displayed (line);
+    if (!next_line)
+        return 0;
+
+    /* buffer is not the same as next line => display standard prefix */
+    if (line->data->buffer != next_line->data->buffer)
+        return 0;
+
+    /*
+     * next line does not have a tag beginning with "prefix_nick"
+     * => display standard prefix
+     */
+    if (!gui_line_search_tag_starting_with (next_line, "prefix_nick"))
+        return 0;
+
+    /* no nick on next line => display standard prefix */
+    nick_next = gui_line_get_nick_tag (next_line);
+    if (!nick_next)
+        return 0;
+
+    /* prefix can be hidden/replaced if nicks are equal */
+    return (strcmp (nick, nick_next) == 0) ? 1 : 0;
+}
+
+/*
  * Gets prefix and its length (for display only).
  *
  * If the prefix can be hidden (same nick as previous message), and if the
@@ -193,33 +247,68 @@ gui_line_get_prefix_for_display (struct t_gui_line *line,
         && CONFIG_STRING(config_look_prefix_same_nick)[0]
         && gui_line_prefix_is_same_nick_as_previous (line))
     {
-        /* same nick: return empty prefix or value from option */
-        if (strcmp (CONFIG_STRING(config_look_prefix_same_nick), " ") == 0)
+        if (CONFIG_STRING(config_look_prefix_same_nick_more)
+            && CONFIG_STRING(config_look_prefix_same_nick_more)[0]
+            && gui_line_prefix_is_same_nick_as_next (line))
         {
-            /* return empty prefix */
-            if (prefix)
-                *prefix = gui_chat_prefix_empty;
-            if (length)
-                *length = 0;
-            if (color)
-                *color = NULL;
+            /* same nick: return empty prefix or value from option */
+            if (strcmp (CONFIG_STRING(config_look_prefix_same_nick_more), " ") == 0)
+            {
+                /* return empty prefix */
+                if (prefix)
+                    *prefix = gui_chat_prefix_empty;
+                if (length)
+                    *length = 0;
+                if (color)
+                    *color = NULL;
+            }
+            else
+            {
+                /* return prefix from option "weechat.look.prefix_same_nick_more" */
+                if (prefix)
+                    *prefix = CONFIG_STRING(config_look_prefix_same_nick_more);
+                if (length)
+                    *length = config_length_prefix_same_nick_more;
+                if (color)
+                {
+                    tag_prefix_nick = gui_line_search_tag_starting_with (line,
+                                                                         "prefix_nick_");
+                    *color = (tag_prefix_nick) ? (char *)(tag_prefix_nick + 12) : NULL;
+                }
+            }
+            if (prefix_is_nick)
+                *prefix_is_nick = 0;
         }
         else
         {
-            /* return prefix from option "weechat.look.prefix_same_nick" */
-            if (prefix)
-                *prefix = CONFIG_STRING(config_look_prefix_same_nick);
-            if (length)
-                *length = config_length_prefix_same_nick;
-            if (color)
+            /* same nick: return empty prefix or value from option */
+            if (strcmp (CONFIG_STRING(config_look_prefix_same_nick), " ") == 0)
             {
-                tag_prefix_nick = gui_line_search_tag_starting_with (line,
-                                                                     "prefix_nick_");
-                *color = (tag_prefix_nick) ? (char *)(tag_prefix_nick + 12) : NULL;
+                /* return empty prefix */
+                if (prefix)
+                    *prefix = gui_chat_prefix_empty;
+                if (length)
+                    *length = 0;
+                if (color)
+                    *color = NULL;
             }
+            else
+            {
+                /* return prefix from option "weechat.look.prefix_same_nick" */
+                if (prefix)
+                    *prefix = CONFIG_STRING(config_look_prefix_same_nick);
+                if (length)
+                    *length = config_length_prefix_same_nick;
+                if (color)
+                {
+                    tag_prefix_nick = gui_line_search_tag_starting_with (line,
+                                                                         "prefix_nick_");
+                    *color = (tag_prefix_nick) ? (char *)(tag_prefix_nick + 12) : NULL;
+                }
+            }
+            if (prefix_is_nick)
+                *prefix_is_nick = 0;
         }
-        if (prefix_is_nick)
-            *prefix_is_nick = 0;
     }
     else
     {


### PR DESCRIPTION
Defines a prefix to be displayed on the middle lines if same nick sends
more than 2 messages in a row

This fixes #930.