### PR TITLE
Smart filter improvements

### DIFF
--- a/doc/en/weechat_user.en.adoc
+++ b/doc/en/weechat_user.en.adoc
@@ -2529,10 +2529,11 @@ For more info about Freenode and TOR:
 http://freenode.net/kb/answer/chat#accessing-freenode-via-tor
 
 [[irc_smart_filter_join_part_quit]]
-==== Smart filter for join/part/quit messages
+==== Smart filter for join/part/quit/nick/mode messages
 
-A smart filter is available to filter join/part/quit messages when nick did not
-say something during past X minutes on channel.
+Smart filtering is available to filter join/part/quit/nick/mode messages when
+nick did not say anything (or set topic, kick or get kicked) during the past X
+minutes on channel.
 
 Smart filter is enabled by default, but you must add a filter to hide lines on
 buffers, for example:
@@ -2541,20 +2542,15 @@ buffers, for example:
 /filter add irc_smart * irc_smart_filter *
 ----
 
-It is possible to create filter for one channel only or channels beginning with
-same name (see `/help filter`):
+It is possible to create a filter for only one channel or channels with the same
+beginning (see `/help filter`):
 
 ----
 /filter add irc_smart_weechat irc.freenode.#weechat irc_smart_filter *
 /filter add irc_smart_weechats irc.freenode.#weechat* irc_smart_filter *
 ----
 
-You can hide only join or part/quit with following options:
-
-----
-/set irc.look.smart_filter_join on
-/set irc.look.smart_filter_quit on
-----
+You can choose what to hide with the options _pass:[irc.look.smart_filter_*]_.
 
 You can setup delay (in minutes):
 
@@ -2562,8 +2558,8 @@ You can setup delay (in minutes):
 /set irc.look.smart_filter_delay 5
 ----
 
-If a nick did not speak during last 5 minutes, its join and/or part/quit will be
-hidden on channel.
+If a nick did not speak during the last 5 minutes, its join/part/quit/nick/mode
+lines will be hidden on channel.
 
 [[irc_ctcp_replies]]
 ==== CTCP replies

--- a/src/plugins/irc/irc-config.c
+++ b/src/plugins/irc/irc-config.c
@@ -2886,17 +2886,18 @@ irc_config_init ()
     irc_config_look_smart_filter = weechat_config_new_option (
         irc_config_file, ptr_section,
         "smart_filter", "boolean",
-        N_("filter join/part/quit/nick messages for a nick if not speaking "
-           "for some minutes on channel (you must create a filter on tag "
+        N_("filter join/part/quit/nick/mode messages for a nick that has not "
+           "spoken (or set topic, kicked or got kicked) for some minutes on "
+           "channel (you must create a filter on tag "
            "\"irc_smart_filter\")"),
         NULL, 0, 0, "on", NULL, 0,
         NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
     irc_config_look_smart_filter_delay = weechat_config_new_option (
         irc_config_file, ptr_section,
         "smart_filter_delay", "integer",
-        N_("delay for filtering join/part/quit messages (in minutes): if the "
-           "nick did not speak during the last N minutes, the join/part/quit is "
-           "filtered"),
+        N_("delay for filtering join/part/quit/nick/mode messages (in "
+            "minutes): if the nick did not speak during the last N minutes, the"
+            "line is filtered"),
         NULL, 1, 60*24*7, "5", NULL, 0,
         NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
     irc_config_look_smart_filter_join = weechat_config_new_option (
@@ -2911,9 +2912,9 @@ irc_config_init ()
         "smart_filter_join_unmask", "integer",
         N_("delay for unmasking a join message that was filtered with tag "
            "\"irc_smart_filter\" (in minutes): if a nick has joined max N "
-           "minutes ago and then says something on channel (message, notice or "
-           "update on topic), the join is unmasked, as well as nick changes "
-           "after this join (0 = disable: never unmask a join)"),
+           "minutes ago and then says something on channel (or sets topic, "
+           "kicks or gets kicked), the join is unmasked, as well as nick "
+           "changes after this join (0 = disable: never unmask a join)"),
         NULL, 0, 60*24*7, "30", NULL, 0,
         NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
     irc_config_look_smart_filter_mode = weechat_config_new_option (
@@ -2921,10 +2922,10 @@ irc_config_init ()
         "smart_filter_mode", "string",
         /* TRANSLATORS: please do not translate "mode" */
         N_("enable smart filter for \"mode\" messages: \"*\" to filter all "
-           "modes, \"+\" to filter all modes in server prefixes (for example "
+           "modes, \"+\" to filter all nick prefix modes (for example "
            "\"ovh\"), \"xyz\" to filter only modes x/y/z, \"-xyz\" to filter "
-           "all modes but not x/y/z; examples: \"ovh\": filter modes o/v/h, "
-           "\"-bkl\": filter all modes but not b/k/l"),
+           "all modes except x/y/z; examples: \"l+\": filter mode \"l\" and "
+           "all prefix modes, \"-bkl\": filter all modes except b/k/l"),
         NULL, 0, 0, "+", NULL, 0,
         NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
     irc_config_look_smart_filter_nick = weechat_config_new_option (

--- a/src/plugins/irc/irc-ctcp.c
+++ b/src/plugins/irc/irc-ctcp.c
@@ -1010,9 +1010,6 @@ irc_ctcp_recv (struct t_irc_server *server, time_t date, const char *command,
                                                (pos_args) ?
                                                weechat_string_has_highlight (pos_args,
                                                                              server->nick) : 0);
-                irc_channel_nick_speaking_time_remove_old (channel);
-                irc_channel_nick_speaking_time_add (server, channel, nick,
-                                                    time (NULL));
                 weechat_printf_date_tags (
                     channel->buffer,
                     date,

--- a/src/plugins/irc/irc-mode.c
+++ b/src/plugins/irc/irc-mode.c
@@ -25,11 +25,11 @@
 
 #include "../weechat-plugin.h"
 #include "irc.h"
+#include "irc-nick.h"
 #include "irc-mode.h"
 #include "irc-config.h"
 #include "irc-server.h"
 #include "irc-channel.h"
-#include "irc-nick.h"
 
 
 /*
@@ -317,12 +317,13 @@ irc_mode_smart_filtered (struct t_irc_server *server, char mode)
 int
 irc_mode_channel_set (struct t_irc_server *server,
                       struct t_irc_channel *channel,
-                      const char *modes)
+                      const char *modes,
+                      struct t_irc_nick *ptr_origin_nick)
 {
     char *pos_args, *str_modes, set_flag, **argv, *pos, *ptr_arg, chanmode_type;
     int argc, current_arg, update_channel_modes, channel_modes_updated;
     int smart_filter;
-    struct t_irc_nick *ptr_nick;
+    struct t_irc_nick *ptr_target_nick;
 
     if (!server || !channel || !modes)
         return 0;
@@ -396,8 +397,17 @@ irc_mode_channel_set (struct t_irc_server *server,
                     if (ptr_arg)
                         current_arg++;
 
+                    /*
+                     * filtering disabled for this mode char or the mode setter
+                     * has spoken recently => don't filter
+                     */
                     if (smart_filter
-                        && !irc_mode_smart_filtered (server, pos[0]))
+                        && (!irc_mode_smart_filtered (server, pos[0])
+                            || (ptr_origin_nick
+                                && irc_channel_nick_speaking_time_search (server,
+                                                                          channel,
+                                                                          ptr_origin_nick->name,
+                                                                          1))))
                     {
                         smart_filter = 0;
                     }
@@ -440,23 +450,23 @@ irc_mode_channel_set (struct t_irc_server *server,
                         update_channel_modes = 0;
                         if (ptr_arg)
                         {
-                            ptr_nick = irc_nick_search (server, channel,
-                                                        ptr_arg);
-                            if (ptr_nick)
+                            ptr_target_nick = irc_nick_search (server, channel,
+                                                               ptr_arg);
+                            if (ptr_target_nick)
                             {
-                                irc_nick_set_mode (server, channel, ptr_nick,
+                                irc_nick_set_mode (server, channel, ptr_target_nick,
                                                    (set_flag == '+'), pos[0]);
                                 /*
-                                 * disable smart filtering if mode is sent
-                                 * to me, or based on the nick speaking time
+                                 * disable smart filtering if the mode is sent to me
+                                 * or if the mode recipient has spoken recently
                                  */
                                 if (smart_filter
                                     && ((irc_server_strcasecmp (server,
-                                                                ptr_nick->name,
+                                                                ptr_target_nick->name,
                                                                 server->nick) == 0)
                                         || irc_channel_nick_speaking_time_search (server,
                                                                                   channel,
-                                                                                  ptr_nick->name,
+                                                                                  ptr_target_nick->name,
                                                                                   1)))
                                 {
                                     smart_filter = 0;

--- a/src/plugins/irc/irc-mode.c
+++ b/src/plugins/irc/irc-mode.c
@@ -287,9 +287,10 @@ irc_mode_smart_filtered (struct t_irc_server *server, char mode)
     if (strcmp (ptr_modes, "*") == 0)
         return 1;
 
-    /* if var is "+", modes from server prefixes are filtered */
-    if (strcmp (ptr_modes, "+") == 0)
-        return strchr (irc_server_get_prefix_modes (server), mode) ? 1 : 0;
+    /* if var has "+", modes from server prefixes are filtered */
+    if (strchr (ptr_modes, '+')
+        && strchr (irc_server_get_prefix_modes (server), mode))
+        return 1;
 
     /*
      * if var starts with "-", smart filter all modes except following modes

--- a/src/plugins/irc/irc-mode.h
+++ b/src/plugins/irc/irc-mode.h
@@ -27,7 +27,8 @@ extern char irc_mode_get_chanmode_type (struct t_irc_server *server,
                                         char chanmode);
 extern int irc_mode_channel_set (struct t_irc_server *server,
                                  struct t_irc_channel *channel,
-                                 const char *modes);
+                                 const char *modes,
+                                 struct t_irc_nick *ptr_origin_nick);
 extern void irc_mode_user_set (struct t_irc_server *server, const char *modes,
                                int reset_modes);
 

--- a/src/plugins/irc/irc-protocol.c
+++ b/src/plugins/irc/irc-protocol.c
@@ -1173,14 +1173,14 @@ IRC_PROTOCOL_CALLBACK(mode)
     {
         smart_filter = 0;
         ptr_channel = irc_channel_search (server, argv[2]);
-        if (ptr_channel)
-        {
-            smart_filter = irc_mode_channel_set (server, ptr_channel,
-                                                 pos_modes);
-        }
         local_mode = (irc_server_strcasecmp (server, nick, server->nick) == 0);
         ptr_nick = irc_nick_search (server, ptr_channel, nick);
         ptr_buffer = (ptr_channel) ? ptr_channel->buffer : server->buffer;
+        if (ptr_channel)
+        {
+            smart_filter = irc_mode_channel_set (server, ptr_channel,
+                                                 pos_modes, ptr_nick);
+        }
         weechat_printf_date_tags (
             irc_msgbuffer_get_target_buffer (server, NULL, command, NULL,
                                              ptr_buffer),
@@ -3320,7 +3320,7 @@ IRC_PROTOCOL_CALLBACK(324)
         if (argc > 4)
         {
             (void) irc_mode_channel_set (server, ptr_channel,
-                                         ptr_channel->modes);
+                                         ptr_channel->modes, NULL);
         }
     }
     if (!ptr_channel

--- a/src/plugins/irc/irc-protocol.c
+++ b/src/plugins/irc/irc-protocol.c
@@ -1926,9 +1926,12 @@ IRC_PROTOCOL_CALLBACK(privmsg)
         {
             /*
              * unmask a smart filtered join if it is in hashtable
-             * "join_smart_filtered" of channel
+             * "join_smart_filtered" of channel, set speaking time
              */
             irc_channel_join_smart_filtered_unmask (ptr_channel, nick);
+            irc_channel_nick_speaking_time_remove_old (ptr_channel);
+            irc_channel_nick_speaking_time_add (server, ptr_channel, nick,
+                                                time (NULL));
 
             /* CTCP to channel */
             if (pos_args[0] == '\01')
@@ -1990,9 +1993,6 @@ IRC_PROTOCOL_CALLBACK(privmsg)
                 nick,
                 weechat_string_has_highlight (pos_args,
                                               server->nick));
-            irc_channel_nick_speaking_time_remove_old (ptr_channel);
-            irc_channel_nick_speaking_time_add (server, ptr_channel, nick,
-                                                time (NULL));
         }
     }
     else

--- a/src/plugins/irc/irc-protocol.c
+++ b/src/plugins/irc/irc-protocol.c
@@ -2310,10 +2310,15 @@ IRC_PROTOCOL_CALLBACK(topic)
 
     /*
      * unmask a smart filtered join if it is in hashtable
-     * "join_smart_filtered" of channel
+     * "join_smart_filtered" of channel, set speaking time
      */
     if (ptr_channel)
+    {
         irc_channel_join_smart_filtered_unmask (ptr_channel, nick);
+        irc_channel_nick_speaking_add (ptr_channel, nick, 0);
+        irc_channel_nick_speaking_time_remove_old (ptr_channel);
+        irc_channel_nick_speaking_time_add (server, ptr_channel, nick, time (NULL));
+    }
 
     if (pos_topic && pos_topic[0])
     {

--- a/src/plugins/irc/irc-protocol.c
+++ b/src/plugins/irc/irc-protocol.c
@@ -1497,10 +1497,19 @@ IRC_PROTOCOL_CALLBACK(notice)
 
             /*
              * unmask a smart filtered join if it is in hashtable
-             * "join_smart_filtered" of channel
+             * "join_smart_filtered" of channel, set speaking time
              */
             if (ptr_channel)
+            {
                 irc_channel_join_smart_filtered_unmask (ptr_channel, nick);
+                irc_channel_nick_speaking_add (ptr_channel,
+                                               nick,
+                                               weechat_string_has_highlight (pos_args,
+                                                                             server->nick));
+                irc_channel_nick_speaking_time_remove_old (ptr_channel);
+                irc_channel_nick_speaking_time_add (server, ptr_channel, nick,
+                                                    time (NULL));
+            }
 
             ptr_nick = irc_nick_search (server, ptr_channel, nick);
             weechat_printf_date_tags (


### PR DESCRIPTION
* Set speaking time at notice (#585), kick (#833), CTCP and topic change (topic change already unmasks join)
* Unmask join of kicked/kicking nick (#833)
* Allow smart filtering both all prefix modes and custom modes (#548), eg.
`/set irc.look.smart_filter_mode "l+"`