### PR TITLE
Search WEECHAT_EXTRA_LIBDIR for plugins

### DIFF
--- a/src/core/wee-completion.c
+++ b/src/core/wee-completion.c
@@ -875,7 +875,7 @@ completion_list_add_plugins_installed_cb (const void *pointer, void *data,
                                           struct t_gui_buffer *buffer,
                                           struct t_gui_completion *completion)
 {
-    char *plugin_path, *plugin_path2, *dir_name;
+    char *plugin_path, *plugin_path2, *dir_name, *extra_libdir;
     int length;
 
     /* make C compiler happy */
@@ -904,6 +904,23 @@ completion_list_add_plugins_installed_cb (const void *pointer, void *data,
             free (plugin_path);
         if (plugin_path2)
             free (plugin_path2);
+    }
+
+
+    /* plugins in WeeChat extra lib dir */
+    extra_libdir = getenv("WEECHAT_EXTRA_LIBDIR");
+    if (extra_libdir && extra_libdir[0])
+    {
+        length = strlen (extra_libdir) + 16 + 1;
+        dir_name = malloc (length);
+        if (dir_name)
+        {
+            snprintf (dir_name, length, "%s/plugins", extra_libdir);
+            util_exec_on_files (dir_name, 0,
+                                &completion_list_add_plugins_installed_exec_cb,
+                                completion);
+            free (dir_name);
+        }
     }
 
     /* plugins in WeeChat global lib dir */

--- a/src/core/wee-debug.c
+++ b/src/core/wee-debug.c
@@ -571,11 +571,16 @@ debug_libs_cb (const void *pointer, void *data,
 void
 debug_directories ()
 {
+    char *extra_libdir;
     gui_chat_printf (NULL, "");
     gui_chat_printf (NULL, _("Directories:"));
     gui_chat_printf (NULL, "  home  : %s (%s: %s)",
                      weechat_home, _("default"), WEECHAT_HOME);
     gui_chat_printf (NULL, "  lib   : %s", WEECHAT_LIBDIR);
+
+    extra_libdir = getenv("WEECHAT_EXTRA_LIBDIR");
+    gui_chat_printf (NULL, "  lib+  : %s", (extra_libdir && extra_libdir[0]) ? extra_libdir : "unset");
+
     gui_chat_printf (NULL, "  share : %s", WEECHAT_SHAREDIR);
     gui_chat_printf (NULL, "  locale: %s", LOCALEDIR);
 }

--- a/src/core/wee-util.c
+++ b/src/core/wee-util.c
@@ -530,7 +530,7 @@ char *
 util_search_full_lib_name_ext (const char *filename, const char *extension,
                                const char *plugins_dir)
 {
-    char *name_with_ext, *final_name;
+    char *name_with_ext, *final_name, *extra_libdir;
     int length;
     struct stat st;
 
@@ -565,6 +565,31 @@ util_search_full_lib_name_ext (const char *filename, const char *extension,
         return final_name;
     }
     free (final_name);
+
+    extra_libdir = getenv("WEECHAT_EXTRA_LIBDIR");
+    if (extra_libdir && extra_libdir[0])
+    {
+        length = strlen(extra_libdir) + strlen(name_with_ext) + strlen(plugins_dir) + 16;
+        final_name = malloc(length);
+        if (!final_name)
+        {
+            free(name_with_ext);
+            return NULL;
+        }
+        snprintf(final_name, length,
+                 "%s%s%s%s%s",
+                 extra_libdir,
+                 DIR_SEPARATOR,
+                 plugins_dir,
+                 DIR_SEPARATOR,
+                 name_with_ext);
+        if ((stat (final_name, &st) == 0) && (st.st_size > 0))
+        {
+            free(name_with_ext);
+            return final_name;
+        }
+        free(final_name);
+    }
 
     /* try WeeChat global lib dir */
     length = strlen (WEECHAT_LIBDIR) + strlen (name_with_ext) +

--- a/src/plugins/plugin.c
+++ b/src/plugins/plugin.c
@@ -992,7 +992,7 @@ plugin_arraylist_cmp_cb (void *data,
 void
 plugin_auto_load (int argc, char **argv)
 {
-    char *dir_name, *plugin_path, *plugin_path2;
+    char *dir_name, *plugin_path, *plugin_path2, *extra_libdir;
     struct t_weechat_plugin *ptr_plugin;
     struct t_plugin_args plugin_args;
     struct t_arraylist *arraylist;
@@ -1041,6 +1041,19 @@ plugin_auto_load (int argc, char **argv)
                             &plugin_auto_load_file, &plugin_args);
         free (dir_name);
     }
+
+    /* auto-load plugins in WEECHAT_EXTRA_LIBDIR environment variable */
+    extra_libdir = getenv("WEECHAT_EXTRA_LIBDIR");
+    if (extra_libdir && extra_libdir[0])
+    {
+        length = strlen (extra_libdir) + 16 + 1;
+        dir_name = malloc (length);
+        snprintf (dir_name, length, "%s/plugins", extra_libdir);
+        util_exec_on_files (dir_name, 0,
+                            &plugin_auto_load_file, &plugin_args);
+        free (dir_name);
+    }
+
 
     /* free autoload array */
     if (plugin_autoload_array)


### PR DESCRIPTION
In addition to searching the statically configured WEECHAT_LIBDIR
(weechat's installation directory) for plugins, search the path
given in the environment variable WEECHAT_EXTRA_LIBDIR. This makes
departing from the FHS standard while keeping the plugins packaged
separately easier. This change was made specifically with the Nix
package manager in mind, but can easily be used by others.