### PR TITLE
Search & scroll fixes

### DIFF
--- a/src/gui/curses/gui-curses-chat.c
+++ b/src/gui/curses/gui-curses-chat.c
@@ -1875,6 +1875,9 @@ gui_chat_draw_free_buffer (struct t_gui_window *window, int clear_chat)
             ptr_line = gui_line_get_next_displayed (ptr_line);
         if (ptr_line)
         {
+            window->scroll->first_line_displayed =
+                (ptr_line == gui_line_get_first_displayed (window->buffer));
+
             y_start = (window->scroll->start_line) ? ptr_line->data->y : 0;
             y_end = y_start + window->win_chat_height - 1;
             while (ptr_line && (ptr_line->data->y <= y_end))

--- a/src/gui/curses/gui-curses-chat.c
+++ b/src/gui/curses/gui-curses-chat.c
@@ -1272,6 +1272,13 @@ gui_chat_display_line (struct t_gui_window *window, struct t_gui_line *line,
     pre_lines_displayed = 0;
     lines_displayed = 0;
 
+    /* calculate marker position (maybe not used for this line!) */
+    if (window->buffer->time_for_each_line && line->data->str_time)
+        read_marker_x = x + gui_chat_strlen_screen (line->data->str_time);
+    else
+        read_marker_x = x;
+    read_marker_y = y;
+
     /* display message before first line of buffer if date is not today */
     if ((line->data->date != 0)
         && CONFIG_BOOLEAN(config_look_day_change)
@@ -1301,16 +1308,11 @@ gui_chat_display_line (struct t_gui_window *window, struct t_gui_line *line,
                 gui_chat_display_new_line (window, num_lines, count,
                                            &lines_displayed, simulate);
                 pre_lines_displayed++;
+                read_marker_y++;
             }
         }
     }
 
-    /* calculate marker position (maybe not used for this line!) */
-    if (window->buffer->time_for_each_line && line->data->str_time)
-        read_marker_x = x + gui_chat_strlen_screen (line->data->str_time);
-    else
-        read_marker_x = x;
-    read_marker_y = y;
 
     /* display time and prefix */
     gui_chat_display_time_to_prefix (window, line, num_lines, count,

--- a/src/gui/curses/gui-curses-chat.c
+++ b/src/gui/curses/gui-curses-chat.c
@@ -2005,6 +2005,8 @@ gui_chat_draw_bare (struct t_gui_window *window)
             y += num_lines;
             ptr_line = gui_line_get_next_displayed (ptr_line);
         }
+        window->scroll->first_line_displayed =
+            (ptr_line == gui_line_get_first_displayed (window->buffer));
     }
     else
     {

--- a/src/gui/gui-buffer.h
+++ b/src/gui/gui-buffer.h
@@ -54,6 +54,7 @@ enum t_gui_buffer_notify
 #define GUI_TEXT_SEARCH_DISABLED 0
 #define GUI_TEXT_SEARCH_BACKWARD 1
 #define GUI_TEXT_SEARCH_FORWARD  2
+#define GUI_TEXT_SEARCH_EITHER   3 /* searching but search direction not explicitly set */
 
 #define GUI_TEXT_SEARCH_IN_MESSAGE 1
 #define GUI_TEXT_SEARCH_IN_PREFIX  2

--- a/src/gui/gui-input.c
+++ b/src/gui/gui-input.c
@@ -712,7 +712,8 @@ gui_input_search_previous (struct t_gui_buffer *buffer)
     struct t_gui_window *window;
 
     window = gui_window_search_with_buffer (buffer);
-    if (window && (window->buffer->text_search != GUI_TEXT_SEARCH_DISABLED))
+    if (window && (window->buffer->text_search != GUI_TEXT_SEARCH_DISABLED)
+        && window->scroll->first_line_displayed == 0)
     {
         window->buffer->text_search = GUI_TEXT_SEARCH_BACKWARD;
         (void) gui_window_search_text (window);

--- a/src/gui/gui-input.c
+++ b/src/gui/gui-input.c
@@ -578,8 +578,8 @@ gui_input_search_text_here (struct t_gui_buffer *buffer)
     window = gui_window_search_with_buffer (buffer);
     if (window)
     {
+        gui_input_search_stop_here (buffer);
         gui_window_search_start (window, window->scroll->start_line);
-        gui_input_search_signal (buffer);
     }
 }
 
@@ -595,8 +595,8 @@ gui_input_search_text (struct t_gui_buffer *buffer)
     window = gui_window_search_with_buffer (buffer);
     if (window)
     {
+        gui_input_search_stop_here (buffer);
         gui_window_search_start (window, NULL);
-        gui_input_search_signal (buffer);
     }
 }
 

--- a/src/gui/gui-input.c
+++ b/src/gui/gui-input.c
@@ -730,7 +730,9 @@ gui_input_search_next (struct t_gui_buffer *buffer)
     struct t_gui_window *window;
 
     window = gui_window_search_with_buffer (buffer);
-    if (window && (window->buffer->text_search != GUI_TEXT_SEARCH_DISABLED))
+    if (window && (window->buffer->text_search != GUI_TEXT_SEARCH_DISABLED)
+        && (window->scroll->start_line
+            || window->buffer->type == GUI_BUFFER_TYPE_FREE))
     {
         window->buffer->text_search = GUI_TEXT_SEARCH_FORWARD;
         (void) gui_window_search_text (window);

--- a/src/gui/gui-input.c
+++ b/src/gui/gui-input.c
@@ -527,8 +527,7 @@ gui_input_complete (struct t_gui_buffer *buffer)
 void
 gui_input_complete_next (struct t_gui_buffer *buffer)
 {
-    if (buffer->input
-        && (buffer->text_search == GUI_TEXT_SEARCH_DISABLED))
+    if (buffer->input)
     {
         gui_buffer_undo_snap (buffer);
         gui_completion_search (buffer->completion,
@@ -551,8 +550,7 @@ gui_input_complete_next (struct t_gui_buffer *buffer)
 void
 gui_input_complete_previous (struct t_gui_buffer *buffer)
 {
-    if (buffer->input
-        && (buffer->text_search == GUI_TEXT_SEARCH_DISABLED))
+    if (buffer->input)
     {
         gui_buffer_undo_snap (buffer);
         gui_completion_search (buffer->completion,
@@ -578,7 +576,7 @@ gui_input_search_text_here (struct t_gui_buffer *buffer)
     struct t_gui_window *window;
 
     window = gui_window_search_with_buffer (buffer);
-    if (window && (window->buffer->text_search == GUI_TEXT_SEARCH_DISABLED))
+    if (window)
     {
         gui_window_search_start (window, window->scroll->start_line);
         gui_input_search_signal (buffer);
@@ -595,7 +593,7 @@ gui_input_search_text (struct t_gui_buffer *buffer)
     struct t_gui_window *window;
 
     window = gui_window_search_with_buffer (buffer);
-    if (window && (window->buffer->text_search == GUI_TEXT_SEARCH_DISABLED))
+    if (window)
     {
         gui_window_search_start (window, NULL);
         gui_input_search_signal (buffer);
@@ -1425,8 +1423,7 @@ gui_input_jump_smart (struct t_gui_buffer *buffer)
 
     scroll_to_bottom = 0;
     window = gui_window_search_with_buffer (buffer);
-    if (window
-        && (window->buffer->text_search == GUI_TEXT_SEARCH_DISABLED))
+    if (window)
     {
         if (gui_hotlist)
         {
@@ -1479,8 +1476,7 @@ gui_input_jump_last_buffer_displayed (struct t_gui_buffer *buffer)
     struct t_gui_window *window;
 
     window = gui_window_search_with_buffer (buffer);
-    if (window
-        && (window->buffer->text_search == GUI_TEXT_SEARCH_DISABLED))
+    if (window)
     {
         if (gui_buffer_last_displayed)
             gui_buffer_switch_by_number (window,
@@ -1501,8 +1497,7 @@ gui_input_jump_previously_visited_buffer (struct t_gui_buffer *buffer)
     struct t_gui_buffer_visited *ptr_buffer_visited;
 
     window = gui_window_search_with_buffer (buffer);
-    if (window
-        && (window->buffer->text_search == GUI_TEXT_SEARCH_DISABLED))
+    if (window)
     {
         index = gui_buffer_visited_get_index_previous ();
         if (index >= 0)
@@ -1535,8 +1530,7 @@ gui_input_jump_next_visited_buffer (struct t_gui_buffer *buffer)
     struct t_gui_buffer_visited *ptr_buffer_visited;
 
     window = gui_window_search_with_buffer (buffer);
-    if (window
-        && (window->buffer->text_search == GUI_TEXT_SEARCH_DISABLED))
+    if (window)
     {
         index = gui_buffer_visited_get_index_next ();
         if (index >= 0)

--- a/src/gui/gui-window.c
+++ b/src/gui/gui-window.c
@@ -1217,8 +1217,14 @@ gui_window_scroll (struct t_gui_window *window, char *scroll)
     }
     else
     {
-        ptr_line = (window->scroll->start_line) ?
-            window->scroll->start_line : window->buffer->lines->first_line;
+        if (window->scroll->start_line)
+            ptr_line = window->scroll->start_line;
+        else if (window->scroll->first_line_displayed
+                 || window->buffer->type == GUI_BUFFER_TYPE_FREE)
+            ptr_line = window->buffer->lines->first_line;
+        else
+            return;
+
         while (ptr_line
                && (!gui_line_is_displayed (ptr_line)
                    || ((window->buffer->type == GUI_BUFFER_TYPE_FORMATTED)

--- a/src/gui/gui-window.c
+++ b/src/gui/gui-window.c
@@ -1569,51 +1569,60 @@ gui_window_search_text (struct t_gui_window *window)
 
     if (!window)
         return 0;
+    if (!window->buffer->lines->first_line)
+        return 0;
+    if (!window->buffer->input_buffer)
+        return 0;
+    if (!window->buffer->input_buffer[0])
+        return 0;
 
-    if (window->buffer->text_search == GUI_TEXT_SEARCH_BACKWARD)
+    if (window->buffer->text_search == GUI_TEXT_SEARCH_BACKWARD
+        || (window->buffer->text_search == GUI_TEXT_SEARCH_EITHER
+            && (window->buffer->type == GUI_BUFFER_TYPE_FORMATTED
+                || window->scroll->start_line)))
     {
-        if (window->buffer->lines->first_line
-            && window->buffer->input_buffer && window->buffer->input_buffer[0])
-        {
-            ptr_line = (window->scroll->start_line) ?
+        ptr_line = (window->scroll->start_line) ?
+            ((window->buffer->text_search == GUI_TEXT_SEARCH_BACKWARD) ?
                 gui_line_get_prev_displayed (window->scroll->start_line) :
-                gui_line_get_last_displayed (window->buffer);
-            while (ptr_line)
+                window->scroll->start_line) :
+             gui_line_get_last_displayed (window->buffer);
+        while (ptr_line)
+        {
+            if (gui_line_search_text (window->buffer, ptr_line))
             {
-                if (gui_line_search_text (window->buffer, ptr_line))
-                {
-                    window->scroll->start_line = ptr_line;
-                    window->scroll->start_line_pos = 0;
-                    window->scroll->first_line_displayed =
-                        (window->scroll->start_line == gui_line_get_first_displayed (window->buffer));
-                    gui_buffer_ask_chat_refresh (window->buffer, 2);
-                    return 1;
-                }
-                ptr_line = gui_line_get_prev_displayed (ptr_line);
+                window->scroll->start_line = ptr_line;
+                window->scroll->start_line_pos = 0;
+                window->scroll->first_line_displayed =
+                    (window->scroll->start_line == gui_line_get_first_displayed (window->buffer));
+                gui_buffer_ask_chat_refresh (window->buffer, 2);
+                return 1;
             }
+            ptr_line = gui_line_get_prev_displayed (ptr_line);
         }
     }
-    else if (window->buffer->text_search == GUI_TEXT_SEARCH_FORWARD)
+
+    if (window->buffer->text_search == GUI_TEXT_SEARCH_FORWARD
+        || (window->buffer->text_search == GUI_TEXT_SEARCH_EITHER
+            && (window->buffer->type == GUI_BUFFER_TYPE_FREE
+                || window->scroll->start_line)))
     {
-        if (window->buffer->lines->first_line
-            && window->buffer->input_buffer && window->buffer->input_buffer[0])
-        {
-            ptr_line = (window->scroll->start_line) ?
+        ptr_line = (window->scroll->start_line) ?
+            ((window->buffer->text_search == GUI_TEXT_SEARCH_FORWARD) ?
                 gui_line_get_next_displayed (window->scroll->start_line) :
-                gui_line_get_first_displayed (window->buffer);
-            while (ptr_line)
+                window->scroll->start_line) :
+            gui_line_get_first_displayed (window->buffer);
+        while (ptr_line)
+        {
+            if (gui_line_search_text (window->buffer, ptr_line))
             {
-                if (gui_line_search_text (window->buffer, ptr_line))
-                {
-                    window->scroll->start_line = ptr_line;
-                    window->scroll->start_line_pos = 0;
-                    window->scroll->first_line_displayed =
-                        (window->scroll->start_line == window->buffer->lines->first_line);
-                    gui_buffer_ask_chat_refresh (window->buffer, 2);
-                    return 1;
-                }
-                ptr_line = gui_line_get_next_displayed (ptr_line);
+                window->scroll->start_line = ptr_line;
+                window->scroll->start_line_pos = 0;
+                window->scroll->first_line_displayed =
+                    (window->scroll->start_line == window->buffer->lines->first_line);
+                gui_buffer_ask_chat_refresh (window->buffer, 2);
+                return 1;
             }
+            ptr_line = gui_line_get_next_displayed (ptr_line);
         }
     }
     return 0;
@@ -1632,9 +1641,7 @@ gui_window_search_start (struct t_gui_window *window,
         return;
 
     window->scroll->text_search_start_line = text_search_start_line;
-    window->buffer->text_search =
-        (window->buffer->type == GUI_BUFFER_TYPE_FORMATTED) ?
-        GUI_TEXT_SEARCH_BACKWARD : GUI_TEXT_SEARCH_FORWARD;
+    window->buffer->text_search = GUI_TEXT_SEARCH_EITHER;
 
     if ((window->buffer->text_search_where == 0)
         ||  CONFIG_BOOLEAN(config_look_buffer_search_force_default))
@@ -1689,9 +1696,7 @@ gui_window_search_restart (struct t_gui_window *window)
 
     window->scroll->start_line = window->scroll->text_search_start_line;
     window->scroll->start_line_pos = 0;
-    window->buffer->text_search =
-        (window->buffer->type == GUI_BUFFER_TYPE_FORMATTED) ?
-        GUI_TEXT_SEARCH_BACKWARD : GUI_TEXT_SEARCH_FORWARD;
+    window->buffer->text_search = GUI_TEXT_SEARCH_EITHER;
     window->buffer->text_search_found = 0;
     gui_input_search_compile_regex (window->buffer);
     if (gui_window_search_text (window))


### PR DESCRIPTION
Fixes for the following:
- filter indicator showed in day change message (in screenshot)
- searching fails when there are matches only after the starting point, or only before the starting point in free content buffers (alt+home, ctrl+r, type) (in screenshot)
- first letter in search mode scrolls up even if the first line matches
- searching previous match at the top of a free content buffer scrolls to the bottom (ctrl+r, b, alt+home, up)
- searching next match at the end of the buffer scrolls to the first match (ctrl+r, b, alt+end, down)
- /window scroll +n at the end of the buffer scrolls to the top
- /input's completion, buffer switch and search functions are disabled in search mode (a leftover for when scroll state wasn't saved?)
- scrolling up in bare mode fails when switched to bare mode at the top of the buffer (#899)
![sc](http://weechat.arza.us/search_bugs.png)