### PR TITLE
Add weechat.look.read_marker_update_on_buffer_switch

### DIFF
--- a/src/core/wee-config.c
+++ b/src/core/wee-config.c
@@ -135,6 +135,7 @@ struct t_config_option *config_look_hotlist_short_names;
 struct t_config_option *config_look_hotlist_sort;
 struct t_config_option *config_look_hotlist_suffix;
 struct t_config_option *config_look_hotlist_unique_numbers;
+struct t_config_option *config_look_hotlist_update_on_buffer_switch;
 struct t_config_option *config_look_input_cursor_scroll;
 struct t_config_option *config_look_input_share;
 struct t_config_option *config_look_input_share_overwrite;
@@ -3100,6 +3101,12 @@ config_weechat_init_options ()
         NULL, NULL, NULL,
         &config_change_buffer_content, NULL, NULL,
         NULL, NULL, NULL);
+    config_look_hotlist_update_on_buffer_switch = config_file_new_option (
+        weechat_config_file, ptr_section,
+        "hotlist_update_on_buffer_switch", "boolean",
+        N_("update the hotlist when switching buffers"),
+        NULL, 0, 0, "on", NULL, 0,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
     config_look_input_cursor_scroll = config_file_new_option (
         weechat_config_file, ptr_section,
         "input_cursor_scroll", "integer",

--- a/src/core/wee-config.c
+++ b/src/core/wee-config.c
@@ -180,6 +180,7 @@ struct t_config_option *config_look_quote_time_format;
 struct t_config_option *config_look_read_marker;
 struct t_config_option *config_look_read_marker_always_show;
 struct t_config_option *config_look_read_marker_string;
+struct t_config_option *config_look_read_marker_update_on_buffer_switch;
 struct t_config_option *config_look_save_config_on_exit;
 struct t_config_option *config_look_save_config_with_fsync;
 struct t_config_option *config_look_save_layout_on_exit;
@@ -3524,6 +3525,12 @@ config_weechat_init_options ()
         NULL, NULL, NULL,
         &config_change_read_marker, NULL, NULL,
         NULL, NULL, NULL);
+    config_look_read_marker_update_on_buffer_switch = config_file_new_option (
+        weechat_config_file, ptr_section,
+        "read_marker_update_on_buffer_switch", "boolean",
+        N_("update the read marker when switching buffers"),
+        NULL, 0, 0, "on", NULL, 0,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
     config_look_save_config_on_exit = config_file_new_option (
         weechat_config_file, ptr_section,
         "save_config_on_exit", "boolean",

--- a/src/core/wee-config.h
+++ b/src/core/wee-config.h
@@ -233,6 +233,7 @@ extern struct t_config_option *config_look_quote_time_format;
 extern struct t_config_option *config_look_read_marker;
 extern struct t_config_option *config_look_read_marker_always_show;
 extern struct t_config_option *config_look_read_marker_string;
+extern struct t_config_option *config_look_read_marker_update_on_buffer_switch;
 extern struct t_config_option *config_look_save_config_on_exit;
 extern struct t_config_option *config_look_save_config_with_fsync;
 extern struct t_config_option *config_look_save_layout_on_exit;

--- a/src/core/wee-config.h
+++ b/src/core/wee-config.h
@@ -188,6 +188,7 @@ extern struct t_config_option *config_look_hotlist_short_names;
 extern struct t_config_option *config_look_hotlist_sort;
 extern struct t_config_option *config_look_hotlist_suffix;
 extern struct t_config_option *config_look_hotlist_unique_numbers;
+extern struct t_config_option *config_look_hotlist_update_on_buffer_switch;
 extern struct t_config_option *config_look_input_cursor_scroll;
 extern struct t_config_option *config_look_input_share;
 extern struct t_config_option *config_look_input_share_overwrite;

--- a/src/gui/curses/gui-curses-window.c
+++ b/src/gui/curses/gui-curses-window.c
@@ -1265,7 +1265,7 @@ gui_window_switch_to_buffer (struct t_gui_window *window,
     gui_buffer_compute_num_displayed ();
 
     if (!weechat_upgrading
-        && CONFIG_BOOLEAN(config_look_read_marker_update_on_buffer_switch)
+        && CONFIG_BOOLEAN(config_look_hotlist_update_on_buffer_switch)
         && (old_buffer != buffer))
     {
         gui_hotlist_remove_buffer (buffer, 0);

--- a/src/gui/curses/gui-curses-window.c
+++ b/src/gui/curses/gui-curses-window.c
@@ -1235,13 +1235,17 @@ gui_window_switch_to_buffer (struct t_gui_window *window,
             gui_buffer_visited_add (window->buffer);
             gui_buffer_visited_add (buffer);
         }
-        if (set_last_read)
+        if (CONFIG_BOOLEAN(config_look_read_marker_update_on_buffer_switch)
+            && set_last_read)
         {
             if (window->buffer->num_displayed == 0)
             {
                 window->buffer->lines->last_read_line = window->buffer->lines->last_line;
                 window->buffer->lines->first_line_not_read = 0;
             }
+        }
+        if (set_last_read)
+        {
             /*
              * if there is no line displayed after last read line,
              * then remove the read marker
@@ -1260,8 +1264,12 @@ gui_window_switch_to_buffer (struct t_gui_window *window,
     gui_buffer_set_active_buffer (buffer);
     gui_buffer_compute_num_displayed ();
 
-    if (!weechat_upgrading && (old_buffer != buffer))
+    if (!weechat_upgrading
+        && CONFIG_BOOLEAN(config_look_read_marker_update_on_buffer_switch)
+        && (old_buffer != buffer))
+    {
         gui_hotlist_remove_buffer (buffer, 0);
+    }
 
     /* remove unused bars and add missing bars in window */
     gui_bar_window_remove_unused_bars (window);


### PR DESCRIPTION
AFAICT, it's not possible to achieve what I'm looking for in #992 just via the configuration and/or plugins.

I identified the places in the code where this behaviour is occurring (non-configurably), and confirmed that commenting out these lines was enough to provide the behaviour that I was looking for.  I then added an option and cleaned up the code, so that the existing behaviour is preserved by default, but interested users can still easily opt-in to this alternate behaviour.

I have been using this on a daily basis for the past 2 months, and haven't noticed any ill-effects.  I find that this approach of manually resetting the read marker and hotlist fits nicely with my workflow.

I believe that the code changes should be fairly straightforward and low-risk.  Please let me know if there is anything that can be done to improve this PR.