### PR TITLE
core: add /input set_unread_current_buffer_here

### DIFF
--- a/doc/en/autogen/user/weechat_commands.adoc
+++ b/doc/en/autogen/user/weechat_commands.adoc
@@ -474,6 +474,7 @@ list of actions:
   grab_mouse_area: grab mouse event code with area
   set_unread: set unread marker for all buffers
   set_unread_current_buffer: set unread marker for current buffer
+  set_unread_current_buffer_here: set unread marker at current position
   switch_active_buffer: switch to next merged buffer
   switch_active_buffer_previous: switch to previous merged buffer
   zoom_merged_buffer: zoom on merged buffer

--- a/doc/en/weechat_plugin_api.en.adoc
+++ b/doc/en/weechat_plugin_api.en.adoc
@@ -11945,8 +11945,10 @@ Properties:
   "1": do not stop completion when command line is updated
   (global setting, buffer pointer is not used).
 
-| unread | - |
-  Set unread marker after last line of buffer.
+| unread | "0", "1", or "-1" |
+  "0": set unread marker before first line
+  "1": set unread marker after end line of current scroll position
+  "-1": set unread marker after last line of buffer
 
 | display | "1" or "auto" |
   "1": switch to this buffer in current window +

--- a/src/core/wee-command.c
+++ b/src/core/wee-command.c
@@ -3072,6 +3072,8 @@ COMMAND_CALLBACK(input)
         gui_input_set_unread ();
     else if (string_strcasecmp (argv[1], "set_unread_current_buffer") == 0)
         gui_input_set_unread_current (buffer);
+    else if (string_strcasecmp (argv[1], "set_unread_current_buffer_here") == 0)
+        gui_input_set_unread_current_here (buffer);
     else if (string_strcasecmp (argv[1], "switch_active_buffer") == 0)
         gui_input_switch_active_buffer (buffer);
     else if (string_strcasecmp (argv[1], "zoom_merged_buffer") == 0)
@@ -7498,6 +7500,7 @@ command_init ()
            "  grab_mouse_area: grab mouse event code with area\n"
            "  set_unread: set unread marker for all buffers\n"
            "  set_unread_current_buffer: set unread marker for current buffer\n"
+           "  set_unread_current_buffer_here: set unread marker at current position\n"
            "  switch_active_buffer: switch to next merged buffer\n"
            "  switch_active_buffer_previous: switch to previous merged buffer\n"
            "  zoom_merged_buffer: zoom on merged buffer\n"
@@ -7522,7 +7525,8 @@ command_init ()
         "jump_previously_visited_buffer || jump_next_visited_buffer || "
         "hotlist_clear 1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|lowest|highest || "
         "grab_key || grab_key_command || grab_mouse || grab_mouse_area || "
-        "set_unread || set_unread_current_buffer || switch_active_buffer || "
+        "set_unread || set_unread_current_buffer || "
+        "set_unread_current_buffer_here || switch_active_buffer || "
         "switch_active_buffer_previous || zoom_merged_buffer || insert || "
         "send || paste_start || paste_stop",
         &command_input, NULL, NULL);

--- a/src/gui/curses/gui-curses-chat.c
+++ b/src/gui/curses/gui-curses-chat.c
@@ -1731,6 +1731,23 @@ gui_chat_draw_formatted_buffer (struct t_gui_window *window)
     auto_search_first_line = 1;
     ptr_line = NULL;
     line_pos = 0;
+
+    if (window->refresh_due_unread)
+    {
+        window->refresh_due_unread = 0;
+        ptr_line = window->buffer->lines->last_read_line;
+        if (ptr_line && !ptr_line->data->displayed)
+            ptr_line = gui_line_get_prev_displayed (ptr_line);
+        if (ptr_line)
+        {
+            line_pos = gui_chat_display_line (window, ptr_line, 0, 1) - 1;
+            gui_chat_calculate_line_diff (window, &ptr_line, &line_pos,
+                                        (-1) * (window->win_chat_height - 1));
+            window->scroll->start_line = ptr_line;
+            window->scroll->start_line_pos = line_pos;
+        }
+    }
+
     if (window->scroll->start_line)
     {
         auto_search_first_line = 0;
@@ -1817,6 +1834,20 @@ gui_chat_draw_formatted_buffer (struct t_gui_window *window)
     {
         window->scroll->start_line = NULL;
         window->scroll->start_line_pos = 0;
+    }
+
+    window->scroll->end_line = NULL;
+    if (window->scroll->scrolling)
+    {
+        if (ptr_line)
+        {
+            ptr_line2 = gui_line_get_prev_displayed (ptr_line);
+            if (count < gui_chat_display_line (window, ptr_line2, 0, 1))
+                ptr_line2 = gui_line_get_prev_displayed (ptr_line2);
+        }
+        else
+            ptr_line2 = gui_line_get_prev_displayed(gui_line_get_last_displayed (window->buffer));
+        window->scroll->end_line = ptr_line2;
     }
 
     window->scroll->lines_after = 0;

--- a/src/gui/gui-buffer.c
+++ b/src/gui/gui-buffer.c
@@ -1765,21 +1765,35 @@ gui_buffer_set_input_get_unknown_commands (struct t_gui_buffer *buffer,
  */
 
 void
-gui_buffer_set_unread (struct t_gui_buffer *buffer)
+gui_buffer_set_unread (struct t_gui_buffer *buffer, int target)
 {
-    int refresh;
+    struct t_gui_window *window;
+    struct t_gui_line *old_last_read_line;
+    int old_first_line_not_read;
 
     if (!buffer || (buffer->type != GUI_BUFFER_TYPE_FORMATTED))
         return;
 
-    refresh = ((buffer->lines->last_read_line != NULL)
-               && (buffer->lines->last_read_line != buffer->lines->last_line));
+    window = gui_window_search_with_buffer (buffer);
+    old_last_read_line = buffer->lines->last_read_line;
+    old_first_line_not_read = buffer->lines->first_line_not_read;
 
-    buffer->lines->last_read_line = buffer->lines->last_line;
+    if (target < 0)
+        buffer->lines->last_read_line = buffer->lines->last_line;
+    else if (target == 0)
+        buffer->lines->last_read_line = NULL;
+    else
+        buffer->lines->last_read_line = (window && window->scroll->end_line) ?
+            window->scroll->end_line : buffer->lines->last_line;
     buffer->lines->first_line_not_read = (buffer->lines->last_read_line) ? 0 : 1;
 
-    if (refresh)
+    if (old_last_read_line != buffer->lines->last_read_line ||
+        old_first_line_not_read != buffer->lines->first_line_not_read)
+    {
+        if (window)
+            window->refresh_due_unread = 1;
         gui_buffer_ask_chat_refresh (buffer, 2);
+    }
 }
 
 /*
@@ -1827,7 +1841,12 @@ gui_buffer_set (struct t_gui_buffer *buffer, const char *property,
     /* properties that need a buffer */
     if (string_strcasecmp (property, "unread") == 0)
     {
-        gui_buffer_set_unread (buffer);
+        error = NULL;
+        number = strtol (value, &error, 10);
+        if (error && value[0] && !error[0])
+            gui_buffer_set_unread (buffer, number);
+        else
+            gui_buffer_set_unread (buffer, -1);
     }
     else if (string_strcasecmp (property, "display") == 0)
     {

--- a/src/gui/gui-buffer.h
+++ b/src/gui/gui-buffer.h
@@ -289,7 +289,7 @@ extern void gui_buffer_set_highlight_tags (struct t_gui_buffer *buffer,
                                            const char *new_tags);
 extern void gui_buffer_set_hotlist_max_level_nicks (struct t_gui_buffer *buffer,
                                                     const char *new_hotlist_max_level_nicks);
-extern void gui_buffer_set_unread (struct t_gui_buffer *buffer);
+extern void gui_buffer_set_unread (struct t_gui_buffer *buffer, int target);
 extern void gui_buffer_set (struct t_gui_buffer *buffer, const char *property,
                             const char *value);
 extern void gui_buffer_set_pointer (struct t_gui_buffer *buffer,

--- a/src/gui/gui-input.c
+++ b/src/gui/gui-input.c
@@ -1654,7 +1654,7 @@ gui_input_set_unread ()
     for (ptr_buffer = gui_buffers; ptr_buffer;
          ptr_buffer = ptr_buffer->next_buffer)
     {
-        gui_buffer_set_unread (ptr_buffer);
+        gui_buffer_set_unread (ptr_buffer, -1);
     }
 }
 
@@ -1665,7 +1665,17 @@ gui_input_set_unread ()
 void
 gui_input_set_unread_current (struct t_gui_buffer *buffer)
 {
-    gui_buffer_set_unread (buffer);
+    gui_buffer_set_unread (buffer, -1);
+}
+
+/*
+ * Sets unread marker at current position.
+ */
+
+void
+gui_input_set_unread_current_here (struct t_gui_buffer *buffer)
+{
+    gui_buffer_set_unread (buffer, 1);
 }
 
 /*

--- a/src/gui/gui-input.h
+++ b/src/gui/gui-input.h
@@ -82,6 +82,7 @@ extern void gui_input_grab_key (struct t_gui_buffer *buffer, int command,
 extern void gui_input_grab_mouse (struct t_gui_buffer *buffer, int area);
 extern void gui_input_set_unread ();
 extern void gui_input_set_unread_current (struct t_gui_buffer *buffer);
+extern void gui_input_set_unread_current_here (struct t_gui_buffer *buffer);
 extern void gui_input_switch_active_buffer (struct t_gui_buffer *buffer);
 extern void gui_input_switch_active_buffer_previous (struct t_gui_buffer *buffer);
 extern void gui_input_zoom_merged_buffer (struct t_gui_buffer *buffer);

--- a/src/gui/gui-window.h
+++ b/src/gui/gui-window.h
@@ -58,6 +58,7 @@ struct t_gui_window
 
     /* refresh */
     int refresh_needed;                /* 1 if refresh needed for window    */
+    int refresh_due_unread;            /* 1 if refresh due unread marker    */
 
     /* GUI specific objects */
     void *gui_objects;                 /* pointer to a GUI specific struct  */
@@ -89,7 +90,8 @@ struct t_gui_window_scroll
 {
     struct t_gui_buffer *buffer;       /* buffer scrolled in window         */
     int first_line_displayed;          /* = 1 if first line is displayed    */
-    struct t_gui_line *start_line;     /* pointer to line if scrolling      */
+    struct t_gui_line *start_line;     /* pointer to start line if scrolling*/
+    struct t_gui_line *end_line;       /* pointer to end line if scrolling  */
     int start_line_pos;                /* position in first line displayed  */
     int scrolling;                     /* = 1 if "MORE" should be displayed */
     int start_col;                     /* first column displayed            */

--- a/src/plugins/irc/irc-command.c
+++ b/src/plugins/irc/irc-command.c
@@ -921,12 +921,12 @@ irc_command_away_server (struct t_irc_server *server, const char *arguments,
             if (reset_unread_marker)
             {
                 if (weechat_buffer_get_integer (server->buffer, "num_displayed") > 0)
-                    weechat_buffer_set (server->buffer, "unread", "");
+                    weechat_buffer_set (server->buffer, "unread", "-1");
                 for (ptr_channel = server->channels; ptr_channel;
                      ptr_channel = ptr_channel->next_channel)
                 {
                     if (weechat_buffer_get_integer (ptr_channel->buffer, "num_displayed") > 0)
-                        weechat_buffer_set (ptr_channel->buffer, "unread", "");
+                        weechat_buffer_set (ptr_channel->buffer, "unread", "-1");
                 }
             }
 

--- a/src/plugins/logger/logger.c
+++ b/src/plugins/logger/logger.c
@@ -1028,7 +1028,7 @@ logger_backlog (struct t_gui_buffer *buffer, const char *filename, int lines)
                                   weechat_color (weechat_config_string (logger_config_color_backlog_end)),
                                   weechat_color (weechat_config_string (logger_config_color_backlog_end)),
                                   num_lines);
-        weechat_buffer_set (buffer, "unread", "");
+        weechat_buffer_set (buffer, "unread", "-1");
     }
     weechat_buffer_set (buffer, "print_hooks_enabled", "1");
 }


### PR DESCRIPTION
**Edited:** I've force-pushed patch with few cosmetic changes, especially in relation to #1007. 

* new "/input" action:

    set_unread_current_buffer_here: set unread marker at current position

* buffer "unread" property value now means:

    "0": set unread marker before first line
    int > 0: set unread marker after end line of current scroll position
    int < 0: set unread marker after last line of buffer

    Any other value is treated as "-1".