### PR TITLE
core: simplify gui_window_switch_to_buffer

### DIFF
--- a/src/gui/curses/gui-curses-window.c
+++ b/src/gui/curses/gui-curses-window.c
@@ -1201,23 +1201,11 @@ gui_window_switch_to_buffer (struct t_gui_window *window,
             gui_buffer_visited_add (window->buffer);
             gui_buffer_visited_add (buffer);
         }
-        if (set_last_read)
+        if (set_last_read && window->buffer->num_displayed == 0)
         {
-            if (window->buffer->num_displayed == 0)
-            {
-                window->buffer->lines->last_read_line = window->buffer->lines->last_line;
-                window->buffer->lines->first_line_not_read = 0;
-            }
-            /*
-             * if there is no line displayed after last read line,
-             * then remove the read marker
-             */
-            if (buffer->lines->last_read_line
-                && !gui_line_get_next_displayed (buffer->lines->last_read_line))
-            {
-                buffer->lines->last_read_line = NULL;
-                buffer->lines->first_line_not_read = 0;
-            }
+            window->buffer->lines->last_read_line = window->buffer->lines->last_line;
+            window->buffer->lines->first_line_not_read =
+                (window->buffer->lines->last_read_line) ? 0 : 1;
         }
     }
 
@@ -1273,14 +1261,6 @@ gui_window_switch_to_buffer (struct t_gui_window *window,
          ptr_bar_window = ptr_bar_window->next_bar_window)
     {
         ptr_bar_window->bar->bar_refresh_needed = 1;
-    }
-
-    if (CONFIG_BOOLEAN(config_look_read_marker_always_show)
-        && set_last_read
-        && !window->buffer->lines->last_read_line
-        && !window->buffer->lines->first_line_not_read)
-    {
-        window->buffer->lines->last_read_line = window->buffer->lines->last_line;
     }
 
     gui_input_move_to_buffer (old_buffer, window->buffer);


### PR DESCRIPTION
* make sure first_line_not_read is set correctly
* don't set/unset read marker in target buffer

Currently read marker in target buffer would be unset if there is no
line displayed after last read line. This e.g., leads to following
scenario:

    * go to buffer A with some content (read marker might be set)
    * go to buffer B, buffer A will get read marker set to last line
    * buffer A hasn't seen any new messages
    * go to buffer A, buffer B will get read marker set to last line,
      and buffer A will get read marker *unset*
    * now buffer A gets some new messages
    * you can't return/scroll to the last set read marker

Following the "rule" that read marker should not be manipulated in
target buffer whole logic gets simplified.