### PR TITLE
core: add config_look_read_marker_auto_set

### DIFF
--- a/src/core/wee-config.c
+++ b/src/core/wee-config.c
@@ -176,6 +176,7 @@ struct t_config_option *config_look_quote_nick_suffix;
 struct t_config_option *config_look_quote_time_format;
 struct t_config_option *config_look_read_marker;
 struct t_config_option *config_look_read_marker_always_show;
+struct t_config_option *config_look_read_marker_auto_set;
 struct t_config_option *config_look_read_marker_string;
 struct t_config_option *config_look_save_config_on_exit;
 struct t_config_option *config_look_save_layout_on_exit;
@@ -3325,6 +3326,12 @@ config_weechat_init_options ()
         "read_marker_always_show", "boolean",
         N_("always show read marker, even if it is after last buffer line"),
         NULL, 0, 0, "off", NULL, 0,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+    config_look_read_marker_auto_set = config_file_new_option (
+        weechat_config_file, ptr_section,
+        "read_marker_auto_set", "boolean",
+        N_("set read marker automatically"),
+        NULL, 0, 0, "on", NULL, 0,
         NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
     config_look_read_marker_string = config_file_new_option (
         weechat_config_file, ptr_section,

--- a/src/core/wee-config.h
+++ b/src/core/wee-config.h
@@ -227,6 +227,7 @@ extern struct t_config_option *config_look_quote_nick_suffix;
 extern struct t_config_option *config_look_quote_time_format;
 extern struct t_config_option *config_look_read_marker;
 extern struct t_config_option *config_look_read_marker_always_show;
+extern struct t_config_option *config_look_read_marker_auto_set;
 extern struct t_config_option *config_look_read_marker_string;
 extern struct t_config_option *config_look_save_config_on_exit;
 extern struct t_config_option *config_look_save_layout_on_exit;

--- a/src/gui/curses/gui-curses-window.c
+++ b/src/gui/curses/gui-curses-window.c
@@ -1181,6 +1181,9 @@ gui_window_switch_to_buffer (struct t_gui_window *window,
     if (!gui_init_ok)
         return;
 
+    set_last_read = set_last_read &&
+        CONFIG_BOOLEAN(config_look_read_marker_auto_set);
+
     gui_buffer_add_value_num_displayed (window->buffer, -1);
 
     old_buffer = window->buffer;


### PR DESCRIPTION
This is similar to #993. It's limited only to read marker (doesn't deal with hotlist) and suggests different configuration option name (``config_look_read_marker_auto_set``) which seems more appropriate to me.