### PR TITLE
Small fixes and code cleanup for problems found by CLion inspections

### DIFF
--- a/src/core/wee-command.c
+++ b/src/core/wee-command.c
@@ -1740,7 +1740,7 @@ COMMAND_CALLBACK(debug)
 
     if (string_strcasecmp (argv[1], "color") == 0)
     {
-        gui_color_dump (buffer);
+        gui_color_dump ();
         return WEECHAT_RC_OK;
     }
 

--- a/src/core/wee-infolist.h
+++ b/src/core/wee-infolist.h
@@ -22,6 +22,8 @@
 
 #include <time.h>
 
+struct t_weechat_plugin;
+
 /* list structures */
 
 enum t_infolist_type

--- a/src/core/wee-secure.c
+++ b/src/core/wee-secure.c
@@ -42,8 +42,6 @@
 #define SALT_SIZE 8
 
 struct t_config_file *secure_config_file = NULL;
-struct t_config_section *secure_config_section_crypt = NULL;
-struct t_config_section *secure_config_section_data = NULL;
 
 struct t_config_option *secure_config_crypt_cipher = NULL;
 struct t_config_option *secure_config_crypt_hash_algo = NULL;

--- a/src/gui/gui-bar-item.c
+++ b/src/gui/gui-bar-item.c
@@ -81,8 +81,6 @@ char *gui_bar_items_default_for_bars[][2] =
 struct t_gui_bar_item_hook *gui_bar_item_hooks = NULL;
 struct t_hook *gui_bar_item_timer = NULL;
 
-struct t_hdata *gui_bar_item_hdata_bar_item = NULL;
-
 
 /*
  * Checks if a bar item pointer is valid.

--- a/src/gui/gui-bar-window.h
+++ b/src/gui/gui-bar-window.h
@@ -20,10 +20,11 @@
 #ifndef WEECHAT_GUI_BAR_WINDOW_H
 #define WEECHAT_GUI_BAR_WINDOW_H 1
 
+#include "gui-bar.h"
+
 struct t_infolist;
 struct t_gui_buffer;
 struct t_gui_window;
-enum t_gui_bar_position;
 
 struct t_gui_bar_window_coords
 {

--- a/src/gui/gui-chat.h
+++ b/src/gui/gui-chat.h
@@ -105,7 +105,5 @@ extern const char *gui_chat_string_next_char (struct t_gui_window *window,
                                               int apply_style_inactive,
                                               int nick_offline);
 extern void gui_chat_draw (struct t_gui_buffer *buffer, int clear_chat);
-extern void gui_chat_draw_line (struct t_gui_buffer *buffer,
-                                struct t_gui_line *line);
 
 #endif /* WEECHAT_GUI_CHAT_H */

--- a/src/gui/gui-completion.c
+++ b/src/gui/gui-completion.c
@@ -1399,31 +1399,6 @@ gui_completion_hdata_completion_cb (const void *pointer, void *data,
 }
 
 /*
- * Returns hdata for completion word.
- */
-
-struct t_hdata *
-gui_completion_hdata_completion_word_cb (const void *pointer, void *data,
-                                         const char *hdata_name)
-{
-    struct t_hdata *hdata;
-
-    /* make C compiler happy */
-    (void) pointer;
-    (void) data;
-
-    hdata = hdata_new (NULL, hdata_name, "prev_item", "next_item",
-                       0, 0, NULL, NULL);
-    if (hdata)
-    {
-        HDATA_VAR(struct t_gui_completion_word, word, STRING, 0, NULL, NULL);
-        HDATA_VAR(struct t_gui_completion_word, nick_completion, CHAR, 0, NULL, NULL);
-        HDATA_VAR(struct t_gui_completion_word, count, INTEGER, 0, NULL, NULL);
-    }
-    return hdata;
-}
-
-/*
  * Prints list of completion words in WeeChat log file (usually for crash dump).
  */
 

--- a/src/gui/gui-completion.h
+++ b/src/gui/gui-completion.h
@@ -83,9 +83,6 @@ extern const char *gui_completion_get_string (struct t_gui_completion *completio
 extern struct t_hdata *gui_completion_hdata_completion_cb (const void *pointer,
                                                            void *data,
                                                            const char *hdata_name);
-extern struct t_hdata *gui_completion_hdata_completion_partial_cb (const void *pointer,
-                                                                   void *data,
-                                                                   const char *hdata_name);
 extern void gui_completion_print_log (struct t_gui_completion *completion);
 
 #endif /* WEECHAT_GUI_COMPLETION_H */

--- a/src/gui/gui-focus.h
+++ b/src/gui/gui-focus.h
@@ -18,7 +18,7 @@
  */
 
 #ifndef WEECHAT_GUI_FOCUS_H
-#define WEECHAT_GUI_FOCUS 1
+#define WEECHAT_GUI_FOCUS_H 1
 
 /* focus structures */
 

--- a/src/gui/gui-key.c
+++ b/src/gui/gui-key.c
@@ -1007,28 +1007,6 @@ gui_key_focus_matching (struct t_gui_key *key,
 }
 
 /*
- * Callback for replacing values in string with a hashtable.
- */
-
-char *
-gui_key_focus_command_replace_cb (void *data, const char *text)
-{
-    struct t_hashtable *ptr_hashtable;
-    const char *ptr_value;
-
-    ptr_hashtable = (struct t_hashtable *)data;
-
-    if (ptr_hashtable)
-    {
-        ptr_value = hashtable_get (ptr_hashtable, text);
-        if (ptr_value)
-            return strdup (ptr_value);
-    }
-
-    return NULL;
-}
-
-/*
  * Runs command according to focus.
  *
  * Returns:

--- a/src/gui/gui-key.h
+++ b/src/gui/gui-key.h
@@ -140,6 +140,6 @@ extern void gui_key_print_log (struct t_gui_buffer *buffer);
 
 /* key functions (GUI dependent) */
 
-extern void gui_key_default_bindings ();
+extern void gui_key_default_bindings (int context);
 
 #endif /* WEECHAT_GUI_KEY_H */

--- a/src/gui/gui-layout.h
+++ b/src/gui/gui-layout.h
@@ -129,7 +129,5 @@ extern int gui_layout_window_add_to_infolist (struct t_infolist *infolist,
 extern int gui_layout_add_to_infolist (struct t_infolist *infolist,
                                        struct t_gui_layout *layout);
 extern void gui_layout_print_log ();
-extern void gui_layout_init ();
-extern void gui_layout_end ();
 
 #endif /* WEECHAT_GUI_LAYOUT_H */

--- a/src/gui/gui-line.h
+++ b/src/gui/gui-line.h
@@ -97,7 +97,6 @@ extern int gui_line_has_offline_nick (struct t_gui_line *line);
 extern void gui_line_compute_buffer_max_length (struct t_gui_buffer *buffer,
                                                 struct t_gui_lines *lines);
 extern void gui_line_compute_prefix_max_length (struct t_gui_lines *lines);
-extern void gui_line_set_prefix_same_nick (struct t_gui_line *line);
 extern void gui_line_mixed_free_buffer (struct t_gui_buffer *buffer);
 extern void gui_line_mixed_free_all (struct t_gui_buffer *buffer);
 extern void gui_line_free (struct t_gui_buffer *buffer,

--- a/src/plugins/buflist/buflist.h
+++ b/src/plugins/buflist/buflist.h
@@ -33,7 +33,6 @@ extern struct t_hdata *buflist_hdata_hotlist;
 extern void buflist_add_bar ();
 extern void buflist_buffer_get_irc_pointers(struct t_gui_buffer *buffer,
                                             void **irc_server, void **irc_channel);
-extern struct t_gui_hotlist *buflist_search_hotlist_for_buffer (struct t_gui_buffer *buffer);
 extern struct t_arraylist *buflist_sort_buffers ();
 
 #endif /* WEECHAT_BUFLIST_H */

--- a/src/plugins/exec/exec-config.h
+++ b/src/plugins/exec/exec-config.h
@@ -21,7 +21,6 @@
 #define WEECHAT_EXEC_CONFIG_H 1
 
 #define EXEC_CONFIG_NAME "exec"
-#define EXEC_CONFIG_SECTION_EXEC "exec"
 
 extern struct t_config_file *exec_config_file;
 

--- a/src/plugins/fifo/fifo.c
+++ b/src/plugins/fifo/fifo.c
@@ -54,7 +54,7 @@ char *fifo_filename = NULL;
 char *fifo_unterminated = NULL;
 
 
-int fifo_fd_cb ();
+int fifo_fd_cb (const void *pointer, void *data, int fd);
 
 
 /*

--- a/src/plugins/fifo/fifo.h
+++ b/src/plugins/fifo/fifo.h
@@ -22,7 +22,6 @@
 
 #define weechat_plugin weechat_fifo_plugin
 #define FIFO_PLUGIN_NAME "fifo"
-#define FIFO_OPTION_NAME "fifo"
 
 extern struct t_weechat_plugin *weechat_fifo_plugin;
 extern int fifo_quiet;

--- a/src/plugins/irc/irc-buffer.h
+++ b/src/plugins/irc/irc-buffer.h
@@ -38,11 +38,6 @@
                                            &ptr_channel);               \
     }
 
-#define IRC_BUFFER_RAW_NAME            "irc_raw"
-#define IRC_BUFFER_RAW_PREFIX_RECV     "-->"
-#define IRC_BUFFER_RAW_PREFIX_RECV_MOD "==>"
-#define IRC_BUFFER_RAW_PREFIX_SEND     "<--"
-#define IRC_BUFFER_RAW_PREFIX_SEND_MOD "<=="
 
 struct t_gui_buffer;
 struct t_irc_server;

--- a/src/plugins/irc/irc-msgbuffer.h
+++ b/src/plugins/irc/irc-msgbuffer.h
@@ -32,12 +32,6 @@ enum t_irc_msgbuffer_target
 
 struct t_irc_server;
 
-struct t_irc_msgbuffer
-{
-    char *message;                      /* IRC message                       */
-    enum t_irc_msgbuffer_target target; /* target buffer                     */
-};
-
 extern struct t_gui_buffer *irc_msgbuffer_get_target_buffer (struct t_irc_server *server,
                                                              const char *nick,
                                                              const char *message,

--- a/src/plugins/irc/irc-server.h
+++ b/src/plugins/irc/irc-server.h
@@ -337,7 +337,7 @@ char *irc_server_fingerprint_str_sizes ();
 #endif /* HAVE_GNUTLS */
 extern int irc_server_connect (struct t_irc_server *server);
 extern void irc_server_auto_connect (int auto_connect);
-extern void irc_server_autojoin_channels ();
+extern void irc_server_autojoin_channels (struct t_irc_server *server);
 extern int irc_server_recv_cb (const void *pointer, void *data, int fd);
 extern int irc_server_timer_sasl_cb (const void *pointer, void *data,
                                      int remaining_calls);

--- a/src/plugins/plugin-api.h
+++ b/src/plugins/plugin-api.h
@@ -22,12 +22,6 @@
 
 #include <time.h>
 
-struct t_plugin_api_hdata
-{
-    char *name;                              /* hdata name                  */
-    struct t_hdata *(*callback_get_hdata)(); /* callback to get hdata       */
-};
-
 /* strings */
 extern void plugin_api_charset_set (struct t_weechat_plugin *plugin,
                                     const char *charset);

--- a/src/plugins/relay/irc/relay-irc.c
+++ b/src/plugins/relay/irc/relay-irc.c
@@ -1773,13 +1773,12 @@ relay_irc_close_connection (struct t_relay_client *client)
 void
 relay_irc_alloc (struct t_relay_client *client)
 {
-    struct t_relay_irc_data *irc_data;
     char *password;
 
     password = weechat_string_eval_expression (weechat_config_string (relay_config_network_password),
                                                NULL, NULL, NULL);
 
-    client->protocol_data = malloc (sizeof (*irc_data));
+    client->protocol_data = malloc (sizeof (struct t_relay_irc_data));
     if (client->protocol_data)
     {
         RELAY_IRC_DATA(client, address) = strdup ("weechat.relay.irc");
@@ -1810,9 +1809,7 @@ void
 relay_irc_alloc_with_infolist (struct t_relay_client *client,
                                struct t_infolist *infolist)
 {
-    struct t_relay_irc_data *irc_data;
-
-    client->protocol_data = malloc (sizeof (*irc_data));
+    client->protocol_data = malloc (sizeof (struct t_relay_irc_data));
     if (client->protocol_data)
     {
         RELAY_IRC_DATA(client, address) = strdup (weechat_infolist_string (infolist, "address"));

--- a/src/plugins/relay/relay-config.c
+++ b/src/plugins/relay/relay-config.c
@@ -776,7 +776,9 @@ relay_config_init ()
            "interfaces, use \"127.0.0.1\" to allow connections from "
             "local machine only)"),
         NULL, 0, 0, "", NULL, 0,
-        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+        NULL, NULL, NULL,
+        &relay_config_change_network_bind_address_cb, NULL, NULL,
+        NULL, NULL, NULL);
     relay_config_network_clients_purge_delay = weechat_config_new_option (
         relay_config_file, ptr_section,
         "clients_purge_delay", "integer",

--- a/src/plugins/relay/weechat/relay-weechat-protocol.h
+++ b/src/plugins/relay/weechat/relay-weechat-protocol.h
@@ -86,11 +86,6 @@ extern int relay_weechat_protocol_signal_buffer_cb (const void *pointer,
                                                     const char *signal,
                                                     const char *type_data,
                                                     void *signal_data);
-extern int relay_weechat_protocol_signal_nicklist_cb (const void *pointer,
-                                                      void *data,
-                                                      const char *signal,
-                                                      const char *type_data,
-                                                      void *signal_data);
 extern int relay_weechat_protocol_hsignal_nicklist_cb (const void *pointer,
                                                        void *data,
                                                        const char *signal,

--- a/src/plugins/relay/weechat/relay-weechat.c
+++ b/src/plugins/relay/weechat/relay-weechat.c
@@ -166,13 +166,12 @@ relay_weechat_free_buffers_nicklist (struct t_hashtable *hashtable,
 void
 relay_weechat_alloc (struct t_relay_client *client)
 {
-    struct t_relay_weechat_data *weechat_data;
     char *password;
 
     password = weechat_string_eval_expression (weechat_config_string (relay_config_network_password),
                                                NULL, NULL, NULL);
 
-    client->protocol_data = malloc (sizeof (*weechat_data));
+    client->protocol_data = malloc (sizeof (struct t_relay_weechat_data));
     if (client->protocol_data)
     {
         RELAY_WEECHAT_DATA(client, password_ok) = (password && password[0]) ? 0 : 1;
@@ -212,12 +211,11 @@ void
 relay_weechat_alloc_with_infolist (struct t_relay_client *client,
                                    struct t_infolist *infolist)
 {
-    struct t_relay_weechat_data *weechat_data;
     int index, value;
     char name[64];
     const char *key;
 
-    client->protocol_data = malloc (sizeof (*weechat_data));
+    client->protocol_data = malloc (sizeof (struct t_relay_weechat_data));
     if (client->protocol_data)
     {
         /* general stuff */

--- a/src/plugins/script/script-config.c
+++ b/src/plugins/script/script-config.c
@@ -34,9 +34,6 @@
 
 
 struct t_config_file *script_config_file = NULL;
-struct t_config_section *script_config_section_look = NULL;
-struct t_config_section *script_config_section_color = NULL;
-struct t_config_section *script_config_section_scripts = NULL;
 
 /* script config, look section */
 

--- a/src/plugins/weechat-plugin.h
+++ b/src/plugins/weechat-plugin.h
@@ -36,14 +36,20 @@ extern "C" {
 #endif /* PATH_MAX */
 
 struct t_config_option;
+struct t_config_section;
+struct t_config_file;
 struct t_gui_window;
 struct t_gui_buffer;
 struct t_gui_bar;
 struct t_gui_bar_item;
 struct t_gui_completion;
+struct t_gui_nick;
+struct t_gui_nick_group;
 struct t_infolist;
 struct t_infolist_item;
+struct t_upgrade_file;
 struct t_weelist;
+struct t_weelist_item;
 struct t_arraylist;
 struct t_hashtable;
 struct t_hdata;


### PR DESCRIPTION
I ran CLion's static analysis on weechat source, then manually went through them and fixed some that I found to be the biggest issues. All of these are very small code fixes or just cleaning up code, including:

1. Functions declared with different arguments than defined and called.
2. Local variables created only to use `sizeof` for `malloc`.
3. Missing forward declarations used in some API function arguments.
4. Broken header guard.
5. Unused `#define`-s and global variables.
6. Declared functions that are not defined and used.
7. Callbacks that are not hooked.
8. Unused `struct`s.
9. Callbacks that are no longer used.

It is easier to review these changes commit by commit, not as an entire PR. Feel free to ask any questions or exclude some changes.