### PR TITLE
trigger: if hashmap creation failed, don't use tags

### DIFF
--- a/src/plugins/trigger/trigger-callback.c
+++ b/src/plugins/trigger/trigger-callback.c
@@ -591,14 +591,14 @@ trigger_callback_modifier_cb (const void *pointer, void *data,
     int length, num_tags;
     void *ptr_irc_server, *ptr_irc_channel;
 
-    TRIGGER_CALLBACK_CB_INIT(NULL);
-
-    TRIGGER_CALLBACK_CB_NEW_POINTERS;
-
     buffer = NULL;
     tags = NULL;
     num_tags = 0;
     string_no_color = NULL;
+
+    TRIGGER_CALLBACK_CB_INIT(NULL);
+
+    TRIGGER_CALLBACK_CB_NEW_POINTERS;
 
     /* split IRC message (if string is an IRC message) */
     if ((strncmp (modifier, "irc_in_", 7) == 0)


### PR DESCRIPTION
If hashmap creation fails (eg. not enough memory), it jumps to the label
"end", where it checks the pointer `tags`, that hadn't been initialized
before.

The simple fix is to initialize it before creating the hashmap.

Found by the clang static analyzer. I know, it is unlikely to happen, but let's be on the safe side.
