### PR TITLE
irc: Remove unnecessary stores

### DIFF
--- a/src/plugins/irc/irc-message.c
+++ b/src/plugins/irc/irc-message.c
@@ -981,7 +981,6 @@ irc_message_split (struct t_irc_server *server, const char *message)
     host = NULL;
     command = NULL;
     arguments = NULL;
-    index_args = 0;
     argv = NULL;
     argv_eol = NULL;
 

--- a/src/plugins/irc/irc-sasl.c
+++ b/src/plugins/irc/irc-sasl.c
@@ -151,7 +151,6 @@ irc_sasl_mechanism_ecdsa_nist256p_challenge (struct t_irc_server *server,
 
     answer_base64 = NULL;
     string = NULL;
-    length = 0;
 
     if (strcmp (data_base64, "+") == 0)
     {


### PR DESCRIPTION
Stores that are overwritten anyway before being read. Compilers probably optimize them away, but let's just remove them, nobody is going to be hurt.

Found by the clang static analyzer.