### PR TITLE
Add support for 64 bits time_t

### DIFF
--- a/src/plugins/plugin-api.c
+++ b/src/plugins/plugin-api.c
@@ -890,7 +890,7 @@ plugin_api_info_uptime_cb (const void *pointer, void *data,
     {
         /* return the number of seconds */
         util_get_uptime (&total_seconds, NULL, NULL, NULL, NULL);
-        snprintf (value, sizeof (value), "%ld", (long)total_seconds);
+        snprintf (value, sizeof (value), "%lld", (long long)total_seconds);
         return value;
     }
 


### PR DESCRIPTION
Hi,

I'm in the process of updating weechat on OpenBSD. In OpenBSD land, time_t is 64 bits. Here's a PR to support 64 bits time_t while being 32 bits compatible.

Cheers,
Daniel