### PR TITLE
core: Add an option for multiline input in a buffer

### DIFF
--- a/ChangeLog.adoc
+++ b/ChangeLog.adoc
@@ -420,6 +420,7 @@ Bug fixes::
 
 New features::
 
+  * core: add flag "input_multiline" in buffer
   * core: add flag "input_get_empty" in buffer
   * core: add signals "buffer_filters_enabled" and "buffer_filters_disabled"
   * core: support loading of plugins from path in environment variable "WEECHAT_EXTRA_LIBDIR" (issue #971, issue #979)

--- a/doc/de/autogen/plugin_api/hdata.adoc
+++ b/doc/de/autogen/plugin_api/hdata.adoc
@@ -587,6 +587,7 @@ _input_callback_pointer_   (pointer) +
 _input_callback_data_   (pointer) +
 _input_get_unknown_commands_   (integer) +
 _input_get_empty_   (integer) +
+_input_multiline_   (integer) +
 _input_buffer_   (string) +
 _input_buffer_alloc_   (integer) +
 _input_buffer_size_   (integer) +

--- a/doc/en/autogen/plugin_api/hdata.adoc
+++ b/doc/en/autogen/plugin_api/hdata.adoc
@@ -587,6 +587,7 @@ _input_callback_pointer_   (pointer) +
 _input_callback_data_   (pointer) +
 _input_get_unknown_commands_   (integer) +
 _input_get_empty_   (integer) +
+_input_multiline_   (integer) +
 _input_buffer_   (string) +
 _input_buffer_alloc_   (integer) +
 _input_buffer_size_   (integer) +

--- a/doc/en/weechat_plugin_api.en.adoc
+++ b/doc/en/weechat_plugin_api.en.adoc
@@ -12816,6 +12816,8 @@ Arguments:
 ** _input_get_unknown_commands_: 1 if unknown commands are sent to input
    callback, otherwise 0
 ** _input_get_empty_: 1 if empty input is sent to input callback, otherwise 0
+** _input_multiline_: 1 if multiple lines are sent as one message to input
+   callback, otherwise 0
 ** _input_size_: input size (in bytes)
 ** _input_length_: input length (number of chars)
 ** _input_pos_: cursor position in buffer input
@@ -13116,6 +13118,10 @@ Properties:
 
 | input_get_empty | "0" or "1" |
   "0" to disable empty input on this buffer (default behavior), "1" to get empty input.
+
+| input_multiline | "0" or "1" |
+  "0" to send each line separately to this buffer (default behavior), "1" to
+  send multiple lines as a single message.
 
 | localvar_set_xxx | any string |
   Set new value for local variable _xxx_ (variable is created if it does not

--- a/doc/fr/autogen/plugin_api/hdata.adoc
+++ b/doc/fr/autogen/plugin_api/hdata.adoc
@@ -587,6 +587,7 @@ _input_callback_pointer_   (pointer) +
 _input_callback_data_   (pointer) +
 _input_get_unknown_commands_   (integer) +
 _input_get_empty_   (integer) +
+_input_multiline_   (integer) +
 _input_buffer_   (string) +
 _input_buffer_alloc_   (integer) +
 _input_buffer_size_   (integer) +

--- a/doc/it/autogen/plugin_api/hdata.adoc
+++ b/doc/it/autogen/plugin_api/hdata.adoc
@@ -587,6 +587,7 @@ _input_callback_pointer_   (pointer) +
 _input_callback_data_   (pointer) +
 _input_get_unknown_commands_   (integer) +
 _input_get_empty_   (integer) +
+_input_multiline_   (integer) +
 _input_buffer_   (string) +
 _input_buffer_alloc_   (integer) +
 _input_buffer_size_   (integer) +

--- a/doc/ja/autogen/plugin_api/hdata.adoc
+++ b/doc/ja/autogen/plugin_api/hdata.adoc
@@ -587,6 +587,7 @@ _input_callback_pointer_   (pointer) +
 _input_callback_data_   (pointer) +
 _input_get_unknown_commands_   (integer) +
 _input_get_empty_   (integer) +
+_input_multiline_   (integer) +
 _input_buffer_   (string) +
 _input_buffer_alloc_   (integer) +
 _input_buffer_size_   (integer) +

--- a/doc/pl/autogen/plugin_api/hdata.adoc
+++ b/doc/pl/autogen/plugin_api/hdata.adoc
@@ -587,6 +587,7 @@ _input_callback_pointer_   (pointer) +
 _input_callback_data_   (pointer) +
 _input_get_unknown_commands_   (integer) +
 _input_get_empty_   (integer) +
+_input_multiline_   (integer) +
 _input_buffer_   (string) +
 _input_buffer_alloc_   (integer) +
 _input_buffer_size_   (integer) +

--- a/src/core/wee-input.c
+++ b/src/core/wee-input.c
@@ -298,7 +298,11 @@ input_data (struct t_gui_buffer *buffer, const char *data,
                 break;
         }
 
-        pos = strchr (ptr_data, '\n');
+        if (buffer->input_multiline)
+            pos = NULL;
+        else
+            pos = strchr (ptr_data, '\n');
+
         if (pos)
             pos[0] = '\0';
 

--- a/src/core/wee-upgrade.c
+++ b/src/core/wee-upgrade.c
@@ -517,6 +517,8 @@ upgrade_weechat_read_buffer (struct t_infolist *infolist)
         infolist_integer (infolist, "input_get_unknown_commands");
     ptr_buffer->input_get_empty =
         infolist_integer (infolist, "input_get_empty");
+    ptr_buffer->input_multiline =
+        infolist_integer (infolist, "input_multiline");
 
     if (infolist_integer (infolist, "input_buffer_alloc") > 0)
     {

--- a/src/gui/gui-buffer.c
+++ b/src/gui/gui-buffer.c
@@ -93,9 +93,10 @@ char *gui_buffer_properties_get_integer[] =
   "nicklist_case_sensitive", "nicklist_max_length", "nicklist_display_groups",
   "nicklist_count", "nicklist_groups_count", "nicklist_nicks_count",
   "nicklist_visible_count", "input", "input_get_unknown_commands",
-  "input_get_empty", "input_size", "input_length", "input_pos",
-  "input_1st_display", "num_history", "text_search", "text_search_exact",
-  "text_search_regex", "text_search_where", "text_search_found",
+  "input_get_empty", "input_multiline", "input_size", "input_length",
+  "input_pos", "input_1st_display", "num_history", "text_search",
+  "text_search_exact", "text_search_regex", "text_search_where",
+  "text_search_found",
   NULL
 };
 char *gui_buffer_properties_get_string[] =
@@ -116,7 +117,7 @@ char *gui_buffer_properties_set[] =
   "highlight_words_del", "highlight_regex", "highlight_tags_restrict",
   "highlight_tags", "hotlist_max_level_nicks", "hotlist_max_level_nicks_add",
   "hotlist_max_level_nicks_del", "input", "input_pos",
-  "input_get_unknown_commands", "input_get_empty",
+  "input_get_unknown_commands", "input_get_empty", "input_multiline",
   NULL
 };
 
@@ -743,6 +744,7 @@ gui_buffer_new (struct t_weechat_plugin *plugin,
     new_buffer->input_callback_data = input_callback_data;
     new_buffer->input_get_unknown_commands = 0;
     new_buffer->input_get_empty = 0;
+    new_buffer->input_multiline = 0;
     gui_buffer_input_buffer_init (new_buffer);
 
     /* undo for input */
@@ -1180,6 +1182,8 @@ gui_buffer_get_integer (struct t_gui_buffer *buffer, const char *property)
         return buffer->input_get_unknown_commands;
     else if (string_strcasecmp (property, "input_get_empty") == 0)
         return buffer->input_get_empty;
+    else if (string_strcasecmp (property, "input_multiline") == 0)
+        return buffer->input_multiline;
     else if (string_strcasecmp (property, "input_size") == 0)
         return buffer->input_buffer_size;
     else if (string_strcasecmp (property, "input_length") == 0)
@@ -1912,6 +1916,20 @@ gui_buffer_set_input_get_empty (struct t_gui_buffer *buffer,
 }
 
 /*
+ * Sets flag "input_multiline" for a buffer.
+ */
+
+void
+gui_buffer_set_input_multiline (struct t_gui_buffer *buffer,
+                                int input_multiline)
+{
+    if (!buffer)
+        return;
+
+    buffer->input_multiline = (input_multiline) ? 1 : 0;
+}
+
+/*
  * Sets unread marker for a buffer.
  */
 
@@ -2197,6 +2215,13 @@ gui_buffer_set (struct t_gui_buffer *buffer, const char *property,
         number = strtol (value, &error, 10);
         if (error && !error[0])
             gui_buffer_set_input_get_empty (buffer, number);
+    }
+    else if (string_strcasecmp (property, "input_multiline") == 0)
+    {
+        error = NULL;
+        number = strtol (value, &error, 10);
+        if (error && !error[0])
+            gui_buffer_set_input_multiline (buffer, number);
     }
     else if (string_strncasecmp (property, "localvar_set_", 13) == 0)
     {
@@ -4290,6 +4315,7 @@ gui_buffer_hdata_buffer_cb (const void *pointer, void *data,
         HDATA_VAR(struct t_gui_buffer, input_callback_data, POINTER, 0, NULL, NULL);
         HDATA_VAR(struct t_gui_buffer, input_get_unknown_commands, INTEGER, 0, NULL, NULL);
         HDATA_VAR(struct t_gui_buffer, input_get_empty, INTEGER, 0, NULL, NULL);
+        HDATA_VAR(struct t_gui_buffer, input_multiline, INTEGER, 0, NULL, NULL);
         HDATA_VAR(struct t_gui_buffer, input_buffer, STRING, 0, NULL, NULL);
         HDATA_VAR(struct t_gui_buffer, input_buffer_alloc, INTEGER, 0, NULL, NULL);
         HDATA_VAR(struct t_gui_buffer, input_buffer_size, INTEGER, 0, NULL, NULL);
@@ -4489,6 +4515,8 @@ gui_buffer_add_to_infolist (struct t_infolist *infolist,
     if (!infolist_new_var_integer (ptr_item, "input_get_unknown_commands", buffer->input_get_unknown_commands))
         return 0;
     if (!infolist_new_var_integer (ptr_item, "input_get_empty", buffer->input_get_empty))
+        return 0;
+    if (!infolist_new_var_integer (ptr_item, "input_multiline", buffer->input_multiline))
         return 0;
     if (!infolist_new_var_string (ptr_item, "input_buffer", buffer->input_buffer))
         return 0;
@@ -4705,6 +4733,7 @@ gui_buffer_print_log ()
         log_printf ("  input_callback_data . . : 0x%lx", ptr_buffer->input_callback_data);
         log_printf ("  input_get_unknown_cmd . : %d",    ptr_buffer->input_get_unknown_commands);
         log_printf ("  input_get_empty . . . . : %d",    ptr_buffer->input_get_empty);
+        log_printf ("  input_multiline . . . . : %d",    ptr_buffer->input_multiline);
         log_printf ("  input_buffer. . . . . . : '%s'",  ptr_buffer->input_buffer);
         log_printf ("  input_buffer_alloc. . . : %d",    ptr_buffer->input_buffer_alloc);
         log_printf ("  input_buffer_size . . . : %d",    ptr_buffer->input_buffer_size);

--- a/src/gui/gui-buffer.h
+++ b/src/gui/gui-buffer.h
@@ -157,6 +157,8 @@ struct t_gui_buffer
                                        /* input_callback                    */
     int input_get_empty;               /* 1 if empty input is sent to       */
                                        /* input_callback                    */
+    int input_multiline;               /* 1 if multiple lines are sent as   */
+                                       /* one message to input_callback     */
     char *input_buffer;                /* input buffer                      */
     int input_buffer_alloc;            /* input buffer: allocated size      */
     int input_buffer_size;             /* buffer size in bytes              */


### PR DESCRIPTION
This allows the input callback function for a buffer to receive multiple
lines at once, instead of the message being split on newline before
being sent to the callback. It adds a new flag, input_multiline, to
control this. This flag defaults to 0 which is the current behavior.

Fixes #984