### PR TITLE
improvement: better guidance on reporting crashes

### DIFF
--- a/src/core/wee-debug.c
+++ b/src/core/wee-debug.c
@@ -167,12 +167,17 @@ debug_sigsegv ()
         stderr,
         "***\n"
         "*** Please help WeeChat developers to fix this bug:\n"
-        "***   1. If you have a core file, please run:  gdb /path/to/weechat core\n"
+        "***   1. If you have a core file, please run: gdb /path/to/weechat core\n"
         "***      then issue command: \"bt full\" and send result to developers\n"
-        "***      (see user's guide for more info about report of crashes).\n"
-        "***   2. Otherwise send backtrace (below), only if it is a complete trace.\n"
+        "***      (see the user's guide for more info about report of crashes,\n"
+        "***       and the enabling of core files.)\n\n"
+
+        "***   2. Otherwise send a backtrace (below), only if it is a complete trace.\n"
         "***      Keep the crash log file, just in case developers ask you some info\n"
-        "***      (be careful, private info like passwords may be in this file).\n\n");
+        "***      (be careful, private info like passwords may be in this file).\n\n"
+
+        "*** For more information regarding reporting of crashes, see:\n"
+        "*** https://weechat.org/files/doc/stable/weechat_user.en.html#report_crashes\n\n");
 
     weechat_backtrace ();
 


### PR DESCRIPTION
* Links directly to the user guide section of report crashes
* Mention that core dumps are not enabled by default
* Overall formatting

This assumes the URL is a permanent link. if not, perhaps it'd be cool to have some sort of short-permalink like https://weechat.org/ref/report-crashes which always redirects to the right URL.