### PR TITLE
improve: docs: mention there is an option to enable crash core files

### DIFF
--- a/doc/en/weechat_user.en.adoc
+++ b/doc/en/weechat_user.en.adoc
@@ -421,7 +421,7 @@ ulimit -c 200000
 ==== Get backtrace with gdb
 
 When WeeChat crashes, your system will create a file _core_ or _core.12345_
-(_12345_ is process id).
+(_12345_ is process id) if the <<core_files,option is enabled>>.
 This file is created in directory where you have run WeeChat (this is *not*
 directory where WeeChat is installed!).
 


### PR DESCRIPTION
For people skimming the section, it will not be immediately clear to
them, especially since everything seems to suggest this option is
enabled by default.

I've not ensured this actually renders at it should, but this looks fine based on the asciidoctor documentation.