### PR TITLE
gui: add color_separator options to bars (closes #975)

### DIFF
--- a/src/gui/curses/gui-curses-bar-window.c
+++ b/src/gui/curses/gui-curses-bar-window.c
@@ -767,32 +767,29 @@ gui_bar_window_draw (struct t_gui_bar_window *bar_window,
 
     if (CONFIG_INTEGER(bar_window->bar->options[GUI_BAR_OPTION_SEPARATOR]))
     {
+        if (!config_file_option_is_null (bar_window->bar->options[GUI_BAR_OPTION_COLOR_SEPARATOR]))
+        {
+            gui_window_set_custom_color_fg_bg (GUI_BAR_WINDOW_OBJECTS(bar_window)->win_separator,
+                                               CONFIG_COLOR(bar_window->bar->options[GUI_BAR_OPTION_COLOR_SEPARATOR]),
+                                               CONFIG_COLOR(config_color_chat_bg), /* same as GUI_COLOR_SEPARATOR bg */
+                                               1);
+        }
+        else
+        {
+            gui_window_set_weechat_color (GUI_BAR_WINDOW_OBJECTS(bar_window)->win_separator,
+                                          GUI_COLOR_SEPARATOR);
+        }
+
         switch (CONFIG_INTEGER(bar_window->bar->options[GUI_BAR_OPTION_POSITION]))
         {
             case GUI_BAR_POSITION_BOTTOM:
-                gui_window_set_weechat_color (GUI_BAR_WINDOW_OBJECTS(bar_window)->win_separator,
-                                              GUI_COLOR_SEPARATOR);
-                gui_window_hline (GUI_BAR_WINDOW_OBJECTS(bar_window)->win_separator,
-                                  0, 0, bar_window->width,
-                                  CONFIG_STRING(config_look_separator_horizontal));
-                break;
             case GUI_BAR_POSITION_TOP:
-                gui_window_set_weechat_color (GUI_BAR_WINDOW_OBJECTS(bar_window)->win_separator,
-                                              GUI_COLOR_SEPARATOR);
                 gui_window_hline (GUI_BAR_WINDOW_OBJECTS(bar_window)->win_separator,
                                   0, 0, bar_window->width,
                                   CONFIG_STRING(config_look_separator_horizontal));
                 break;
             case GUI_BAR_POSITION_LEFT:
-                gui_window_set_weechat_color (GUI_BAR_WINDOW_OBJECTS(bar_window)->win_separator,
-                                              GUI_COLOR_SEPARATOR);
-                gui_window_vline (GUI_BAR_WINDOW_OBJECTS(bar_window)->win_separator,
-                                  0, 0, bar_window->height,
-                                  CONFIG_STRING(config_look_separator_vertical));
-                break;
             case GUI_BAR_POSITION_RIGHT:
-                gui_window_set_weechat_color (GUI_BAR_WINDOW_OBJECTS(bar_window)->win_separator,
-                                              GUI_COLOR_SEPARATOR);
                 gui_window_vline (GUI_BAR_WINDOW_OBJECTS(bar_window)->win_separator,
                                   0, 0, bar_window->height,
                                   CONFIG_STRING(config_look_separator_vertical));

--- a/src/gui/gui-bar.h
+++ b/src/gui/gui-bar.h
@@ -43,6 +43,7 @@ enum t_gui_bar_option
     GUI_BAR_OPTION_COLOR_FG,            /* default text color for bar       */
     GUI_BAR_OPTION_COLOR_DELIM,         /* default delimiter color for bar  */
     GUI_BAR_OPTION_COLOR_BG,            /* default background color for bar */
+    GUI_BAR_OPTION_COLOR_SEPARATOR,     /* separator line color for bar     */
     GUI_BAR_OPTION_SEPARATOR,           /* true if separator line displayed */
     GUI_BAR_OPTION_ITEMS,               /* bar items                        */
     /* number of bar options */


### PR DESCRIPTION
This PR adds a `color_separator` option to all bars as requested by #975 but the naming of this option is chosen to be more consistent with existing bar color options. The option may be `null` in which case it defaults to the current option controlling bar separator colors (`weechat.color.separator`). This keeps compatibility with existing configurations and existing behavior.

For the time being, I chose not to add a `color_separator` argument to [`bar_new`](https://weechat.org/files/doc/devel/weechat_plugin_api.en.html#_bar_new) function of the plugin API in order to avoid breaking compatibility with existing plugins and scripts. If a script really wants to modify its bar's separator color (which wasn't even possible before), it can use [`bar_set`](https://weechat.org/files/doc/devel/weechat_plugin_api.en.html#_bar_set) to do so.