### PR TITLE
doc: mention weechat_plugin pointer used by plugin header

### DIFF
--- a/doc/en/weechat_plugin_api.en.adoc
+++ b/doc/en/weechat_plugin_api.en.adoc
@@ -41,6 +41,15 @@ The plugin has to include "weechat-plugin.h" file (available in WeeChat source
 code).
 This file defines structures and types used to communicate with WeeChat.
 
+In order to call WeeChat functions in the format displayed in <<plugin_api>>,
+the following global pointer must be declared and initialized in
+<<_weechat_plugin_init,weechat_plugin_init>>:
+
+[source,C]
+----
+struct t_weechat_plugin *weechat_plugin;
+----
+
 [[macros]]
 === Macros
 
@@ -83,7 +92,8 @@ int weechat_plugin_init (struct t_weechat_plugin *plugin,
 
 Arguments:
 
-* _plugin_: pointer to WeeChat plugin structure
+* _plugin_: pointer to WeeChat plugin structure, used to initialize the
+  convenience global pointer `weechat_plugin`
 * _argc_: number of arguments for plugin (given on command line by user)
 * _argv_: arguments for plugin
 


### PR DESCRIPTION
The `weechat-plugin.h` header defines all C API functions through macros on a global `weechat_plugin` struct pointer but this fact is not documented in the plugin API, even though the example and all existing plugins do so.

*Reported by muffindrake in #weechat:*
```
17:38:25 < muffindrake> It's a bit jarring that this isn't mentioned in the plugin api
17:38:52 < muffindrake> You must define a macro weechat_plugin, apparently
17:38:58 < muffindrake> as seen in fset/fset.h
17:39:09 < muffindrake> It compiles fine now.
[...]
17:40:26 < sim642> muffindrake, https://weechat.org/files/doc/stable/weechat_plugin_api.en.html#macros
17:41:20 < muffindrake> sim642: That documentation does NOT mention you need to have a symbol weechat_plugin declared
17:42:28 < sim642> The example shows it still
17:43:35 < muffindrake> The example declares and defines a struct t_weechat_plugin *weechat_plugin, but it does not say _anywhere_ that this exact name is necessary
17:44:24 < sim642> technically it isn't
17:44:29 < muffindrake> IT IS
17:44:34 < muffindrake> it will refuse to compile without it
17:45:09 < sim642> You need it for the weechat_* prefixed macros to work
17:45:19 < muffindrake> Where is that written?
17:45:34 < sim642> but you can always call the functions directly by invoking them on the plugin object directly
```