### PR TITLE
core: asks user for passphrase twice (closes #1109) 

### DIFF
--- a/src/core/wee-command.c
+++ b/src/core/wee-command.c
@@ -5352,14 +5352,14 @@ COMMAND_CALLBACK(secure)
             }
             if (strcmp (temp_secure_passphrase, argv_eol[2]))
             {
-                temp_secure_passphrase = NULL;
                 free (temp_secure_passphrase);
+                temp_secure_passphrase = NULL;
                 gui_chat_printf (NULL, _("Passphrase does not match"));
                 return WEECHAT_RC_OK;
             }
             secure_passphrase = strdup (argv_eol[2]);
-            temp_secure_passphrase = NULL;
             free (temp_secure_passphrase);
+            temp_secure_passphrase = NULL;
             gui_chat_printf (NULL,
                              (passphrase_was_set) ?
                              _("Passphrase changed") : _("Passphrase added"));

--- a/src/core/wee-command.c
+++ b/src/core/wee-command.c
@@ -5344,7 +5344,7 @@ COMMAND_CALLBACK(secure)
         }
         else
         {
-            if (string_strcasecmp (temp_secure_passphrase, argv_eol[2]))
+            if (temp_secure_passphrase == NULL || strcmp (temp_secure_passphrase, argv_eol[2]))
             {
                 temp_secure_passphrase = strdup (argv_eol[2]);
                 gui_chat_printf (NULL, "Run the passphrase command again to confirm!");

--- a/src/core/wee-command.c
+++ b/src/core/wee-command.c
@@ -5344,14 +5344,22 @@ COMMAND_CALLBACK(secure)
         }
         else
         {
-            if (temp_secure_passphrase == NULL || strcmp (temp_secure_passphrase, argv_eol[2]))
+            if (temp_secure_passphrase == NULL)
             {
                 temp_secure_passphrase = strdup (argv_eol[2]);
-                gui_chat_printf (NULL, "Run the passphrase command again to confirm!");
+                gui_chat_printf (NULL, _("Run the passphrase command again to confirm"));
+                return WEECHAT_RC_OK;
+            }
+            if (strcmp (temp_secure_passphrase, argv_eol[2]))
+            {
+                temp_secure_passphrase = NULL;
+                free (temp_secure_passphrase);
+                gui_chat_printf (NULL, _("Passphrase does not match"));
                 return WEECHAT_RC_OK;
             }
             secure_passphrase = strdup (argv_eol[2]);
-            free(temp_secure_passphrase);
+            temp_secure_passphrase = NULL;
+            free (temp_secure_passphrase);
             gui_chat_printf (NULL,
                              (passphrase_was_set) ?
                              _("Passphrase changed") : _("Passphrase added"));

--- a/src/core/wee-command.c
+++ b/src/core/wee-command.c
@@ -5344,7 +5344,14 @@ COMMAND_CALLBACK(secure)
         }
         else
         {
+            if (string_strcasecmp (temp_secure_passphrase, argv_eol[2]))
+            {
+                temp_secure_passphrase = strdup (argv_eol[2]);
+                gui_chat_printf (NULL, "Run the passphrase command again to confirm!");
+                return WEECHAT_RC_OK;
+            }
             secure_passphrase = strdup (argv_eol[2]);
+            free(temp_secure_passphrase);
             gui_chat_printf (NULL,
                              (passphrase_was_set) ?
                              _("Passphrase changed") : _("Passphrase added"));

--- a/src/core/wee-secure.c
+++ b/src/core/wee-secure.c
@@ -50,6 +50,7 @@ struct t_config_option *secure_config_crypt_salt = NULL;
 
 /* the passphrase used to encrypt/decrypt data */
 char *secure_passphrase = NULL;
+char *temp_secure_passphrase = NULL;
 
 /* decrypted data */
 struct t_hashtable *secure_hashtable_data = NULL;

--- a/src/core/wee-secure.h
+++ b/src/core/wee-secure.h
@@ -52,6 +52,7 @@ extern struct t_config_option *secure_config_crypt_passphrase_file;
 extern struct t_config_option *secure_config_crypt_salt;
 
 extern char *secure_passphrase;
+extern char *temp_secure_passphrase;
 extern struct t_hashtable *secure_hashtable_data;
 extern struct t_hashtable *secure_hashtable_data_encrypted;
 


### PR DESCRIPTION
This adds a new feature of asking the user to retype the passphrase they are entering to ensure it is correct. When the user runs `/secure passphrase <passphrase>` it asks them to run it again to confirm. 