### PR TITLE
core: add option weechat.look.buffer_time_same

### DIFF
--- a/src/core/wee-config.c
+++ b/src/core/wee-config.c
@@ -98,6 +98,7 @@ struct t_config_option *config_look_buffer_search_force_default;
 struct t_config_option *config_look_buffer_search_regex;
 struct t_config_option *config_look_buffer_search_where;
 struct t_config_option *config_look_buffer_time_format;
+struct t_config_option *config_look_buffer_time_same;
 struct t_config_option *config_look_color_basic_force_bold;
 struct t_config_option *config_look_color_inactive_buffer;
 struct t_config_option *config_look_color_inactive_message;
@@ -300,6 +301,7 @@ struct t_config_option *config_plugin_save_config_on_unload;
 
 /* other */
 
+int config_length_buffer_time_same = 0;
 int config_length_nick_prefix_suffix = 0;
 int config_length_prefix_same_nick = 0;
 struct t_hook *config_day_change_timer = NULL;
@@ -651,6 +653,25 @@ config_change_buffer_time_format (const void *pointer, void *data,
     gui_chat_change_time_format ();
     if (gui_init_ok)
         gui_window_ask_refresh (1);
+}
+
+/*
+ * Callback for changes on option "weechat.look.buffer_time_same".
+ */
+
+void
+config_change_buffer_time_same (const void *pointer, void *data,
+                                struct t_config_option *option)
+{
+    /* make C compiler happy */
+    (void) pointer;
+    (void) data;
+    (void) option;
+
+    config_length_buffer_time_same =
+        gui_chat_strlen_screen (CONFIG_STRING(config_look_buffer_time_same));
+
+    gui_window_ask_refresh (1);
 }
 
 /*
@@ -2642,6 +2663,17 @@ config_weechat_init_options ()
         NULL, 0, 0, "%H:%M:%S", NULL, 0,
         NULL, NULL, NULL,
         &config_change_buffer_time_format, NULL, NULL,
+        NULL, NULL, NULL);
+    config_look_buffer_time_same = config_file_new_option (
+        weechat_config_file, ptr_section,
+        "buffer_time_same", "string",
+        N_("time displayed for a message with same time as previous "
+           "message: use a space \" \" to hide time, another string to "
+           "display this string instead of time, or an empty string to "
+           "disable feature (display time)"),
+        NULL, 0, 0, "", NULL, 0,
+        NULL, NULL, NULL,
+        &config_change_buffer_time_same, NULL, NULL,
         NULL, NULL, NULL);
     config_look_color_basic_force_bold = config_file_new_option (
         weechat_config_file, ptr_section,

--- a/src/core/wee-config.h
+++ b/src/core/wee-config.h
@@ -340,7 +340,6 @@ extern struct t_config_option *config_plugin_extension;
 extern struct t_config_option *config_plugin_path;
 extern struct t_config_option *config_plugin_save_config_on_unload;
 
-extern int config_length_buffer_time_same;
 extern int config_length_nick_prefix_suffix;
 extern int config_length_prefix_same_nick;
 extern int config_emphasized_attributes;
@@ -357,6 +356,7 @@ extern int config_word_chars_input_count;
 extern char **config_nick_colors;
 extern int config_num_nick_colors;
 extern struct t_hashtable *config_hashtable_nick_color_force;
+extern char *config_buffer_time_same_evaluated;
 extern struct t_hashtable *config_hashtable_completion_partial_templates;
 
 extern void config_set_nick_colors ();

--- a/src/core/wee-config.h
+++ b/src/core/wee-config.h
@@ -149,6 +149,7 @@ extern struct t_config_option *config_look_buffer_search_force_default;
 extern struct t_config_option *config_look_buffer_search_regex;
 extern struct t_config_option *config_look_buffer_search_where;
 extern struct t_config_option *config_look_buffer_time_format;
+extern struct t_config_option *config_look_buffer_time_same;
 extern struct t_config_option *config_look_color_basic_force_bold;
 extern struct t_config_option *config_look_color_inactive_buffer;
 extern struct t_config_option *config_look_color_inactive_message;
@@ -339,6 +340,7 @@ extern struct t_config_option *config_plugin_extension;
 extern struct t_config_option *config_plugin_path;
 extern struct t_config_option *config_plugin_save_config_on_unload;
 
+extern int config_length_buffer_time_same;
 extern int config_length_nick_prefix_suffix;
 extern int config_length_prefix_same_nick;
 extern int config_emphasized_attributes;

--- a/src/gui/curses/gui-curses-chat.c
+++ b/src/gui/curses/gui-curses-chat.c
@@ -682,6 +682,31 @@ gui_chat_display_day_changed (struct t_gui_window *window,
 }
 
 /*
+ * Checks if time on line is the same as time on previous line.
+ *
+ * Returns:
+ *   1: prefix is same as time on previous line
+ *   0: prefix is different from time on previous line
+ */
+
+int
+gui_chat_line_time_is_same_as_previous (struct t_gui_line *line)
+{
+    struct t_gui_line *prev_line;
+
+    /*
+     * previous line is not found => display standard time
+     */
+    prev_line = gui_line_get_prev_displayed (line);
+    if (!prev_line)
+        return 0;
+    // TODO find prev line with existing str_time
+
+    /* time can be hidden/replaced if times are equal */
+    return (strcmp (line->data->str_time, prev_line->data->str_time) == 0) ? 1 : 0;
+}
+
+/*
  * Displays time, buffer name (for merged buffers) and prefix for a line.
  */
 
@@ -719,12 +744,48 @@ gui_chat_display_time_to_prefix (struct t_gui_window *window,
     {
         if (window->win_chat_cursor_y < window->coords_size)
             window->coords[window->win_chat_cursor_y].time_x1 = window->win_chat_cursor_x;
-        gui_chat_display_word (window, line, line->data->str_time,
-                               NULL, 1, num_lines, count,
-                               pre_lines_displayed, lines_displayed,
-                               simulate,
-                               CONFIG_BOOLEAN(config_look_color_inactive_time),
-                               0);
+
+        if (CONFIG_STRING(config_look_buffer_time_same)
+            && CONFIG_STRING(config_look_buffer_time_same)[0]
+            && gui_chat_line_time_is_same_as_previous (line))
+        {
+            length_allowed = gui_chat_strlen_screen (line->data->str_time);
+            num_spaces = length_allowed - config_length_buffer_time_same;
+
+            /* not enough space to display full buffer_time_same? => truncate it! */
+            gui_chat_display_word (window, line, CONFIG_STRING(config_look_buffer_time_same),
+                                   (num_spaces < 0) ?
+                                       CONFIG_STRING(config_look_buffer_time_same) +
+                                       gui_chat_string_real_pos (CONFIG_STRING(config_look_buffer_time_same),
+                                                                 length_allowed,
+                                                                 1) :
+                                       NULL,
+                                   1, num_lines, count,
+                                   pre_lines_displayed, lines_displayed,
+                                   simulate,
+                                   CONFIG_BOOLEAN(config_look_color_inactive_time),
+                                   0);
+            /* not enough space to display full buffer_time_same? => loop doesn't do anything */
+            for (i = 0; i < num_spaces; i++)
+            {
+                gui_chat_display_word (window, line, str_space,
+                                       NULL, 1, num_lines, count,
+                                       pre_lines_displayed, lines_displayed,
+                                       simulate,
+                                       CONFIG_BOOLEAN(config_look_color_inactive_time),
+                                       0);
+            }
+        }
+        else
+        {
+            gui_chat_display_word (window, line, line->data->str_time,
+                                   NULL, 1, num_lines, count,
+                                   pre_lines_displayed, lines_displayed,
+                                   simulate,
+                                   CONFIG_BOOLEAN(config_look_color_inactive_time),
+                                   0);
+        }
+
         if (window->win_chat_cursor_y < window->coords_size)
             window->coords[window->win_chat_cursor_y].time_x2 = window->win_chat_cursor_x - 1;
 

--- a/src/gui/curses/gui-curses-chat.c
+++ b/src/gui/curses/gui-curses-chat.c
@@ -749,14 +749,14 @@ gui_chat_display_time_to_prefix (struct t_gui_window *window,
             && CONFIG_STRING(config_look_buffer_time_same)[0]
             && gui_chat_line_time_is_same_as_previous (line))
         {
-            length_allowed = gui_chat_strlen_screen (line->data->str_time);
-            num_spaces = length_allowed - config_length_buffer_time_same;
+            length_allowed = gui_chat_time_length;
+            num_spaces = length_allowed - gui_chat_strlen_screen (config_buffer_time_same_evaluated);
 
             /* not enough space to display full buffer_time_same? => truncate it! */
-            gui_chat_display_word (window, line, CONFIG_STRING(config_look_buffer_time_same),
+            gui_chat_display_word (window, line, config_buffer_time_same_evaluated,
                                    (num_spaces < 0) ?
-                                       CONFIG_STRING(config_look_buffer_time_same) +
-                                       gui_chat_string_real_pos (CONFIG_STRING(config_look_buffer_time_same),
+                                       config_buffer_time_same_evaluated +
+                                       gui_chat_string_real_pos (config_buffer_time_same_evaluated,
                                                                  length_allowed,
                                                                  1) :
                                        NULL,

--- a/src/gui/curses/gui-curses-chat.c
+++ b/src/gui/curses/gui-curses-chat.c
@@ -700,7 +700,13 @@ gui_chat_line_time_is_same_as_previous (struct t_gui_line *line)
     prev_line = gui_line_get_prev_displayed (line);
     if (!prev_line)
         return 0;
-    // TODO find prev line with existing str_time
+
+    /*
+     * previous line has no time => display standard time
+     */
+    if (!line->data->str_time
+        || !prev_line->data->str_time)
+        return 0;
 
     /* time can be hidden/replaced if times are equal */
     return (strcmp (line->data->str_time, prev_line->data->str_time) == 0) ? 1 : 0;


### PR DESCRIPTION
Just like `weechat.look.prefix_same_nick` allows not repeating the nick if it's the same for consecutive lines, this PR adds an option to not repeat the displayed time if it's the same for consecutive lines. The option behaves similarly: empty string means disabled, non-empty string is evaluated (to allow colors) to use a custom string (may be a space for just hiding).

Custom strings are left-aligned and padded to the length of the displayed time. Too long custom strings are simply truncated. While it would theoretically be possible to add line prefix like alignment customization options, it is an unnecessary complication for this change, especially since it hasn't been needed so far as the time has had constant aligned width.

*Feature requested by pdx in #weechat.*