### PR TITLE
Replace getdtablesize() with sysconf(_SC_OPEN_MAX)

### DIFF
--- a/src/gui/curses/headless/main.c
+++ b/src/gui/curses/headless/main.c
@@ -72,7 +72,7 @@ daemonize ()
     setsid ();
 
     /* close all file descriptors */
-    for (i = getdtablesize(); i >= 0; --i)
+    for (i = sysconf(_SC_OPEN_MAX); i >= 0; --i)
     {
         close (i);
     }


### PR DESCRIPTION
From the getdtablesize(3) man page:

       It is not specified in POSIX.1; portable applications should
       employ sysconf(_SC_OPEN_MAX) instead of this call.

Specifically, this fixes a compilation problem on Android.