### PR TITLE
doc: use '-out' instead of shell redirection for openssl ecparam

### DIFF
--- a/doc/de/weechat_user.de.adoc
+++ b/doc/de/weechat_user.de.adoc
@@ -2687,7 +2687,7 @@ dadurch kein Passwort während des Verbindungsaufbaus benötigt).
 Ein Schlüssel kann mit folgendem Befehl erzeugt werden:
 
 ----
-$ openssl ecparam -genkey -name prime256v1 >~/.weechat/ecdsa.pem
+$ openssl ecparam -genkey -name prime256v1 -out ~/.weechat/ecdsa.pem
 ----
 
 Um den öffentlichen Schlüssel zu erhalten (base64 enkodiert) muss

--- a/doc/en/weechat_user.en.adoc
+++ b/doc/en/weechat_user.en.adoc
@@ -2629,7 +2629,7 @@ ECDSA-NIST256P-CHALLENGE mechanism (no password is required on connection).
 You can generate the key with this command:
 
 ----
-$ openssl ecparam -genkey -name prime256v1 >~/.weechat/ecdsa.pem
+$ openssl ecparam -genkey -name prime256v1 -out ~/.weechat/ecdsa.pem
 ----
 
 Get the public key (encoded as base64) with this command:

--- a/doc/fr/weechat_user.fr.adoc
+++ b/doc/fr/weechat_user.fr.adoc
@@ -2721,7 +2721,7 @@ connexion).
 Vous pouvez générer la clé avec cette commande :
 
 ----
-$ openssl ecparam -genkey -name prime256v1 >~/.weechat/ecdsa.pem
+$ openssl ecparam -genkey -name prime256v1 -out ~/.weechat/ecdsa.pem
 ----
 
 Récupérez la clé publique (encodée en base64) avec cette commande :

--- a/doc/it/weechat_user.it.adoc
+++ b/doc/it/weechat_user.it.adoc
@@ -2811,7 +2811,7 @@ ECDSA-NIST256P-CHALLENGE mechanism (no password is required on connection).
 You can generate the key with this command:
 
 ----
-$ openssl ecparam -genkey -name prime256v1 >~/.weechat/ecdsa.pem
+$ openssl ecparam -genkey -name prime256v1 -out ~/.weechat/ecdsa.pem
 ----
 
 Get the public key (encoded as base64) with this command:

--- a/doc/ja/weechat_user.ja.adoc
+++ b/doc/ja/weechat_user.ja.adoc
@@ -2626,7 +2626,7 @@ ECDSA-NIST256P-CHALLENGE を使って認証を行うためには、秘密鍵を�
 鍵を作成するには、以下のコマンドを使ってください:
 
 ----
-$ openssl ecparam -genkey -name prime256v1 >~/.weechat/ecdsa.pem
+$ openssl ecparam -genkey -name prime256v1 -out ~/.weechat/ecdsa.pem
 ----
 
 公開鍵を (base64 エンコード形式で) 作成するには、以下のコマンドを使ってください:

--- a/doc/pl/weechat_user.pl.adoc
+++ b/doc/pl/weechat_user.pl.adoc
@@ -2648,7 +2648,7 @@ ECDSA-NIST256P-CHALLENGE (hasło nie potrzebne do połączenia).
 Klucz można wygenerować za pomocą komendy:
 
 ----
-$ openssl ecparam -genkey -name prime256v1 >~/.weechat/ecdsa.pem
+$ openssl ecparam -genkey -name prime256v1 -out ~/.weechat/ecdsa.pem
 ----
 
 Klucz publiczny (zakodowany za pomocą base64) uzyskujemy wywołując komendę:


### PR DESCRIPTION
Generated with:

```console
$ sed -i 's|openssl ecparam -genkey -name prime256v1 >~/.weechat/ecdsa.pem|openssl ecparam -genkey -name prime256v1 -out ~/.weechat/ecdsa.pem|' $(git grep -l 'openssl ecparam')
```

There's no reason to involve shell redirection, which we've had since 88073243.  We already use `-in` or `-out` for our other `openssl` invocations, as shown by:

```console
$ git grep 'openssl.*\(<\|>\|-in\|-out\)' doc/en
doc/en/weechat_user.en.adoc:$ openssl req -nodes -newkey rsa:2048 -keyout nick.pem -x509 -days 365 -out nick.pem
doc/en/weechat_user.en.adoc:$ openssl ecparam -genkey -name prime256v1 -out ~/.weechat/ecdsa.pem
doc/en/weechat_user.en.adoc:$ openssl ec -noout -text -conv_form compressed -in ~/.weechat/ecdsa.pem | grep '^pub:' -A 3 | tail -n 3 | tr -d ' \n:' | xxd -r -p | base64
doc/en/weechat_user.en.adoc:$ openssl req -nodes -newkey rsa:2048 -keyout relay.pem -x509 -days 365 -out relay.pem
```