### PR TITLE
irc: delegated SASL authentication mechanism

### DIFF
--- a/src/plugins/irc/irc-protocol.c
+++ b/src/plugins/irc/irc-protocol.c
@@ -272,6 +272,10 @@ IRC_PROTOCOL_CALLBACK(authenticate)
                 answer = irc_sasl_mechanism_ecdsa_nist256p_challenge (
                     server, argv[1], sasl_username, sasl_key);
                 break;
+            case IRC_SASL_MECHANISM_ECDSA_NIST256P_CHALLENGE_DELEGATED:
+                answer = irc_sasl_mechanism_ecdsa_nist256p_challenge_delegated (
+                    server, argv[1], sasl_username, sasl_key);
+                break;
             case IRC_SASL_MECHANISM_EXTERNAL:
                 answer = strdup ("+");
                 break;

--- a/src/plugins/irc/irc-sasl.h
+++ b/src/plugins/irc/irc-sasl.h
@@ -28,6 +28,7 @@ enum t_irc_sasl_mechanism
 {
     IRC_SASL_MECHANISM_PLAIN = 0,
     IRC_SASL_MECHANISM_ECDSA_NIST256P_CHALLENGE,
+    IRC_SASL_MECHANISM_ECDSA_NIST256P_CHALLENGE_DELEGATED,
     IRC_SASL_MECHANISM_EXTERNAL,
     IRC_SASL_MECHANISM_DH_BLOWFISH,
     IRC_SASL_MECHANISM_DH_AES,
@@ -43,6 +44,10 @@ extern char *irc_sasl_mechanism_ecdsa_nist256p_challenge (struct t_irc_server *s
                                                           const char *data_base64,
                                                           const char *sasl_username,
                                                           const char *sasl_key);
+extern char *irc_sasl_mechanism_ecdsa_nist256p_challenge_delegated (struct t_irc_server *server,
+                                                                    const char *data_base64,
+                                                                    const char *sasl_username,
+                                                                    const char *sasl_key);
 extern char *irc_sasl_mechanism_dh_blowfish (const char *data_base64,
                                              const char *sasl_username,
                                              const char *sasl_password);

--- a/src/plugins/irc/irc-server.c
+++ b/src/plugins/irc/irc-server.c
@@ -516,7 +516,8 @@ irc_server_sasl_enabled (struct t_irc_server *server)
      * - another mechanism with username/password set
      */
     rc = ((sasl_mechanism == IRC_SASL_MECHANISM_EXTERNAL)
-          || ((sasl_mechanism == IRC_SASL_MECHANISM_ECDSA_NIST256P_CHALLENGE)
+          || (((sasl_mechanism == IRC_SASL_MECHANISM_ECDSA_NIST256P_CHALLENGE)
+               || (sasl_mechanism == IRC_SASL_MECHANISM_ECDSA_NIST256P_CHALLENGE_DELEGATED))
               && sasl_username && sasl_username[0]
               && sasl_key && sasl_key[0])
           || (sasl_username && sasl_username[0]


### PR DESCRIPTION
In order to minimize code changes, this mechanism assumes that `SASL_KEY` option 
holds ~a path of the external program to be used as an authentication agent~ an identification string which agent may use as some kind of domain separation. `SASL_AGENT is a dedicated option for the agent program. 

During authentication process, mechanism implementation executes this agent, passing ~username~ key and challenge data to it. The output of the agent is passed to the server as challenge response.

TODO:
- [x] implement delegation mechanism for an external SASL agent;
- [x] implement reference SASL agent that mimics the default NIST256P challenge behaviour (see https://github.com/mrwhythat/weechat-sasl-agent); any suggestions on how to include `ecdsa_nist256p_challenge.py` with WeeChat package?;
- [x] as suggested on IRC, give some thoughts on how to make it into a more general API for defining
custom authentication mechanisms.

NOTE: in order to implement more general API for custom SASL mechanisms, DELEGATED mechanism assumes the following agent behaviour:
- when called without arguments, agent should return a string that is a fixed (possibly standard) name
for SASL mechanism (for example `"ecdsa-nist256p-challenge"`), thus allowing WeeChat to ask it for an method beforehand to initiate authentication exchange;
- when *username*, *key* and *data* parameters are supplied, agent should return the authenticated data which WeeChat will forward to the server, thus completing the protocol.

Comments and reviews are **very** welcome, as I am not sure whether this decision is a good one and only did some basic manual testing.