### PR TITLE
workaround/fix DCC get hangs

### DIFF
--- a/src/plugins/xfer/xfer-config.c
+++ b/src/plugins/xfer/xfer-config.c
@@ -51,6 +51,7 @@ struct t_config_option *xfer_config_network_own_ip;
 struct t_config_option *xfer_config_network_port_range;
 struct t_config_option *xfer_config_network_speed_limit;
 struct t_config_option *xfer_config_network_timeout;
+struct t_config_option *xfer_config_network_send_ack;
 
 /* xfer config, file section */
 
@@ -295,6 +296,12 @@ xfer_config_init ()
         "timeout", "integer",
         N_("timeout for xfer request (in seconds)"),
         NULL, 5, INT_MAX, "300", NULL, 0,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+    xfer_config_network_send_ack = weechat_config_new_option (
+        xfer_config_file, ptr_section,
+        "send_ack", "boolean",
+        N_("does not send acks when receiving files"),
+        NULL, 0, 0, "on", NULL, 0,
         NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
     ptr_section = weechat_config_new_section (xfer_config_file, "file",

--- a/src/plugins/xfer/xfer-config.h
+++ b/src/plugins/xfer/xfer-config.h
@@ -41,6 +41,7 @@ extern struct t_config_option *xfer_config_network_own_ip;
 extern struct t_config_option *xfer_config_network_port_range;
 extern struct t_config_option *xfer_config_network_speed_limit;
 extern struct t_config_option *xfer_config_network_timeout;
+extern struct t_config_option *xfer_config_network_send_ack;
 
 extern struct t_config_option *xfer_config_file_auto_accept_chats;
 extern struct t_config_option *xfer_config_file_auto_accept_files;

--- a/src/plugins/xfer/xfer-dcc.c
+++ b/src/plugins/xfer/xfer-dcc.c
@@ -309,7 +309,7 @@ xfer_dcc_resume_hash (struct t_xfer *xfer)
 void
 xfer_dcc_recv_file_child (struct t_xfer *xfer)
 {
-    int flags, num_read, ack_enabled, ready;
+    int flags, num_read, ready;
     static char buffer[XFER_BLOCKSIZE_MAX];
     time_t last_sent, new_time;
     unsigned long long pos_last_ack;
@@ -362,7 +362,6 @@ xfer_dcc_recv_file_child (struct t_xfer *xfer)
     fcntl (xfer->sock, F_SETFL, flags | O_NONBLOCK);
 
     last_sent = time (NULL);
-    ack_enabled = 1;
     pos_last_ack = 0;
 
     while (1)
@@ -498,7 +497,7 @@ xfer_dcc_recv_file_child (struct t_xfer *xfer)
         }
 
         /* send ACK to sender (if needed) */
-        if (ack_enabled && (xfer->pos > pos_last_ack))
+        if (xfer->send_ack && (xfer->pos > pos_last_ack))
         {
             switch (xfer_dcc_recv_file_send_ack (xfer))
             {
@@ -509,7 +508,7 @@ xfer_dcc_recv_file_child (struct t_xfer *xfer)
                     return;
                 case 1:
                     /* send error, not fatal (buffer full?): disable ACKs */
-                    ack_enabled = 0;
+                    xfer->send_ack = 0;
                     break;
                 case 2:
                     /* send OK: save position in file as last ACK sent */

--- a/src/plugins/xfer/xfer-dcc.c
+++ b/src/plugins/xfer/xfer-dcc.c
@@ -28,6 +28,7 @@
 #include <sys/socket.h>
 #include <poll.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <fcntl.h>
 #include <time.h>
 #include <netdb.h>
@@ -344,6 +345,11 @@ xfer_dcc_recv_file_child (struct t_xfer *xfer)
                                  XFER_ERROR_CONNECT_SENDER);
         return;
     }
+
+    /* set TCP_NODELAY to be more aggressive with acks */
+    /* ignore error as transfer should still work if this fails */
+    flags = 1;
+    setsockopt(xfer->sock, IPPROTO_TCP, TCP_NODELAY, &flags, sizeof(flags));
 
     /* connection is OK, change DCC status (inform parent process) */
     xfer_network_write_pipe (xfer, XFER_STATUS_ACTIVE,

--- a/src/plugins/xfer/xfer.c
+++ b/src/plugins/xfer/xfer.c
@@ -501,6 +501,7 @@ xfer_alloc ()
     new_xfer->filename_suffix = -1;
     new_xfer->pos = 0;
     new_xfer->ack = 0;
+    new_xfer->send_ack = weechat_config_boolean (xfer_config_network_send_ack);
     new_xfer->start_resume = 0;
     new_xfer->last_check_time = time_now;
     new_xfer->last_check_pos = time_now;

--- a/src/plugins/xfer/xfer.h
+++ b/src/plugins/xfer/xfer.h
@@ -156,6 +156,7 @@ struct t_xfer
     char *remote_nick_color;           /* color name for remote nick        */
                                        /* (returned by IRC plugin)          */
     int fast_send;                     /* fast send file: does not wait ACK */
+    int send_ack;                      /* send ack on file receive          */
     int blocksize;                     /* block size for sending file       */
     time_t start_time;                 /* time when xfer started            */
     time_t start_transfer;             /* time when xfer transfer started   */


### PR DESCRIPTION
PR pendant of #1167.

I'll be shutting down my network now but I've hogged up quite a bit with just `TCP_NODELAY`, it works as a workaround and doesn't seem to have any obvious drawback, so we can probably use that for everyone safely.

I still don't like that the xfer logic sometimes disable intermediate acks at runtime based on retry-able error though so I'd also like to add the option even if I haven't needed it, I can remove that second commit if you think it's fluff. Given there is no message when that auto-disabling happens (and I don't see how to display something easily from the fork child) I can't really say how often it has but it feels too frequent...
