### PR TITLE
honor $CURL_CA_BUNDLE when setting up curl

### DIFF
--- a/src/core/wee-url.c
+++ b/src/core/wee-url.c
@@ -1126,6 +1126,12 @@ weeurl_download (const char *url, struct t_hashtable *options)
     curl_easy_setopt (curl, CURLOPT_URL, url);
     curl_easy_setopt (curl, CURLOPT_FOLLOWLOCATION, 1L);
 
+    /* use $CURL_CA_BUNDLE if it's set */
+    char * env_ca = getenv("CURL_CA_BUNDLE");
+    if (env_ca) {
+	curl_easy_setopt (curl, CURLOPT_CAINFO, env_ca);
+    }
+    
     /* set proxy (if option weechat.network.proxy_curl is set) */
     if (CONFIG_STRING(config_network_proxy_curl)
         && CONFIG_STRING(config_network_proxy_curl)[0])


### PR DESCRIPTION
Currently libcurl only looks for ca-certificates at configure time.
This can be a problem:
- if certificates are available at runtime but not at configure/compile time, libcurl will always fail to check certificates.
- if certificates are available at a certain path at configure/compile time, but they're not available at the same path at runtime (the runtime environment might not be the same) libcurl will also fail.

One simple solution (as suggested [here](https://curl.haxx.se/mail/lib-2016-08/0118.html)) is to check for the CURL_CA_BUNDLE environment variable at runtime. That way, if the variable is set it will be used by libcurl. If it's not set, libcurl will still try to use what was available at configure/compile time.

