### PR TITLE
core: unhook TLS handshake fd before calling connect callback

### DIFF
--- a/src/core/wee-network.c
+++ b/src/core/wee-network.c
@@ -1305,6 +1305,7 @@ network_connect_gnutls_handshake_fd_cb (const void *pointer, void *data,
     }
     else if (rc != GNUTLS_E_SUCCESS)
     {
+        unhook (HOOK_CONNECT(hook_connect, handshake_hook_fd));
         (void) (HOOK_CONNECT(hook_connect, callback))
             (hook_connect->callback_pointer,
              hook_connect->callback_data,
@@ -1326,6 +1327,7 @@ network_connect_gnutls_handshake_fd_cb (const void *pointer, void *data,
          */
         if (hook_connect_gnutls_verify_certificates (*HOOK_CONNECT(hook_connect, gnutls_sess)) != 0)
         {
+            unhook (HOOK_CONNECT(hook_connect, handshake_hook_fd));
             (void) (HOOK_CONNECT(hook_connect, callback))
                 (hook_connect->callback_pointer,
                  hook_connect->callback_data,
@@ -1371,6 +1373,7 @@ network_connect_gnutls_handshake_timer_cb (const void *pointer,
 
     HOOK_CONNECT(hook_connect, handshake_hook_timer) = NULL;
 
+    unhook (HOOK_CONNECT(hook_connect, handshake_hook_fd));
     (void) (HOOK_CONNECT(hook_connect, callback))
         (hook_connect->callback_pointer,
          hook_connect->callback_data,


### PR DESCRIPTION
When there are multiple addresses for a server and a TLS handshake failure
occurs, the next server in the list will connect and then timeout without
performing any TLS handshake.

This is because irc_server_close_connection closes server->sock so the next
pipe to be created reuses that fd, but the hook for the handshake fd still
exists when the next connection attempt is started.

The hook for network_connect_child_read_cb is never added because a hook
for the reused fd number still exists.

Resolve this by removing the handshake hook before calling the connect
callback.

```
         │12:05:42    z_je  -- irc: connecting to server irc.z.je/6697 (SSL)...
         │12:05:42    z_je  -- irc: retry=0 ssl=1 gnutls=0x55fe1c9689b0...
         │12:05:42 weechat     debug: adding hook: type=5 (connect), plugin="irc", priority=1000
         │12:05:42 weechat     network_connect_with_fork: sock=-1 (status=-1)
         │12:05:42 weechat     network_connect_with_fork: pipe created, r=9 w=10
         │12:05:42 weechat     debug: adding hook: type=2 (timer), plugin="irc", priority=1000
         │12:05:42 weechat     network_connect_with_fork: adding fd hook for 9
         │12:05:42 weechat     debug: adding hook: type=3 (fd), plugin="irc", priority=1000
         │12:05:42 weechat     debug: added fd hook for 9 (r=1 w=0 e=0)
         │12:05:42 weechat     network_connect_with_fork: added fd hook (0x55fe1cdbf930)
         │12:05:42    z_je  -- irc: hook_connect called...
         │12:05:42 weechat     network_connect_child_read_cb: 0
         │12:05:42 weechat     network_connect_child_read_cb: gnutls_sess=0x55fe1c9689b0 child_read=9 sock=10
         │12:05:42 weechat     network_connect_child_read_cb: gnutls_handshake=-28
         │12:05:42 weechat     debug: removing hook: type=3 (fd), plugin="irc"
         │12:05:42 weechat     debug: removed fd hook for 9
         │12:05:42 weechat     debug: adding hook: type=3 (fd), plugin="irc", priority=1000
fd 10 -> │12:05:42 weechat     debug: added fd hook for 10 (r=1 w=0 e=0)
         │12:05:42 weechat     debug: adding hook: type=2 (timer), plugin="irc", priority=1000
         │12:05:42 weechat     network_connect_gnutls_handshake_fd_cb: sock=10 (status=2050)
         │12:05:42 weechat     network_connect_gnutls_handshake_fd_cb: rc=-28
         │12:05:42 weechat     network_connect_gnutls_handshake_fd_cb: sock=10 (status=2050)
         │12:05:42 weechat     network_connect_gnutls_handshake_fd_cb: rc=-28
         │12:05:42 weechat     network_connect_gnutls_handshake_fd_cb: sock=10 (status=2050)
         │12:05:42    z_je  -- gnutls: connected using 4096-bit Diffie-Hellman shared secret exchange
         │12:05:42    z_je  -- gnutls: receiving 2 certificates
         │12:05:42    z_je  --  - certificate[1] info:
         │12:05:42    z_je  --    - subject `CN=*.irc.z.je', issuer `CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US', serial 0x04ede4440ba9803b66b3914a41ba55a07295, RSA key 2048 bits, signed using RSA-SHA256, activated `2018-05-10 19:02:50 UTC', expires `2018-08-08
         │                     19:02:50 UTC', key-ID `sha256:b6d3f7ac110629fca4c9a47c404dc680cb0213d79ce2fc555ee30a352b4e40e6'
         │12:05:42    z_je  --  - certificate[2] info:
         │12:05:42    z_je  --    - subject `CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US', issuer `CN=DST Root CA X3,O=Digital Signature Trust Co.', serial 0x0a0141420000015385736a0b85eca708, RSA key 2048 bits, signed using RSA-SHA256, activated `2016-03-17 16:40:46
         │                     UTC', expires `2021-03-17 16:40:46 UTC', key-ID `sha256:60b87575447dcba2a36b7d11ac09fb24a9db406fee12d2cc90180517616e8a18'
         │12:05:42    z_je =!= gnutls: the hostname in the certificate does NOT match "irc.z.je"
         │12:05:42    z_je  -- gnutls: peer's certificate is trusted
         │12:05:42 weechat     network_connect_gnutls_handshake_fd_cb: rc=-43
         │12:05:42 weechat     network_connect_gnutls_handshake_fd_cb: callback... sock=10 (status=2050)
         │12:05:42    z_je =!= irc: TLS handshake failed
         │12:05:42    z_je =!= irc: error: Error in the certificate.
close -> │12:05:42    z_je  -- irc: irc_server_close_connection sock=10
         │12:05:42    z_je  -- irc: switching address to zero.irc.z.je/6697
         │12:05:42    z_je  -- irc: connecting to server zero.irc.z.je/6697 (SSL)...
         │12:05:42    z_je  -- irc: retry=0 ssl=1 gnutls=0x55fe1c9689b0...
         │12:05:42 weechat     debug: adding hook: type=5 (connect), plugin="irc", priority=1000
         │12:05:42 weechat     network_connect_with_fork: sock=-1 (status=-1)
reuse -> │12:05:42 weechat     network_connect_with_fork: pipe created, r=10 w=12
         │12:05:42 weechat     debug: adding hook: type=2 (timer), plugin="irc", priority=1000
fd 10 -> │12:05:42 weechat     network_connect_with_fork: adding fd hook for 10
fails -> │12:05:42 weechat     network_connect_with_fork: added fd hook ((nil))
         │12:05:42    z_je  -- irc: hook_connect called...
         │12:05:42 weechat     network_connect_gnutls_handshake_fd_cb: unhook...
         │12:05:42 weechat     debug: removing hook: type=5 (connect), plugin="irc"
         │12:05:42 weechat     debug: removing hook: type=2 (timer), plugin="irc"
         │12:05:42 weechat     debug: removing hook: type=3 (fd), plugin="irc"
late  -> │12:05:42 weechat     debug: removed fd hook for 10
         │12:05:42 weechat     debug: removing hook: type=2 (timer), plugin="irc"
         │12:05:42 weechat     network_connect_gnutls_handshake_fd_cb: unhooked
```