### PR TITLE
Add config_look_hotlist_names_and_numbers option

### DIFF
--- a/src/core/wee-config.c
+++ b/src/core/wee-config.c
@@ -129,6 +129,7 @@ struct t_config_option *config_look_hotlist_names_length;
 struct t_config_option *config_look_hotlist_names_level;
 struct t_config_option *config_look_hotlist_names_merged_buffers;
 struct t_config_option *config_look_hotlist_prefix;
+struct t_config_option *config_look_hotlist_names_and_numbers;
 struct t_config_option *config_look_hotlist_remove;
 struct t_config_option *config_look_hotlist_short_names;
 struct t_config_option *config_look_hotlist_sort;
@@ -2903,6 +2904,15 @@ config_weechat_init_options ()
         N_("display messages count if number of messages is greater or equal "
            "to this value"),
         NULL, 1, 100, "2", NULL, 0,
+        NULL, NULL, NULL,
+        &config_change_buffer_content, NULL, NULL,
+        NULL, NULL, NULL);
+    config_look_hotlist_names_and_numbers = config_file_new_option (
+        weechat_config_file, ptr_section,
+        "hotlist_names_and_numbers", "boolean",
+        N_("if set, buffer numbers are displayed in the hotlist even when "
+           "the name is also displayed"),
+        NULL, 0, 0, "on", NULL, 0,
         NULL, NULL, NULL,
         &config_change_buffer_content, NULL, NULL,
         NULL, NULL, NULL);

--- a/src/core/wee-config.h
+++ b/src/core/wee-config.h
@@ -175,6 +175,7 @@ extern struct t_config_option *config_look_hotlist_add_conditions;
 extern struct t_config_option *config_look_hotlist_buffer_separator;
 extern struct t_config_option *config_look_hotlist_count_max;
 extern struct t_config_option *config_look_hotlist_count_min_msg;
+extern struct t_config_option *config_look_hotlist_names_and_numbers;
 extern struct t_config_option *config_look_hotlist_names_count;
 extern struct t_config_option *config_look_hotlist_names_length;
 extern struct t_config_option *config_look_hotlist_names_level;

--- a/src/gui/gui-bar-item.c
+++ b/src/gui/gui-bar-item.c
@@ -1345,7 +1345,7 @@ gui_bar_item_hotlist_cb (const void *pointer, void *data,
     char str_hotlist[4096], *buffer_without_name_displayed, *buffer_name;
     const char *hotlist_suffix, *ptr_buffer_name;
     struct t_gui_hotlist *ptr_hotlist;
-    int numbers_count, names_count, display_name, count_max;
+    int entries_count, names_count, display_name, count_max;
     int priority, priority_min, priority_min_displayed, private;
 
     /* make C compiler happy */
@@ -1371,7 +1371,7 @@ gui_bar_item_hotlist_cb (const void *pointer, void *data,
             memset (buffer_without_name_displayed, 0, last_gui_buffer->number);
     }
 
-    numbers_count = 0;
+    entries_count = 0;
     names_count = 0;
     for (ptr_hotlist = gui_hotlist; ptr_hotlist;
          ptr_hotlist = ptr_hotlist->next_hotlist)
@@ -1404,7 +1404,7 @@ gui_bar_item_hotlist_cb (const void *pointer, void *data,
         if (display_name || !buffer_without_name_displayed
             || (buffer_without_name_displayed[ptr_hotlist->buffer->number - 1] == 0))
         {
-            if ((numbers_count > 0)
+            if ((entries_count > 0)
                 && (CONFIG_STRING(config_look_hotlist_buffer_separator))
                 && (CONFIG_STRING(config_look_hotlist_buffer_separator)[0]))
             {
@@ -1438,16 +1438,22 @@ gui_bar_item_hotlist_cb (const void *pointer, void *data,
                      */
                     break;
             }
-            snprintf (str_hotlist + strlen (str_hotlist), 16,
-                      "%d", ptr_hotlist->buffer->number);
-            numbers_count++;
+            if (CONFIG_BOOLEAN(config_look_hotlist_names_and_numbers) || !display_name)
+            {
+                snprintf (str_hotlist + strlen (str_hotlist), 16,
+                          "%d", ptr_hotlist->buffer->number);
+            }
+            entries_count++;
 
             if (display_name)
             {
                 names_count++;
 
-                strcat (str_hotlist, GUI_COLOR_CUSTOM_BAR_DELIM);
-                strcat (str_hotlist, ":");
+                if (CONFIG_BOOLEAN(config_look_hotlist_names_and_numbers))
+                {
+                    strcat (str_hotlist, GUI_COLOR_CUSTOM_BAR_DELIM);
+                    strcat (str_hotlist, ":");
+                }
                 strcat (str_hotlist, GUI_COLOR_CUSTOM_BAR_FG);
                 ptr_buffer_name = (CONFIG_BOOLEAN(config_look_hotlist_short_names)) ?
                     gui_buffer_get_short_name (ptr_hotlist->buffer) : ptr_hotlist->buffer->name;


### PR DESCRIPTION
Allowing this to be disabled means that buffer numbers in the hotlist can be turned off if the names are also shown, reducing clutter.