### PR TITLE
don't overwrite user installed GNU auto* files

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -64,7 +64,7 @@ run "rm -f ABOUT-NLS"
 run "rm -rf intl"
 
 # execute autoreconf cmds
-run "autoreconf -fvi"
+run "autoreconf -vi"
 
 # ending
 rm -f $AUTOGEN_LOG


### PR DESCRIPTION
autoreconf -f overwrites user installed GNU auto* files like config.sub and config.guess