### PR TITLE
Add hotlist sort criteria "group_priority"

### DIFF
--- a/src/core/wee-command.c
+++ b/src/core/wee-command.c
@@ -564,7 +564,7 @@ COMMAND_CALLBACK(buffer)
              ptr_buffer = ptr_buffer->next_buffer)
         {
             gui_chat_printf (NULL,
-                             _("  %s[%s%d%s]%s %s%s.%s%s%s (notify: %s)%s%s"),
+                             _("  %s[%s%d%s]%s %s%s.%s%s%s (notify: %s, priority: %s)%s%s"),
                              GUI_COLOR(GUI_COLOR_CHAT_DELIMITERS),
                              GUI_COLOR(GUI_COLOR_CHAT),
                              ptr_buffer->number,
@@ -576,6 +576,7 @@ COMMAND_CALLBACK(buffer)
                              ptr_buffer->name,
                              GUI_COLOR(GUI_COLOR_CHAT),
                              gui_buffer_notify_string[ptr_buffer->notify],
+                             gui_buffer_notify_string[ptr_buffer->priority],
                              (ptr_buffer->hidden) ? " " : "",
                              /* TRANSLATORS: "hidden" is displayed in list of buffers */
                              (ptr_buffer->hidden) ? _("(hidden)") : "");
@@ -1094,6 +1095,20 @@ COMMAND_CALLBACK(buffer)
         {
             gui_chat_printf (NULL,
                              _("%sError: unable to set notify level \"%s\""),
+                             gui_chat_prefix[GUI_CHAT_PREFIX_ERROR],
+                             argv_eol[2]);
+        }
+        return WEECHAT_RC_OK;
+    }
+
+    /* set buffer priority */
+    if (string_strcasecmp (argv[1], "priority") == 0)
+    {
+        COMMAND_MIN_ARGS(3, "priority");
+        if (!config_weechat_priority_set (buffer, argv_eol[2]))
+        {
+            gui_chat_printf (NULL,
+                             _("%sError: unable to set buffer priority \"%s\""),
                              gui_chat_prefix[GUI_CHAT_PREFIX_ERROR],
                              argv_eol[2]);
         }
@@ -7111,6 +7126,7 @@ command_init ()
            " || renumber [<number1> [<number2> [<start>]]]"
            " || close [<n1>[-<n2>]|<name>]"
            " || notify <level>"
+           " || priority <priority>"
            " || localvar"
            " || set <property> [<value>]"
            " || get <property>"
@@ -7142,6 +7158,9 @@ command_init ()
            "            message: for messages from users + highlights\n"
            "                all: all messages\n"
            "              reset: reset to default value (all)\n"
+           " prioriy: set priority of current buffer: the buffer priority "
+           "can be used as a sort criteria to determine the position of the buffer "
+           "in the hotlist."
            "localvar: display local variables for current buffer\n"
            "     set: set a property for current buffer\n"
            "     get: display a property of current buffer\n"
@@ -7198,6 +7217,7 @@ command_init ()
         " || close %(buffers_plugins_names)"
         " || list"
         " || notify reset|none|highlight|message|all"
+        " || priority"
         " || localvar"
         " || set %(buffer_properties_set)"
         " || get %(buffer_properties_get)"

--- a/src/core/wee-config.h
+++ b/src/core/wee-config.h
@@ -88,6 +88,7 @@ enum t_config_look_hotlist_sort
     CONFIG_LOOK_HOTLIST_SORT_GROUP_NUMBER_DESC,
     CONFIG_LOOK_HOTLIST_SORT_NUMBER_ASC,
     CONFIG_LOOK_HOTLIST_SORT_NUMBER_DESC,
+    CONFIG_LOOK_HOTLIST_SORT_GROUP_PRIORITY,
 };
 
 enum t_config_look_input_share
@@ -126,6 +127,7 @@ extern struct t_config_section *weechat_config_section_color;
 extern struct t_config_section *weechat_config_section_proxy;
 extern struct t_config_section *weechat_config_section_bar;
 extern struct t_config_section *weechat_config_section_notify;
+extern struct t_config_section *weechat_config_section_priority;
 
 extern struct t_config_option *config_startup_command_after_plugins;
 extern struct t_config_option *config_startup_command_before_plugins;
@@ -143,6 +145,7 @@ extern struct t_config_option *config_look_bare_display_exit_on_input;
 extern struct t_config_option *config_look_bare_display_time_format;
 extern struct t_config_option *config_look_buffer_auto_renumber;
 extern struct t_config_option *config_look_buffer_notify_default;
+extern struct t_config_option *config_look_buffer_priority_default;
 extern struct t_config_option *config_look_buffer_position;
 extern struct t_config_option *config_look_buffer_search_case_sensitive;
 extern struct t_config_option *config_look_buffer_search_force_default;
@@ -364,6 +367,8 @@ extern int config_weechat_debug_set (const char *plugin_name,
 extern void config_weechat_debug_set_all ();
 extern int config_weechat_notify_set (struct t_gui_buffer *buffer,
                                       const char *notify);
+extern int config_weechat_priority_set (struct t_gui_buffer *buffer,
+                                        const char *priority);
 extern void config_get_item_time (char *text_time, int max_length);
 extern int config_weechat_init ();
 extern int config_weechat_read ();

--- a/src/gui/gui-buffer.h
+++ b/src/gui/gui-buffer.h
@@ -60,6 +60,9 @@ enum t_gui_buffer_notify
 
 #define GUI_BUFFER_INPUT_BLOCK_SIZE 256
 
+#define GUI_BUFFER_PRIORITY_MIN -128
+#define GUI_BUFFER_PRIORITY_MAX 127
+
 /* buffer structures */
 
 struct t_gui_input_undo
@@ -203,6 +206,7 @@ struct t_gui_buffer
     struct t_gui_hotlist *hotlist;     /* hotlist entry for buffer          */
     struct t_hashtable *hotlist_max_level_nicks; /* max hotlist level for   */
                                                  /* some nicks              */
+    int priority;                      /* a hotlist sort criteria for buffer*/
 
     /* keys associated to buffer */
     struct t_gui_key *keys;            /* keys specific to buffer           */
@@ -238,6 +242,7 @@ extern struct t_gui_buffer *gui_buffer_last_displayed;
 extern char *gui_buffer_reserved_names[];
 extern char *gui_buffer_type_string[];
 extern char *gui_buffer_notify_string[];
+
 extern char *gui_buffer_properties_get_integer[];
 extern char *gui_buffer_properties_get_string[];
 extern char *gui_buffer_properties_get_pointer[];
@@ -250,6 +255,7 @@ extern const char *gui_buffer_get_plugin_name (struct t_gui_buffer *buffer);
 extern const char *gui_buffer_get_short_name (struct t_gui_buffer *buffer);
 extern void gui_buffer_build_full_name (struct t_gui_buffer *buffer);
 extern void gui_buffer_notify_set_all ();
+extern void gui_buffer_priority_set_all ();
 extern void gui_buffer_input_buffer_init (struct t_gui_buffer *buffer);
 extern int gui_buffer_is_reserved_name (const char *name);
 extern struct t_gui_buffer *gui_buffer_new (struct t_weechat_plugin *plugin,

--- a/src/gui/gui-hotlist.c
+++ b/src/gui/gui-hotlist.c
@@ -235,6 +235,17 @@ gui_hotlist_find_pos (struct t_gui_hotlist *hotlist,
                     return ptr_hotlist;
             }
             break;
+        case CONFIG_LOOK_HOTLIST_SORT_GROUP_PRIORITY:
+            for (ptr_hotlist = hotlist; ptr_hotlist;
+                 ptr_hotlist = ptr_hotlist->next_hotlist)
+            {
+                if ((new_hotlist->priority > ptr_hotlist->priority)
+                    || ((new_hotlist->priority == ptr_hotlist->priority)
+                        && (new_hotlist->buffer->priority > ptr_hotlist->buffer->priority)))
+                    return ptr_hotlist;
+            }
+            break;
+
     }
     return NULL;
 }

--- a/src/gui/gui-hotlist.h
+++ b/src/gui/gui-hotlist.h
@@ -40,6 +40,7 @@ struct t_gui_hotlist
 {
     enum t_gui_hotlist_priority priority;  /* 0=crappy msg (join/part),     */
                                            /* 1=msg, 2=pv, 3=nick highlight */
+    int buffer_priority;                   /* buffer priority               */
     struct timeval creation_time;          /* time when entry was added     */
     struct t_gui_buffer *buffer;           /* associated buffer             */
     int count[GUI_HOTLIST_NUM_PRIORITIES]; /* number of msgs by priority    */


### PR DESCRIPTION
Currently weechat.look.hotlist_sort supports sorting by notify level then time
or number. This patch assigns each buffer a priority and introduces a new sort
criteria: buffer priority. This can be useful when you are more interested in
certain buffers(channels) and would like to read messages from these buffers
regardless the notify message levels.

Here is a real-world scenario when this feature helps me. When using weechat at
work, I join many buffers, some are for casual chats, some are for serious stuff.
While most messages are of the same notify level (hotlist_priority), the
messages in the buffers for serious stuff are actually more important and are
what I'd like to read first. This patch allows me to jump to corresponding
buffers first using "Alt+a" (Switch to next buffer with activity).

Below are usage examples (note that buffer priority ranges -128 ~127):
    # set sort criteria
    /set weechat.look.hotlist_sort group_priority
    # set priority of a buffer
    /set weechat.priority.python.mycompany.slack.com.&chat -10
    # alternatively, go to the designated buffer and run the following
    /buffer priority -10
    # save the configuration
    /save