### PR TITLE
gui: attempt to auto-reset color pairs even when full

### DIFF
--- a/src/gui/curses/gui-curses-color.c
+++ b/src/gui/curses/gui-curses-color.c
@@ -407,6 +407,12 @@ gui_color_get_pair (int fg, int bg)
                             &gui_color_timer_warning_pairs_full, NULL, NULL);
                 gui_color_warning_pairs_full = 1;
             }
+            else if (!gui_color_pairs_auto_reset_pending // TODO: need (gui_color_num_pairs > 1) ?
+                && (CONFIG_INTEGER(config_look_color_pairs_auto_reset) >= 0))
+            {
+                gui_color_pairs_auto_reset = 1;
+            }
+
             return 1;
         }
 

--- a/src/gui/curses/gui-curses-color.c
+++ b/src/gui/curses/gui-curses-color.c
@@ -359,10 +359,20 @@ gui_color_timer_warning_pairs_full (const void *pointer, void *data,
     (void) data;
     (void) remaining_calls;
 
-    gui_chat_printf (NULL,
-                     _("Warning: the %d color pairs are used, do "
-                       "\"/color reset\" to remove unused pairs"),
-                     gui_color_num_pairs);
+    if (CONFIG_INTEGER(config_look_color_pairs_auto_reset) < 0)
+    {
+        gui_chat_printf (NULL,
+                         _ ("Warning: the %d color pairs are used, do "
+                            "\"/color reset\" to remove unused pairs"),
+                         gui_color_num_pairs);
+    }
+    else
+    {
+        gui_chat_printf (NULL,
+                         _ ("Warning: the %d color pairs are used and "
+                            "automatic reset failed"),
+                         gui_color_num_pairs);
+    }
 
     return WEECHAT_RC_OK;
 }
@@ -399,15 +409,14 @@ gui_color_get_pair (int fg, int bg)
         if (gui_color_pairs_used >= gui_color_num_pairs)
         {
             /* oh no, no more pair available! */
-            if (!gui_color_warning_pairs_full
-                && (CONFIG_INTEGER(config_look_color_pairs_auto_reset) < 0))
+            if (!gui_color_warning_pairs_full)
             {
-                /* display warning if auto reset of pairs is disabled */
                 hook_timer (NULL, 1, 0, 1,
                             &gui_color_timer_warning_pairs_full, NULL, NULL);
                 gui_color_warning_pairs_full = 1;
             }
-            else if (!gui_color_pairs_auto_reset_pending // TODO: need (gui_color_num_pairs > 1) ?
+
+            if (!gui_color_pairs_auto_reset_pending // TODO: need (gui_color_num_pairs > 1) ?
                 && (CONFIG_INTEGER(config_look_color_pairs_auto_reset) >= 0))
             {
                 gui_color_pairs_auto_reset = 1;


### PR DESCRIPTION
Previously if color pairs fill up because all pairs are rendered at once
and auto-reset therefore fails, weechat will never try to auto-reset
again and manual reset is necessary.

This attempts to auto-reset even a full table, in case now less pairs
are visible and the reset will be successful.

For testing I wrote this script to spam a huge number of color combinations into a single buffer to fill up all the ncurses color pairs: https://gist.github.com/sim642/dde23725f23907bc960fce308ecda4f1.
Running the script messes up bar colors etc and switching to a different buffer, which doesn't need all those color pairs should auto reset and fix the color pairs again, but it doesn't. This PR changes that and attempts auto color reset when the pairs are already completely full.

On at least two occasions in the recent months this issue has been brought up in #weechat, which seems to have been caused by such color pair spam. One would expect color pair auto reset to eventually fix the colors but it didn't because nothing was attempted when the limit was already over.

Happy Hacktoberfest!