### PR TITLE
irc: use key when /join-ing in open channel buffer

### DIFF
--- a/src/plugins/irc/irc-channel.c
+++ b/src/plugins/irc/irc-channel.c
@@ -1277,7 +1277,8 @@ irc_channel_join_smart_filtered_unmask (struct t_irc_channel *channel,
  */
 
 void
-irc_channel_rejoin (struct t_irc_server *server, struct t_irc_channel *channel)
+irc_channel_rejoin (struct t_irc_server *server, struct t_irc_channel *channel,
+                    int manual_join, int noswitch)
 {
     char join_args[256];
 
@@ -1286,7 +1287,7 @@ irc_channel_rejoin (struct t_irc_server *server, struct t_irc_channel *channel)
               (channel->key) ? " " : "",
               (channel->key) ? channel->key : "");
 
-    irc_command_join_server (server, join_args, 0, 1);
+    irc_command_join_server (server, join_args, manual_join, noswitch);
 }
 
 /*
@@ -1323,7 +1324,7 @@ irc_channel_autorejoin_cb (const void *pointer, void *data,
 
     if (ptr_server_found && (ptr_channel_arg->hook_autorejoin))
     {
-        irc_channel_rejoin (ptr_server_found, ptr_channel_arg);
+        irc_channel_rejoin (ptr_server_found, ptr_channel_arg, 0, 1);
         ptr_channel_arg->hook_autorejoin = NULL;
     }
 

--- a/src/plugins/irc/irc-channel.c
+++ b/src/plugins/irc/irc-channel.c
@@ -1280,14 +1280,29 @@ void
 irc_channel_rejoin (struct t_irc_server *server, struct t_irc_channel *channel,
                     int manual_join, int noswitch)
 {
-    char join_args[256];
+    char *join_string;
+    int join_length;
 
-    snprintf (join_args, sizeof (join_args), "%s%s%s",
-              channel->name,
-              (channel->key) ? " " : "",
-              (channel->key) ? channel->key : "");
-
-    irc_command_join_server (server, join_args, manual_join, noswitch);
+    if (channel->key)
+    {
+        join_length = strlen (channel->name) + 1 + strlen (channel->key) + 1;
+        join_string = malloc (join_length);
+        if (join_string)
+        {
+            snprintf (join_string, join_length, "%s %s",
+                      channel->name,
+                      channel->key);
+            irc_command_join_server (server, join_string,
+                                     manual_join, noswitch);
+            free (join_string);
+        }
+        else
+            irc_command_join_server (server, channel->name,
+                                     manual_join, noswitch);
+    }
+    else
+        irc_command_join_server (server, channel->name,
+                                 manual_join, noswitch);
 }
 
 /*

--- a/src/plugins/irc/irc-channel.h
+++ b/src/plugins/irc/irc-channel.h
@@ -154,8 +154,9 @@ extern void irc_channel_join_smart_filtered_remove (struct t_irc_channel *channe
                                                     const char *nick);
 extern void irc_channel_join_smart_filtered_unmask (struct t_irc_channel *channel,
                                                     const char *nick);
-extern void irc_channel_rejoin (struct t_irc_server *server,
-                                struct t_irc_channel *channel);
+extern void
+irc_channel_rejoin (struct t_irc_server *server, struct t_irc_channel *channel,
+                    int manual_join, int noswitch);
 extern int irc_channel_autorejoin_cb (const void *pointer, void *data,
                                       int remaining_calls);
 extern void irc_channel_display_nick_back_in_pv (struct t_irc_server *server,

--- a/src/plugins/irc/irc-command.c
+++ b/src/plugins/irc/irc-command.c
@@ -2673,8 +2673,7 @@ IRC_COMMAND_CALLBACK(join)
         if (ptr_channel && (ptr_channel->type == IRC_CHANNEL_TYPE_CHANNEL)
             && !ptr_channel->nicks)
         {
-            irc_command_join_server (ptr_server, ptr_channel->name,
-                                     1, noswitch);
+            irc_channel_rejoin (ptr_server, ptr_channel, 1, noswitch);
         }
         else
         {

--- a/src/plugins/irc/irc-protocol.c
+++ b/src/plugins/irc/irc-protocol.c
@@ -1262,7 +1262,7 @@ IRC_PROTOCOL_CALLBACK(kick)
                                           IRC_SERVER_OPTION_AUTOREJOIN_DELAY) == 0)
             {
                 /* immediately rejoin if delay is 0 */
-                irc_channel_rejoin (server, ptr_channel);
+                irc_channel_rejoin (server, ptr_channel, 0, 1);
             }
             else
             {

--- a/src/plugins/irc/irc-protocol.c
+++ b/src/plugins/irc/irc-protocol.c
@@ -2005,26 +2005,7 @@ IRC_PROTOCOL_CALLBACK(part)
         if (ptr_channel->cycle)
         {
             ptr_channel->cycle = 0;
-            if (ptr_channel->key)
-            {
-                join_length = strlen (ptr_channel->name) + 1 +
-                    strlen (ptr_channel->key) + 1;
-                join_string = malloc (join_length);
-                if (join_string)
-                {
-                    snprintf (join_string, join_length, "%s %s",
-                              ptr_channel->name,
-                              ptr_channel->key);
-                    irc_command_join_server (server, join_string, 1, 1);
-                    free (join_string);
-                }
-                else
-                    irc_command_join_server (server, ptr_channel->name,
-                                             1, 1);
-            }
-            else
-                irc_command_join_server (server, ptr_channel->name,
-                                         1, 1);
+            irc_channel_rejoin (server, ptr_channel, 1, 1);
         }
         else
         {


### PR DESCRIPTION
When a channel buffer is open because it was previously joined, but now has been /part-ed or kicked, the buffer stays open. Running `/join` in it joins to that open channel buffer again. This change makes that `/join` call automatically use the known channel key if it's known to weechat, e.g. was used when first joining that channel.

Really reusing the known channel key could go even further, e.g. when joining that same channel specifically by name also. This doesn't include that because that would require more complex logic in the JOIN command sending to splice in the correct keys for the correct channels and possibly reorder them to match things up properly.

Happy Hacktoberfest!