### PR TITLE
irc: allow specifying SSL CA per server

### DIFF
--- a/src/core/hook/wee-hook-connect.c
+++ b/src/core/hook/wee-hook-connect.c
@@ -95,6 +95,7 @@ hook_connect (struct t_weechat_plugin *plugin, const char *proxy,
     new_hook_connect->gnutls_dhkey_size = gnutls_dhkey_size;
     new_hook_connect->gnutls_priorities = (gnutls_priorities) ?
         strdup (gnutls_priorities) : NULL;
+    new_hook_connect->gnutls_xcred = NULL;
 #endif /* HAVE_GNUTLS */
     new_hook_connect->local_hostname = (local_hostname) ?
         strdup (local_hostname) : NULL;
@@ -230,6 +231,11 @@ hook_connect_free_data (struct t_hook *hook)
     {
         free (HOOK_CONNECT(hook, gnutls_priorities));
         HOOK_CONNECT(hook, gnutls_priorities) = NULL;
+    }
+    if (HOOK_CONNECT(hook, gnutls_xcred))
+    {
+        gnutls_certificate_free_credentials (HOOK_CONNECT(hook, gnutls_xcred));
+        HOOK_CONNECT(hook, gnutls_xcred) = NULL;
     }
 #endif /* HAVE_GNUTLS */
     if (HOOK_CONNECT(hook, local_hostname))

--- a/src/core/hook/wee-hook-connect.h
+++ b/src/core/hook/wee-hook-connect.h
@@ -66,6 +66,7 @@ struct t_hook_connect
     gnutls_callback_t *gnutls_cb;      /* GnuTLS callback during handshake  */
     int gnutls_dhkey_size;             /* Diffie Hellman Key Exchange size  */
     char *gnutls_priorities;           /* GnuTLS priorities                 */
+    gnutls_certificate_credentials_t gnutls_xcred; /* GnuTLS client credentials */
 #endif /* HAVE_GNUTLS */
     char *local_hostname;              /* force local hostname (optional)   */
     int child_read;                    /* to read data in pipe from child   */

--- a/src/core/wee-config.c
+++ b/src/core/wee-config.c
@@ -1267,24 +1267,6 @@ config_change_completion_partial_completion_templates (const void *pointer,
 }
 
 /*
- * Callback for changes on option "weechat.network.gnutls_ca_file".
- */
-
-void
-config_change_network_gnutls_ca_file (const void *pointer, void *data,
-                                      struct t_config_option *option)
-{
-    /* make C compiler happy */
-    (void) pointer;
-    (void) data;
-    (void) option;
-
-    /*if (network_init_gnutls_ok)
-        network_set_gnutls_ca_file ();*/
-    // TODO: anything?
-}
-
-/*
  * Checks option "weechat.network.proxy_curl".
  */
 
@@ -4470,9 +4452,7 @@ config_weechat_init_options ()
         N_("file containing the certificate authorities (\"%h\" will be "
            "replaced by WeeChat home, \"~/.weechat\" by default)"),
         NULL, 0, 0, CA_FILE, NULL, 0,
-        NULL, NULL, NULL,
-        &config_change_network_gnutls_ca_file, NULL, NULL,
-        NULL, NULL, NULL);
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
     config_network_gnutls_handshake_timeout = config_file_new_option (
         weechat_config_file, ptr_section,
         "gnutls_handshake_timeout", "integer",

--- a/src/core/wee-config.c
+++ b/src/core/wee-config.c
@@ -1279,8 +1279,9 @@ config_change_network_gnutls_ca_file (const void *pointer, void *data,
     (void) data;
     (void) option;
 
-    if (network_init_gnutls_ok)
-        network_set_gnutls_ca_file ();
+    /*if (network_init_gnutls_ok)
+        network_set_gnutls_ca_file ();*/
+    // TODO: anything?
 }
 
 /*

--- a/src/core/wee-network.c
+++ b/src/core/wee-network.c
@@ -85,6 +85,7 @@ network_init_gcrypt ()
     gcry_control (GCRYCTL_INITIALIZATION_FINISHED, 0);
 }
 
+#ifdef HAVE_GNUTLS
 /*
  * Sets trust file with option "gnutls_ca_file".
  */
@@ -92,7 +93,6 @@ network_init_gcrypt ()
 void
 network_set_gnutls_ca_file (gnutls_certificate_credentials_t gnutls_xcred)
 {
-#ifdef HAVE_GNUTLS
     char *ca_path, *ca_path2;
 
     if (weechat_no_gnutls)
@@ -110,8 +110,8 @@ network_set_gnutls_ca_file (gnutls_certificate_credentials_t gnutls_xcred)
         }
         free (ca_path);
     }
-#endif /* HAVE_GNUTLS */
 }
+#endif /* HAVE_GNUTLS */
 
 /*
  * Initializes GnuTLS.

--- a/src/core/wee-network.c
+++ b/src/core/wee-network.c
@@ -68,9 +68,6 @@
 
 int network_init_gnutls_ok = 0;
 
-#ifdef HAVE_GNUTLS
-gnutls_certificate_credentials_t gnutls_xcred; /* GnuTLS client credentials */
-#endif /* HAVE_GNUTLS */
 
 
 /*
@@ -93,7 +90,7 @@ network_init_gcrypt ()
  */
 
 void
-network_set_gnutls_ca_file ()
+network_set_gnutls_ca_file (gnutls_certificate_credentials_t gnutls_xcred)
 {
 #ifdef HAVE_GNUTLS
     char *ca_path, *ca_path2;
@@ -127,20 +124,6 @@ network_init_gnutls ()
     if (!weechat_no_gnutls)
     {
         gnutls_global_init ();
-        gnutls_certificate_allocate_credentials (&gnutls_xcred);
-
-        network_set_gnutls_ca_file ();
-#if LIBGNUTLS_VERSION_NUMBER >= 0x02090a /* 2.9.10 */
-        gnutls_certificate_set_verify_function (gnutls_xcred,
-                                                &hook_connect_gnutls_verify_certificates);
-#endif /* LIBGNUTLS_VERSION_NUMBER >= 0x02090a */
-#if LIBGNUTLS_VERSION_NUMBER >= 0x020b00 /* 2.11.0 */
-        gnutls_certificate_set_retrieve_function (gnutls_xcred,
-                                                  &hook_connect_gnutls_set_certificates);
-#else
-        gnutls_certificate_client_set_retrieve_function (gnutls_xcred,
-                                                         &hook_connect_gnutls_set_certificates);
-#endif /* LIBGNUTLS_VERSION_NUMBER >= 0x020b00 */
     }
 #endif /* HAVE_GNUTLS */
 
@@ -159,7 +142,6 @@ network_end ()
 #ifdef HAVE_GNUTLS
         if (!weechat_no_gnutls)
         {
-            gnutls_certificate_free_credentials (gnutls_xcred);
             gnutls_global_deinit ();
         }
 #endif /* HAVE_GNUTLS */
@@ -1696,9 +1678,39 @@ network_connect_with_fork (struct t_hook *hook_connect)
             unhook (hook_connect);
             return;
         }
+        gnutls_certificate_allocate_credentials (&HOOK_CONNECT(hook_connect, gnutls_xcred));
         gnutls_credentials_set (*HOOK_CONNECT(hook_connect, gnutls_sess),
                                 GNUTLS_CRD_CERTIFICATE,
-                                gnutls_xcred);
+                                HOOK_CONNECT(hook_connect, gnutls_xcred));
+        network_set_gnutls_ca_file (HOOK_CONNECT(hook_connect, gnutls_xcred));
+        rc = (int) HOOK_CONNECT(hook_connect, gnutls_cb)
+            (hook_connect->callback_pointer,
+             hook_connect->callback_data,
+             *HOOK_CONNECT(hook_connect, gnutls_sess),
+             NULL, 0, NULL, 0, NULL,
+             WEECHAT_HOOK_CONNECT_GNUTLS_CB_INIT_XCRED);
+        if (rc != GNUTLS_E_SUCCESS)
+        {
+            (void) (HOOK_CONNECT(hook_connect, callback))
+                (hook_connect->callback_pointer,
+                 hook_connect->callback_data,
+                 WEECHAT_HOOK_CONNECT_GNUTLS_INIT_ERROR,
+                 0, -1, _("initializing client credentials failed"), NULL);
+            unhook (hook_connect);
+            return;
+        }
+#if LIBGNUTLS_VERSION_NUMBER >= 0x02090a /* 2.9.10 */
+        gnutls_certificate_set_verify_function (HOOK_CONNECT(hook_connect, gnutls_xcred),
+                                                &hook_connect_gnutls_verify_certificates);
+#endif /* LIBGNUTLS_VERSION_NUMBER >= 0x02090a */
+#if LIBGNUTLS_VERSION_NUMBER >= 0x020b00 /* 2.11.0 */
+        gnutls_certificate_set_retrieve_function (HOOK_CONNECT(hook_connect, gnutls_xcred),
+                                                  &hook_connect_gnutls_set_certificates);
+#else
+        gnutls_certificate_client_set_retrieve_function (HOOK_CONNECT(hook_connect, gnutls_xcred),
+                                                         &hook_connect_gnutls_set_certificates);
+#endif /* LIBGNUTLS_VERSION_NUMBER >= 0x020b00 */
+
         gnutls_transport_set_ptr (*HOOK_CONNECT(hook_connect, gnutls_sess),
                                   (gnutls_transport_ptr_t) ((unsigned long) HOOK_CONNECT(hook_connect, sock)));
     }

--- a/src/core/wee-network.h
+++ b/src/core/wee-network.h
@@ -46,7 +46,6 @@ struct t_network_socks5
 extern int network_init_gnutls_ok;
 
 extern void network_init_gcrypt ();
-extern void network_set_gnutls_ca_file ();
 extern void network_init_gnutls ();
 extern void network_end ();
 extern int network_pass_proxy (const char *proxy, int sock,

--- a/src/plugins/irc/irc-command.c
+++ b/src/plugins/irc/irc-command.c
@@ -4788,6 +4788,14 @@ irc_command_display_server (struct t_irc_server *server, int with_detail)
             weechat_printf (NULL, "  ssl_fingerprint. . . : %s'%s'",
                             IRC_COLOR_CHAT_VALUE,
                             weechat_config_string (server->options[IRC_SERVER_OPTION_SSL_FINGERPRINT]));
+        /* ssl_ca_file */
+        if (weechat_config_option_is_null (server->options[IRC_SERVER_OPTION_SSL_CA_FILE]))
+            weechat_printf (NULL, "  ssl_ca_file. . . . . :   ('%s')",
+                            IRC_SERVER_OPTION_STRING(server, IRC_SERVER_OPTION_SSL_CA_FILE));
+        else
+            weechat_printf (NULL, "  ssl_ca_file. . . . . : %s'%s'",
+                            IRC_COLOR_CHAT_VALUE,
+                            weechat_config_string (server->options[IRC_SERVER_OPTION_SSL_CA_FILE]));
         /* ssl_verify */
         if (weechat_config_option_is_null (server->options[IRC_SERVER_OPTION_SSL_VERIFY]))
             weechat_printf (NULL, "  ssl_verify . . . . . :   (%s)",

--- a/src/plugins/irc/irc-config.c
+++ b/src/plugins/irc/irc-config.c
@@ -1780,6 +1780,23 @@ irc_config_server_new_option (struct t_config_file *config_file,
                 callback_change_data,
                 NULL, NULL, NULL);
             break;
+        case IRC_SERVER_OPTION_SSL_CA_FILE:
+            new_option = weechat_config_new_option (
+                config_file, section,
+                option_name, "string",
+                N_("file containing the certificate authorities (\"%h\" will be "
+                   "replaced by WeeChat home, \"~/.weechat\" by default)"),
+                NULL, 0, 0,
+                default_value, value,
+                null_value_allowed,
+                callback_check_value,
+                callback_check_value_pointer,
+                callback_check_value_data,
+                callback_change,
+                callback_change_pointer,
+                callback_change_data,
+                NULL, NULL, NULL);
+            break;
         case IRC_SERVER_OPTION_SSL_VERIFY:
             new_option = weechat_config_new_option (
                 config_file, section,

--- a/src/plugins/irc/irc-server.c
+++ b/src/plugins/irc/irc-server.c
@@ -4431,6 +4431,7 @@ irc_server_gnutls_callback (const void *pointer, void *data,
     const gnutls_datum_t *cert_list;
     gnutls_datum_t filedatum;
     gnutls_certificate_credentials_t xcred;
+    gnutls_x509_trust_list_t trust_list;
     unsigned int i, cert_list_len, status;
     time_t cert_time;
     char *cert_path0, *cert_path1, *cert_path2, *cert_str, *fingerprint_eval;
@@ -4812,6 +4813,11 @@ irc_server_gnutls_callback (const void *pointer, void *data,
                                         (void **) &xcred);
                 if (xcred)
                 {
+                    /* create new (empty) trust list */
+                    gnutls_x509_trust_list_init (&trust_list, 0);
+                    /* set deinits existing trust list */
+                    gnutls_certificate_set_trust_list (xcred, trust_list, 0);
+
                     gnutls_certificate_set_x509_trust_file (xcred, cert_path2,
                                                             GNUTLS_X509_FMT_PEM);
                 }

--- a/src/plugins/irc/irc-server.c
+++ b/src/plugins/irc/irc-server.c
@@ -87,6 +87,7 @@ char *irc_server_options[IRC_SERVER_NUM_OPTIONS][2] =
   { "ssl_priorities",       "NORMAL:-VERS-SSL3.0"     },
   { "ssl_dhkey_size",       "2048"                    },
   { "ssl_fingerprint",      ""                        },
+  { "ssl_ca_file",          ""                        },
   { "ssl_verify",           "on"                      },
   { "password",             ""                        },
   { "capabilities",         ""                        },
@@ -4429,6 +4430,7 @@ irc_server_gnutls_callback (const void *pointer, void *data,
     gnutls_x509_crt_t cert_temp;
     const gnutls_datum_t *cert_list;
     gnutls_datum_t filedatum;
+    gnutls_certificate_credentials_t xcred;
     unsigned int i, cert_list_len, status;
     time_t cert_time;
     char *cert_path0, *cert_path1, *cert_path2, *cert_str, *fingerprint_eval;
@@ -4783,6 +4785,35 @@ irc_server_gnutls_callback (const void *pointer, void *data,
                         server->buffer,
                         _("%sgnutls: unable to read certificate \"%s\""),
                         weechat_prefix ("error"), cert_path2);
+                }
+            }
+
+            if (cert_path1)
+                free (cert_path1);
+            if (cert_path2)
+                free (cert_path2);
+        }
+    }
+    else if (action == WEECHAT_HOOK_CONNECT_GNUTLS_CB_INIT_XCRED)
+    {
+        cert_path0 = (char *) IRC_SERVER_OPTION_STRING(
+            server, IRC_SERVER_OPTION_SSL_CA_FILE);
+        if (cert_path0 && cert_path0[0])
+        {
+            weechat_dir = weechat_info_get ("weechat_dir", "");
+            cert_path1 = weechat_string_replace (cert_path0, "%h", weechat_dir);
+            cert_path2 = (cert_path1) ?
+                         weechat_string_expand_home (cert_path1) : NULL;
+
+            if (cert_path2)
+            {
+                xcred = NULL;
+                gnutls_credentials_get (tls_session, GNUTLS_CRD_CERTIFICATE,
+                                        (void **) &xcred);
+                if (xcred)
+                {
+                    gnutls_certificate_set_x509_trust_file (xcred, cert_path2,
+                                                            GNUTLS_X509_FMT_PEM);
                 }
             }
 
@@ -5846,6 +5877,9 @@ irc_server_add_to_infolist (struct t_infolist *infolist,
     if (!weechat_infolist_new_var_string (ptr_item, "ssl_fingerprint",
                                            IRC_SERVER_OPTION_STRING(server, IRC_SERVER_OPTION_SSL_FINGERPRINT)))
         return 0;
+    if (!weechat_infolist_new_var_string (ptr_item, "ssl_ca_file",
+                                          IRC_SERVER_OPTION_STRING(server, IRC_SERVER_OPTION_SSL_CA_FILE)))
+        return 0;
     if (!weechat_infolist_new_var_integer (ptr_item, "ssl_verify",
                                            IRC_SERVER_OPTION_BOOLEAN(server, IRC_SERVER_OPTION_SSL_VERIFY)))
         return 0;
@@ -6113,6 +6147,13 @@ irc_server_print_log ()
         else
             weechat_log_printf ("  ssl_fingerprint. . . : '%s'",
                                 weechat_config_string (ptr_server->options[IRC_SERVER_OPTION_SSL_FINGERPRINT]));
+        /* ssl_ca_file */
+        if (weechat_config_option_is_null (ptr_server->options[IRC_SERVER_OPTION_SSL_CA_FILE]))
+            weechat_log_printf ("  ssl_ca_file. . . . . : null ('%s')",
+                                IRC_SERVER_OPTION_STRING(ptr_server, IRC_SERVER_OPTION_SSL_CA_FILE));
+        else
+            weechat_log_printf ("  ssl_ca_file. . . . . : '%s'",
+                                weechat_config_string (ptr_server->options[IRC_SERVER_OPTION_SSL_CA_FILE]));
         /* ssl_verify */
         if (weechat_config_option_is_null (ptr_server->options[IRC_SERVER_OPTION_SSL_VERIFY]))
             weechat_log_printf ("  ssl_verify . . . . . : null (%s)",

--- a/src/plugins/irc/irc-server.c
+++ b/src/plugins/irc/irc-server.c
@@ -4431,7 +4431,9 @@ irc_server_gnutls_callback (const void *pointer, void *data,
     const gnutls_datum_t *cert_list;
     gnutls_datum_t filedatum;
     gnutls_certificate_credentials_t xcred;
+#if LIBGNUTLS_VERSION_NUMBER >= 0x030300 /* 3.3.0 */
     gnutls_x509_trust_list_t trust_list;
+#endif /* LIBGNUTLS_VERSION_NUMBER >= 0x030300 */
     unsigned int i, cert_list_len, status;
     time_t cert_time;
     char *cert_path0, *cert_path1, *cert_path2, *cert_str, *fingerprint_eval;
@@ -4808,6 +4810,7 @@ irc_server_gnutls_callback (const void *pointer, void *data,
 
             if (cert_path2)
             {
+#if LIBGNUTLS_VERSION_NUMBER >= 0x030300 /* 3.3.0 */
                 xcred = NULL;
                 gnutls_credentials_get (tls_session, GNUTLS_CRD_CERTIFICATE,
                                         (void **) &xcred);
@@ -4821,6 +4824,12 @@ irc_server_gnutls_callback (const void *pointer, void *data,
                     gnutls_certificate_set_x509_trust_file (xcred, cert_path2,
                                                             GNUTLS_X509_FMT_PEM);
                 }
+#else
+                weechat_printf (server->buffer,
+                    _("%sgnutls: version >= 3.3.3 is required for "
+                      "\"ssl_ca_file\""),
+                    weechat_prefix ("error"));
+#endif /* LIBGNUTLS_VERSION_NUMBER >= 0x030300 */
             }
 
             if (cert_path1)

--- a/src/plugins/irc/irc-server.h
+++ b/src/plugins/irc/irc-server.h
@@ -60,6 +60,7 @@ enum t_irc_server_option
     IRC_SERVER_OPTION_SSL_PRIORITIES, /* gnutls priorities                   */
     IRC_SERVER_OPTION_SSL_DHKEY_SIZE, /* Diffie Hellman key size             */
     IRC_SERVER_OPTION_SSL_FINGERPRINT, /* SHA1 fingerprint of certificate    */
+    IRC_SERVER_OPTION_SSL_CA_FILE,   /* gnutls ssl ca file                   */
     IRC_SERVER_OPTION_SSL_VERIFY,    /* check if the connection is trusted   */
     IRC_SERVER_OPTION_PASSWORD,      /* password for server                  */
     IRC_SERVER_OPTION_CAPABILITIES,  /* client capabilities to enable        */

--- a/src/plugins/weechat-plugin.h
+++ b/src/plugins/weechat-plugin.h
@@ -181,6 +181,7 @@ struct timeval;
 /* action for gnutls callback: verify or set certificate */
 #define WEECHAT_HOOK_CONNECT_GNUTLS_CB_VERIFY_CERT  0
 #define WEECHAT_HOOK_CONNECT_GNUTLS_CB_SET_CERT     1
+#define WEECHAT_HOOK_CONNECT_GNUTLS_CB_INIT_XCRED   2
 
 /* type of data for signal hooked */
 #define WEECHAT_HOOK_SIGNAL_STRING                  "string"


### PR DESCRIPTION
Closes #438.

This PR is an improvement of PR #613 (credit to @ManiacTwister), which started in the right direction but has some still unresolved issues:
1. It accesses core (only) functions from irc plugin by direct include, not via plugin API: https://github.com/weechat/weechat/pull/613/files#r50862583
2. It modifies the trust list during certificate verification instead of setting up the correct trust list before that. It seems wrong because it's not obvious why allocating a new trust list mid-verification is allowed (if it even works) and if GnuTLS doesn't break this in the future. 
3. The solution is not well extensible: other users of `hook_connect` still have no way to manipulate the trust list for their connection only.

This PR tries to solve these problems and hopefully finally bring per server SSL CAs to weechat. Every `hook_connect` user can choose to manipulate the trust list however they see fit: clear it (or not), add CAs from file (or elsewhere).

Turns out GnuTLS >=3.3.0 is required to manipulate the trust list like this. This is a significantly higher requirement than otherwise is needed but it only affects the added `ssl_ca_file` option use and should be fine on most cases (even the old Ubuntu 16.04 has GnuTLS 3.4).

Happy Hacktoberfest!