### PR TITLE
Added "How can I disable highlights for specific nicks?"

### DIFF
--- a/doc/en/weechat_faq.en.adoc
+++ b/doc/en/weechat_faq.en.adoc
@@ -817,6 +817,29 @@ Other scripts on this subject:
 /script search notify
 ----
 
+[[disable_highlights_for_specific_nicks]]
+=== How can I disable highlights for specific nicks?
+With WeeChat ≥ 0.3.4 you can use the link:weechat_user.en.html#max_hotlist_level_nicks[hotlist_max_level_nicks_add] buffer property to set the max hotlist level for some nicks, per buffer, or per group of buffers (like IRC servers). To only disable highlights, you'd have to set it to `2`:
+
+----
+/buffer set hotlist_max_level_nicks_add joe:2,mike:2
+----
+
+This buffer property isn't stored in the configuration though. To automatically reapply these buffer properties, you would need the `buffer_autoset.py` script. For example, to permanently disable highlights from 'mike' on #weechat on the IRC server freenode:
+
+----
+/buffer_autoset add irc.freenode.#weechat hotlist_max_level_nicks_add mike:2
+----
+
+To apply it to the entire freenode server instead:
+
+----
+/buffer_autoset add irc.freenode hotlist_max_level_nicks_add mike:2
+----
+
+
+For more buffer_autoset examples, see `/help buffer_autoset`
+
 [[irc_target_buffer]]
 === How can I change target buffer for commands on merged buffers (like buffer with servers)?
 


### PR DESCRIPTION
I decided to add it to the FAQ, since this question popped up again earlier today on #weechat on IRC:

```
13:25:10    <some_weirdo> hi. what's the command to disable nick hilighting only from specific nicks                        
13:46:49         <FiXato> some_weirdo: https://weechat.org/files/doc/stable/weechat_user.en.html#max_hotlist_level_nicks    
13:46:59        <@nils_2> see docs for hotlist_max_level_nicks                                                              
13:47:08    <some_weirdo> ahh. thanks                                                                                       
```