### PR TITLE
irc: restore away status and message when connecting to away ZNC (#1059) 

### DIFF
--- a/src/plugins/irc/irc-protocol.c
+++ b/src/plugins/irc/irc-protocol.c
@@ -3107,6 +3107,8 @@ IRC_PROTOCOL_CALLBACK(305)
     server->is_away = 0;
     server->away_time = 0;
 
+    /* refresh localvars and bar item */
+    irc_server_set_away (server, server->nick, 0);
     weechat_bar_item_update ("away");
 
     return WEECHAT_RC_OK;

--- a/src/plugins/irc/irc-protocol.c
+++ b/src/plugins/irc/irc-protocol.c
@@ -56,6 +56,7 @@
 #include "irc-sasl.h"
 #include "irc-server.h"
 #include "irc-notify.h"
+#include "irc-redirect.h"
 
 
 /*
@@ -3137,6 +3138,12 @@ IRC_PROTOCOL_CALLBACK(306)
     server->is_away = 1;
     server->away_time = time (NULL);
 
+    /* whois own nick to get away message */
+    irc_redirect_new (server, "whois", "away", 1, server->nick, 0, "301");
+    irc_server_sendf (server, IRC_SERVER_SEND_OUTQ_PRIO_LOW, NULL,
+                      "WHOIS :%s", server->nick);
+
+    /* refresh bar item */
     weechat_bar_item_update ("away");
 
     return WEECHAT_RC_OK;

--- a/src/plugins/irc/irc-server.h
+++ b/src/plugins/irc/irc-server.h
@@ -358,6 +358,9 @@ extern void irc_server_set_away (struct t_irc_server *server, const char *nick,
                                  int is_away);
 extern void irc_server_remove_away (struct t_irc_server *server);
 extern void irc_server_check_away (struct t_irc_server *server);
+extern int irc_server_away_whois_cb (const void *pointer, void *data,
+                                     const char *signal,
+                                     struct t_hashtable *hashtable);
 extern void irc_server_switch_address (struct t_irc_server *server,
                                        int connection);
 extern void irc_server_disconnect (struct t_irc_server *server,

--- a/src/plugins/irc/irc.c
+++ b/src/plugins/irc/irc.c
@@ -202,6 +202,9 @@ weechat_plugin_init (struct t_weechat_plugin *plugin, int argc, char *argv[])
     weechat_hook_hsignal ("irc_redirect_command",
                           &irc_redirect_command_hsignal_cb, NULL, NULL);
 
+    weechat_hook_hsignal ("irc_redirection_away_whois",
+                          &irc_server_away_whois_cb, NULL, NULL);
+
     /* modifiers */
     weechat_hook_modifier ("irc_color_decode",
                            &irc_color_modifier_cb, NULL, NULL);


### PR DESCRIPTION
This PR is a fix for #1059. When numeric 306 is received (from ZNC on connection when away), WHOIS is requested on own nick using irc redirection to get the away message from numeric 301. Properly set away message is necessary for away bar item to actually show anything.

This implementation is not perfect because every 306 is followed by a WHOIS, even when using `/away` manually. Visually there's no difference but there is the added overhead of a single WHOIS request. Maybe additional conditions should be in place to only do the WHOIS when the 306 isn't the result of manual away change.

Also I did not test with `away-notify` capability which maybe makes this WHOIS trickery unnecessary.