### PR TITLE
Fix czech translation kick message

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -9124,11 +9124,11 @@ msgstr "%s%s%s%s%s%s%s%s%s%s opustil %s%s%s"
 
 #, c-format
 msgid "%s%s%s%s has kicked %s%s%s %s(%s%s%s)"
-msgstr "%s%s%s%s byl vykopnut %s%s%s %s(%s%s%s)"
+msgstr "%s%s%s%s vykopnul %s%s%s %s(%s%s%s)"
 
 #, c-format
 msgid "%s%s%s%s has kicked %s%s%s"
-msgstr "%s%s%s%s byl vykopnut %s%s%s"
+msgstr "%s%s%s%s vykopnul %s%s%s"
 
 #, c-format
 msgid "%s%sYou were killed by %s%s%s %s(%s%s%s)"


### PR DESCRIPTION
original: <op> byl vykopnut <user> results in confusing message caused by mistranslation: op was kicked user
proposed fix: <op> vykopnul <user> should result in more understandeable message: op has kicked user