### PR TITLE
gui: only refilter affected buffers on filter change

### DIFF
--- a/src/core/wee-command.c
+++ b/src/core/wee-command.c
@@ -2177,7 +2177,7 @@ COMMAND_CALLBACK(filter)
                     if (!ptr_filter->enabled)
                     {
                         ptr_filter->enabled = 1;
-                        gui_filter_all_buffers ();
+                        gui_filter_all_buffers (ptr_filter);
                         gui_chat_printf_date_tags (NULL, 0,
                                                    GUI_FILTER_TAG_NO_FILTER,
                                                    _("Filter \"%s\" enabled"),
@@ -2235,7 +2235,7 @@ COMMAND_CALLBACK(filter)
                     if (ptr_filter->enabled)
                     {
                         ptr_filter->enabled = 0;
-                        gui_filter_all_buffers ();
+                        gui_filter_all_buffers (ptr_filter);
                         gui_chat_printf_date_tags (NULL, 0,
                                                    GUI_FILTER_TAG_NO_FILTER,
                                                    _("Filter \"%s\" disabled"),
@@ -2289,7 +2289,7 @@ COMMAND_CALLBACK(filter)
                 if (ptr_filter)
                 {
                     ptr_filter->enabled ^= 1;
-                    gui_filter_all_buffers ();
+                    gui_filter_all_buffers (ptr_filter);
                 }
                 else
                 {
@@ -2330,7 +2330,7 @@ COMMAND_CALLBACK(filter)
                                      argv_eol[5]);
         if (ptr_filter)
         {
-            gui_filter_all_buffers ();
+            gui_filter_all_buffers (ptr_filter);
             gui_chat_printf (NULL, "");
             gui_chat_printf_date_tags (NULL, 0, GUI_FILTER_TAG_NO_FILTER,
                                        _("Filter \"%s\" added:"),
@@ -2384,7 +2384,7 @@ COMMAND_CALLBACK(filter)
             if (gui_filters)
             {
                 gui_filter_free_all ();
-                gui_filter_all_buffers ();
+                gui_filter_all_buffers (NULL);
                 gui_chat_printf_date_tags (NULL, 0, GUI_FILTER_TAG_NO_FILTER,
                                            _("All filters have been deleted"));
             }
@@ -2400,7 +2400,7 @@ COMMAND_CALLBACK(filter)
             if (ptr_filter)
             {
                 gui_filter_free (ptr_filter);
-                gui_filter_all_buffers ();
+                gui_filter_all_buffers (ptr_filter);
                 gui_chat_printf_date_tags (NULL, 0, GUI_FILTER_TAG_NO_FILTER,
                                            _("Filter \"%s\" deleted"),
                                            argv[2]);

--- a/src/core/wee-command.c
+++ b/src/core/wee-command.c
@@ -2399,8 +2399,9 @@ COMMAND_CALLBACK(filter)
             ptr_filter = gui_filter_search_by_name (argv[2]);
             if (ptr_filter)
             {
+                ptr_filter->enabled = 0; // disable before refilter
+                gui_filter_all_buffers (ptr_filter); // refilter before free
                 gui_filter_free (ptr_filter);
-                gui_filter_all_buffers (ptr_filter);
                 gui_chat_printf_date_tags (NULL, 0, GUI_FILTER_TAG_NO_FILTER,
                                            _("Filter \"%s\" deleted"),
                                            argv[2]);

--- a/src/core/wee-config.c
+++ b/src/core/wee-config.c
@@ -1359,7 +1359,7 @@ config_weechat_init_after_read ()
     }
 
     /* apply filters on all buffers */
-    gui_filter_all_buffers ();
+    gui_filter_all_buffers (NULL);
 
     config_change_look_nick_color_force (NULL, NULL, NULL);
 }

--- a/src/gui/gui-filter.c
+++ b/src/gui/gui-filter.c
@@ -186,17 +186,26 @@ gui_filter_buffer (struct t_gui_buffer *buffer,
 
 /*
  * Filters all buffers, using message filters.
+ *
+ * If filter is NULL, filters all buffers.
+ * If filter is not NULL, filters only buffers matched by this filter.
  */
 
 void
-gui_filter_all_buffers ()
+gui_filter_all_buffers (struct t_gui_filter *filter)
 {
     struct t_gui_buffer *ptr_buffer;
 
     for (ptr_buffer = gui_buffers; ptr_buffer;
          ptr_buffer = ptr_buffer->next_buffer)
     {
-        gui_filter_buffer (ptr_buffer, NULL);
+        if (!filter
+            || gui_buffer_match_list_split (ptr_buffer,
+                                            filter->num_buffers,
+                                            filter->buffers))
+        {
+            gui_filter_buffer (ptr_buffer, NULL);
+        }
     }
 }
 
@@ -210,7 +219,7 @@ gui_filter_global_enable ()
     if (!gui_filters_enabled)
     {
         gui_filters_enabled = 1;
-        gui_filter_all_buffers ();
+        gui_filter_all_buffers (NULL);
         (void) hook_signal_send ("filters_enabled",
                                  WEECHAT_HOOK_SIGNAL_STRING, NULL);
     }
@@ -226,7 +235,7 @@ gui_filter_global_disable ()
     if (gui_filters_enabled)
     {
         gui_filters_enabled = 0;
-        gui_filter_all_buffers ();
+        gui_filter_all_buffers (NULL);
         (void) hook_signal_send ("filters_disabled",
                                  WEECHAT_HOOK_SIGNAL_STRING, NULL);
     }

--- a/src/gui/gui-filter.h
+++ b/src/gui/gui-filter.h
@@ -56,7 +56,7 @@ extern int gui_filters_enabled;
 extern int gui_filter_check_line (struct t_gui_line_data *line_data);
 extern void gui_filter_buffer (struct t_gui_buffer *buffer,
                                struct t_gui_line_data *line_data);
-extern void gui_filter_all_buffers ();
+extern void gui_filter_all_buffers (struct t_gui_filter *filter);
 extern void gui_filter_global_enable ();
 extern void gui_filter_global_disable ();
 extern struct t_gui_filter *gui_filter_search_by_name (const char *name);


### PR DESCRIPTION
Implemented my suggested solution from #1309: `gui_filter_all_buffers` now has an optional `t_gui_filter*` argument to only refilter buffers which the specified filter affects.

My testing confirms that adding/enabling/toggling/disabling/removing filters which affect one buffer is significantly faster, enough to turn `grep_filter.py` from unbearably slow to essentially instant.