### PR TITLE
irc: quote argument to NICK

### DIFF
--- a/src/plugins/irc/irc-command.c
+++ b/src/plugins/irc/irc-command.c
@@ -3489,7 +3489,7 @@ irc_send_nick_server (struct t_irc_server *server, const char *nickname)
     if (server->is_connected)
     {
         irc_server_sendf (server, IRC_SERVER_SEND_OUTQ_PRIO_HIGH, NULL,
-                          "NICK %s", nickname);
+                          "NICK :%s", nickname);
     }
     else
         irc_server_set_nick (server, nickname);

--- a/src/plugins/irc/irc-protocol.c
+++ b/src/plugins/irc/irc-protocol.c
@@ -5336,7 +5336,7 @@ IRC_PROTOCOL_CALLBACK(432)
 
         irc_server_set_nick (server, alternate_nick);
 
-        irc_server_sendf (server, 0, NULL, "NICK %s", server->nick);
+        irc_server_sendf (server, 0, NULL, "NICK :%s", server->nick);
     }
 
     return WEECHAT_RC_OK;
@@ -5380,7 +5380,7 @@ IRC_PROTOCOL_CALLBACK(433)
 
         irc_server_set_nick (server, alternate_nick);
 
-        irc_server_sendf (server, 0, NULL, "NICK %s", server->nick);
+        irc_server_sendf (server, 0, NULL, "NICK :%s", server->nick);
     }
     else
     {
@@ -5438,7 +5438,7 @@ IRC_PROTOCOL_CALLBACK(437)
 
             irc_server_set_nick (server, alternate_nick);
 
-            irc_server_sendf (server, 0, NULL, "NICK %s", server->nick);
+            irc_server_sendf (server, 0, NULL, "NICK :%s", server->nick);
         }
     }
 

--- a/src/plugins/irc/irc-server.c
+++ b/src/plugins/irc/irc-server.c
@@ -3686,7 +3686,7 @@ irc_server_login (struct t_irc_server *server)
         weechat_string_replace (username, " ", "_") : strdup ("weechat");
     irc_server_sendf (
         server, 0, NULL,
-        "NICK %s\n"
+        "NICK :%s\n"
         "USER %s 0 * :%s",
         server->nick,
         (username2) ? username2 : "weechat",


### PR DESCRIPTION
`/nick :)` results in the user's nick being changed to `)` rather than a server error. Use : before %s in each `NICK` command to avoid this.