### PR TITLE
relay: UNIX socket support (implement #733)

### DIFF
--- a/doc/en/weechat_user.en.adoc
+++ b/doc/en/weechat_user.en.adoc
@@ -3197,11 +3197,11 @@ The URI must always end with "/weechat" (for _irc_ and _weechat_ protocols).
 [[relay_unixsocket]]
 ==== UNIX domain sockets
 
-Using the protocol option "un" and the "/relay addpath" command, you can
+Using the protocol option "unix" with the "/relay add"  command, you can
 listen using any protocol on a UNIX domain socket at a given path. For exmaple:
 
 ----
-/relay addpath un.weechat /tmp/weesock
+/relay add unix.weechat /tmp/weesock
 ----
 
 will allow clients to connect using the WeeChat protocol to /tmp/weesock. This

--- a/doc/en/weechat_user.en.adoc
+++ b/doc/en/weechat_user.en.adoc
@@ -3194,6 +3194,27 @@ websocket = new WebSocket("ws://server.com:9000/weechat");
 The port (9000 in example) is the port defined in Relay plugin.
 The URI must always end with "/weechat" (for _irc_ and _weechat_ protocols).
 
+[[relay_unixsocket]]
+==== UNIX domain sockets
+
+Using the protocol option "un" and the "/relay addpath" command, you can
+listen using any protocol on a UNIX domain socket at a given path. For exmaple:
+
+----
+/relay addpath un.weechat /tmp/weesock
+----
+
+will allow clients to connect using the WeeChat protocol to /tmp/weesock. This
+is particularly useful to allow SSH forwarding for relay clients, when other
+ports cannot be opened. Using OpenSSH:
+
+----
+$ ssh -L9000:/tmp/weesock foo_host
+----
+
+will then allow for local relay clients to connect on port 9000 to a WeeChat
+instance running on "foo_host".
+
 [[relay_commands]]
 ==== Commands
 

--- a/src/plugins/relay/relay-client.c
+++ b/src/plugins/relay/relay-client.c
@@ -1355,7 +1355,7 @@ relay_client_new (int sock, const char *address, struct t_relay_server *server)
         relay_clients = new_client;
 
         weechat_printf_date_tags (NULL, 0, "relay_client",
-                                  _("%s: new client on port %s: %s%s%s"),
+                                  _("%s: new client on port/path %s: %s%s%s"),
                                   RELAY_PLUGIN_NAME,
                                   server->path,
                                   RELAY_COLOR_CHAT_CLIENT,

--- a/src/plugins/relay/relay-client.c
+++ b/src/plugins/relay/relay-client.c
@@ -1355,9 +1355,9 @@ relay_client_new (int sock, const char *address, struct t_relay_server *server)
         relay_clients = new_client;
 
         weechat_printf_date_tags (NULL, 0, "relay_client",
-                                  _("%s: new client on port %d: %s%s%s"),
+                                  _("%s: new client on port %s: %s%s%s"),
                                   RELAY_PLUGIN_NAME,
-                                  server->port,
+                                  server->path,
                                   RELAY_COLOR_CHAT_CLIENT,
                                   new_client->desc,
                                   RELAY_COLOR_CHAT);

--- a/src/plugins/relay/relay-config.c
+++ b/src/plugins/relay/relay-config.c
@@ -698,8 +698,6 @@ relay_config_create_option_port (const void *pointer, void *data,
     {
         if (un)
         {
-            /* find dummy port for use with unix */
-            for (port = -1; relay_server_search_port ((int)port); --port);
             ptr_server = relay_server_search_path (value);
         }
         else
@@ -713,7 +711,7 @@ relay_config_create_option_port (const void *pointer, void *data,
             weechat_printf (NULL, _("%s%s: error: %s \"%s\" is already used"),
                             weechat_prefix ("error"),
                             RELAY_PLUGIN_NAME,
-                            un ? "path" : "port",
+                            un ? _("path") : _("port"),
                             value);
             rc = WEECHAT_CONFIG_OPTION_SET_ERROR;
         }

--- a/src/plugins/relay/relay-config.h
+++ b/src/plugins/relay/relay-config.h
@@ -26,6 +26,7 @@
 
 extern struct t_config_file *relay_config_file;
 extern struct t_config_section *relay_config_section_port;
+extern struct t_config_section *relay_config_section_path;
 
 extern struct t_config_option *relay_config_look_auto_open_buffer;
 extern struct t_config_option *relay_config_look_raw_messages;
@@ -39,6 +40,7 @@ extern struct t_config_option *relay_config_color_text_selected;
 extern struct t_config_option *relay_config_network_allow_empty_password;
 extern struct t_config_option *relay_config_network_allowed_ips;
 extern struct t_config_option *relay_config_network_bind_address;
+extern struct t_config_option *relay_config_network_unix_bind_path;
 extern struct t_config_option *relay_config_network_clients_purge_delay;
 extern struct t_config_option *relay_config_network_compression_level;
 extern struct t_config_option *relay_config_network_ipv6;
@@ -72,6 +74,7 @@ extern int relay_config_create_option_port (const void *pointer, void *data,
                                             struct t_config_section *section,
                                             const char *option_name,
                                             const char *value);
+extern int relay_config_check_path_len (const char *path);
 extern int relay_config_init ();
 extern int relay_config_read ();
 extern int relay_config_write ();

--- a/src/plugins/relay/relay-config.h
+++ b/src/plugins/relay/relay-config.h
@@ -40,7 +40,6 @@ extern struct t_config_option *relay_config_color_text_selected;
 extern struct t_config_option *relay_config_network_allow_empty_password;
 extern struct t_config_option *relay_config_network_allowed_ips;
 extern struct t_config_option *relay_config_network_bind_address;
-extern struct t_config_option *relay_config_network_unix_bind_path;
 extern struct t_config_option *relay_config_network_clients_purge_delay;
 extern struct t_config_option *relay_config_network_compression_level;
 extern struct t_config_option *relay_config_network_ipv6;

--- a/src/plugins/relay/relay-server.c
+++ b/src/plugins/relay/relay-server.c
@@ -528,7 +528,7 @@ relay_server_create_socket (struct t_relay_server *server)
     else
     {
         domain = AF_UNIX;
-        memset (&server_addr, 0, sizeof (struct sockaddr_un));
+        memset (&server_addr_un, 0, sizeof (struct sockaddr_un));
         server_addr_un.sun_family = domain;
         strncpy (server_addr_un.sun_path, server->path,
                  sizeof (server_addr_un.sun_path));

--- a/src/plugins/relay/relay-server.h
+++ b/src/plugins/relay/relay-server.h
@@ -21,7 +21,6 @@
 #define WEECHAT_PLUGIN_RELAY_SERVER_H
 
 #include <time.h>
-
 #ifdef HAVE_GNUTLS
 #define RELAY_SERVER_GNUTLS_DH_BITS 1024
 #endif /* HAVE_GNUTLS */
@@ -33,9 +32,14 @@ struct t_relay_server
     char *protocol_args;               /* arguments used for protocol       */
                                        /* example: server for irc protocol  */
     int port;                          /* listening on this port            */
+                                       /* or UNIX socket, if negative.      */
+    char *path;                        /* listening on this path (UNIX)     */
+                                       /* contains string representation of */
+                                       /* port if IP */
     int ipv4;                          /* IPv4 protocol enabled             */
     int ipv6;                          /* IPv6 protocol enabled             */
     int ssl;                           /* 1 if SSL is enabled               */
+    int un;                            /* 1 if UNIX socket                  */
     int sock;                          /* socket for connection             */
     struct t_hook *hook_fd;            /* hook for socket                   */
     time_t start_time;                 /* start time                        */
@@ -49,18 +53,20 @@ extern struct t_relay_server *last_relay_server;
 
 extern void relay_server_get_protocol_args (const char *protocol_and_string,
                                             int *ipv4, int *ipv6,
-                                            int *ssl,
+                                            int *ssl, int *un,
                                             char **protocol,
                                             char **protocol_args);
 extern struct t_relay_server *relay_server_search (const char *protocol_and_args);
 extern struct t_relay_server *relay_server_search_port (int port);
+extern struct t_relay_server *relay_server_search_path (const char *path);
 extern void relay_server_close_socket (struct t_relay_server *server);
 extern int relay_server_create_socket (struct t_relay_server *server);
 extern struct t_relay_server *relay_server_new (const char *protocol_string,
                                                 enum t_relay_protocol protocol,
                                                 const char *protocol_args,
-                                                int port, int ipv4, int ipv6,
-                                                int ssl);
+                                                int port, const char *path,
+                                                int ipv4, int ipv6,
+                                                int ssl, int un);
 extern void relay_server_update_port (struct t_relay_server *server, int port);
 extern void relay_server_free (struct t_relay_server *server);
 extern void relay_server_free_all ();


### PR DESCRIPTION
This adds support for relay servers listening on UNIX domain sockets.
They can be created using the /relay addpath command and specifying the
un protocol option. 'path' is now used instead of 'port' in messages,
which contains either a string representation of the port or the path to
a socket; port is negative when a UNIX socket is used. Path based relays
are stored in their own config section, with existing callbacks reused
as much as possible. Documentation has been updated as well.