### PR TITLE
quick start guide: rearrange content in section 2

### DIFF
--- a/doc/en/weechat_quickstart.en.adoc
+++ b/doc/en/weechat_quickstart.en.adoc
@@ -34,15 +34,21 @@ To get help on a specific command, issue:
 /help command
 ----
 
-To set options, issue:
+Help is available for options as well:
 
 ----
-/set config.section.option value
+/help config.section.option
 ----
 
 (where `config` is configuration name (`weechat` for core, or a plugin
 name), `section` the section of this configuration and `option` the
 option name).
+
+To set options, issue:
+
+----
+/set config.section.option value
+----
 
 WeeChat immediately uses the new value (you *never* need to restart WeeChat
 after changes to configuration).
@@ -57,12 +63,6 @@ you must run the command `/reload` (with the risk of losing other changes
 that were not yet saved with `/save`). +
 You can use the command `/set`, which checks the value and applies immediately
 the changes.
-
-Help is available for options:
-
-----
-/help config.section.option
-----
 
 The plugin _fset_ allows you to easily browse options and change them.
 


### PR DESCRIPTION
Put everything help-related first, then explain how to set options.