### PR TITLE
gui: support up to 32767 ncurses color pairs (issue #1343)

### DIFF
--- a/cmake/FindNcurses.cmake
+++ b/cmake/FindNcurses.cmake
@@ -23,14 +23,22 @@ endif()
 
 find_path(NCURSES_INCLUDE_PATH
   NAMES ncurses.h curses.h
-  PATHS /usr/include/ncursesw /usr/include/ncurses /usr/include
-  /usr/local/include/ncursesw /usr/local/include/ncurses /usr/local/include
+  PATHS /usr/local/include/ncursesw /usr/local/include/ncurses /usr/local/include
   /usr/pkg/include/ncursesw /usr/pkg/include/ncurses /usr/pkg/include
+  /usr/include/ncursesw /usr/include/ncurses /usr/include
+  NO_DEFAULT_PATH
+)
+find_path(NCURSES_INCLUDE_PATH
+  NAMES ncurses.h curses.h
 )
 
 find_library(NCURSESW_LIBRARY
   NAMES ncursesw
-  PATHS /lib /usr/lib /usr/local/lib /usr/pkg/lib
+  PATHS /usr/local/lib /usr/pkg/lib /usr/lib /lib
+  NO_DEFAULT_PATH
+)
+find_library(NCURSESW_LIBRARY
+  NAMES ncursesw
 )
 
 if(NCURSESW_LIBRARY)
@@ -43,7 +51,11 @@ if(NCURSESW_LIBRARY)
 else()
   find_library(NCURSES_LIBRARY
     NAMES ncurses
-    PATHS /lib /usr/lib /usr/local/lib /usr/pkg/lib
+    PATHS /usr/local/lib /usr/pkg/lib /usr/lib /lib
+    NO_DEFAULT_PATH
+  )
+  find_library(NCURSES_LIBRARY
+    NAMES ncurses
   )
   find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)

--- a/cmake/FindNcurses.cmake
+++ b/cmake/FindNcurses.cmake
@@ -23,22 +23,13 @@ endif()
 
 find_path(NCURSES_INCLUDE_PATH
   NAMES ncurses.h curses.h
-  PATHS /usr/local/include/ncursesw /usr/local/include/ncurses /usr/local/include
-  /usr/pkg/include/ncursesw /usr/pkg/include/ncurses /usr/pkg/include
-  /usr/include/ncursesw /usr/include/ncurses /usr/include
-  NO_DEFAULT_PATH
-)
-find_path(NCURSES_INCLUDE_PATH
-  NAMES ncurses.h curses.h
+  PATH_SUFFIXES ncursesw ncurses
+  PATHS /usr/include /usr/local/include /usr/pkg/include
 )
 
 find_library(NCURSESW_LIBRARY
   NAMES ncursesw
-  PATHS /usr/local/lib /usr/pkg/lib /usr/lib /lib
-  NO_DEFAULT_PATH
-)
-find_library(NCURSESW_LIBRARY
-  NAMES ncursesw
+  PATHS /lib /usr/lib /usr/local/lib /usr/pkg/lib
 )
 
 if(NCURSESW_LIBRARY)
@@ -51,11 +42,7 @@ if(NCURSESW_LIBRARY)
 else()
   find_library(NCURSES_LIBRARY
     NAMES ncurses
-    PATHS /usr/local/lib /usr/pkg/lib /usr/lib /lib
-    NO_DEFAULT_PATH
-  )
-  find_library(NCURSES_LIBRARY
-    NAMES ncurses
+    PATHS /lib /usr/lib /usr/local/lib /usr/pkg/lib
   )
   find_package(PkgConfig QUIET)
   if(PKG_CONFIG_FOUND)

--- a/src/gui/curses/gui-curses-color.c
+++ b/src/gui/curses/gui-curses-color.c
@@ -793,7 +793,7 @@ gui_color_info_term_colors (char *buffer, int size)
 void
 gui_color_buffer_display ()
 {
-    int y, i, lines, line, col, color, max_color, num_items;
+    int y, i, lines, columns, line, col, color, max_color, num_items;
     char str_line[1024], str_color[64], str_rgb[64], **items;
     struct t_gui_color_palette *color_palette;
 
@@ -830,17 +830,16 @@ gui_color_buffer_display ()
                            gui_color_pairs_used,
                            gui_color_num_pairs - gui_color_pairs_used);
     }
+    columns = 16;
     max_color = (gui_color_use_term_colors) ?
-        gui_color_term_colors - 1 : gui_color_num_pairs;
-    if (max_color > 255)
-        max_color = 255;
-    lines = (max_color <= 64) ? 8 : 16;
+        gui_color_term_colors - 1 : gui_color_pairs_used;
+    lines = (max_color + columns) / columns;
     for (line = 0; line < lines; line++)
     {
         str_line[0] = '\0';
-        for (col = 0; col < 16; col++)
+        for (col = 0; col < columns; col++)
         {
-            color = (col * lines) + line;
+            color = line * columns + col;
             if (color <= max_color)
             {
                 if (color == 0)
@@ -852,13 +851,11 @@ gui_color_buffer_display ()
                          || (color <= gui_color_pairs_used))
                 {
                     snprintf (str_color, sizeof (str_color),
-                              "%c%c%05d%c%03d%c",
+                              (color <= 999) ? "%c%c%05d %3d " : "%c%c%05d%5d",
                               GUI_COLOR_COLOR_CHAR,
                               GUI_COLOR_EXTENDED_CHAR,
                               color,
-                              (color == 0) ? '<' : ' ',
-                              color,
-                              (color == 0) ? '>' : ' ');
+                              color);
                 }
                 else
                 {

--- a/src/gui/curses/gui-curses-color.c
+++ b/src/gui/curses/gui-curses-color.c
@@ -834,7 +834,9 @@ gui_color_buffer_display ()
     columns = 16;
     max_color = (gui_color_use_term_colors) ?
         gui_color_term_colors - 1 : gui_color_pairs_used;
-    lines = (max_color + columns) / columns;
+    /* round up to nearest multiple of columns */
+    max_color = (max_color / columns) * columns + columns - 1;
+    lines = max_color / columns + 1;
     for (line = 0; line < lines; line++)
     {
         str_line[0] = '\0';
@@ -852,7 +854,7 @@ gui_color_buffer_display ()
                          || (color <= gui_color_pairs_used))
                 {
                     snprintf (str_color, sizeof (str_color),
-                              (color <= 999) ? "%c%c%05d %3d " : "%c%c%05d%5d",
+                              (color <= 999) ? "%c%c%05d %03d " : "%c%c%05d%5d",
                               GUI_COLOR_COLOR_CHAR,
                               GUI_COLOR_EXTENDED_CHAR,
                               color,

--- a/src/gui/curses/gui-curses-color.c
+++ b/src/gui/curses/gui-curses-color.c
@@ -700,7 +700,7 @@ gui_color_init_pairs_weechat ()
 void
 gui_color_display_terminal_colors ()
 {
-    int lines, line, col, color;
+    int lines, columns, line, col, color;
     char str_line[1024], str_color[64];
 
     initscr ();
@@ -728,13 +728,14 @@ gui_color_display_terminal_colors ()
         printf ("%s\n", _("Default colors:"));
         printf ("------------------------------------------------------------"
                 "--------------------\n");
-        lines = (gui_color_term_colors < 16) ? gui_color_term_colors : 16;
+        columns = 16;
+        lines = (gui_color_term_colors - 1) / columns + 1;
         for (line = 0; line < lines; line++)
         {
             str_line[0] = '\0';
-            for (col = 0; col < 16; col++)
+            for (col = 0; col < columns; col++)
             {
-                color = (col * 16) + line;
+                color = line * columns + col;
                 if (color < gui_color_term_colors)
                 {
                     snprintf (str_color, sizeof (str_color),

--- a/src/gui/curses/gui-curses-color.c
+++ b/src/gui/curses/gui-curses-color.c
@@ -580,8 +580,9 @@ gui_color_init_vars ()
         gui_color_term_color_pairs = COLOR_PAIRS;
         gui_color_term_can_change_color = (can_change_color ()) ? 1 : 0;
 
-        gui_color_num_pairs = (gui_color_term_color_pairs >= 256) ?
-            255 : gui_color_term_color_pairs - 1;
+        /* TODO: ncurses may support 65536, but short type used for pairs supports only 32768? */
+        gui_color_num_pairs = (gui_color_term_color_pairs >= 32768) ?
+            32767 : gui_color_term_color_pairs - 1;
         size = (gui_color_term_colors + 2)
             * (gui_color_term_colors + 2)
             * sizeof (gui_color_pairs[0]);

--- a/src/gui/curses/gui-curses-window.c
+++ b/src/gui/curses/gui-curses-window.c
@@ -193,9 +193,13 @@ gui_window_clear (WINDOW *window, int fg, int bg)
     else
         bg = gui_weechat_colors[bg & GUI_COLOR_EXTENDED_MASK].background;
 
+#ifdef NCURSES_EXT_COLORS
     cchar_t c;
     setcchar (&c, L" ", attrs, gui_color_get_pair (fg, bg), NULL);
     wbkgrndset (window, &c);
+#else
+    wbkgdset (window, ' ' | COLOR_PAIR (gui_color_get_pair (fg, bg)) | attrs);
+#endif
     werase (window);
     wmove (window, 0, 0);
 }
@@ -207,10 +211,16 @@ gui_window_clear (WINDOW *window, int fg, int bg)
 void
 gui_window_clrtoeol (WINDOW *window)
 {
+#ifdef NCURSES_EXT_COLORS
     cchar_t c;
     setcchar (&c, L" ", A_NORMAL, gui_color_get_pair (gui_window_current_style_fg,
                                                       gui_window_current_style_bg), NULL);
     wbkgrndset (window, &c);
+#else
+    wbkgdset (window,
+              ' ' | COLOR_PAIR (gui_color_get_pair (gui_window_current_style_fg,
+                                                    gui_window_current_style_bg)));
+#endif
     wclrtoeol (window);
 }
 

--- a/src/gui/curses/gui-curses-window.c
+++ b/src/gui/curses/gui-curses-window.c
@@ -193,7 +193,9 @@ gui_window_clear (WINDOW *window, int fg, int bg)
     else
         bg = gui_weechat_colors[bg & GUI_COLOR_EXTENDED_MASK].background;
 
-    wbkgdset (window, ' ' | COLOR_PAIR (gui_color_get_pair (fg, bg)) | attrs);
+    cchar_t c;
+    setcchar (&c, L" ", attrs, gui_color_get_pair (fg, bg), NULL);
+    wbkgrndset (window, &c);
     werase (window);
     wmove (window, 0, 0);
 }
@@ -205,9 +207,10 @@ gui_window_clear (WINDOW *window, int fg, int bg)
 void
 gui_window_clrtoeol (WINDOW *window)
 {
-    wbkgdset (window,
-              ' ' | COLOR_PAIR (gui_color_get_pair (gui_window_current_style_fg,
-                                                    gui_window_current_style_bg)));
+    cchar_t c;
+    setcchar (&c, L" ", A_NORMAL, gui_color_get_pair (gui_window_current_style_fg,
+                                                      gui_window_current_style_bg), NULL);
+    wbkgrndset (window, &c);
     wclrtoeol (window);
 }
 
@@ -282,9 +285,8 @@ gui_window_reset_style (WINDOW *window, int weechat_color)
     gui_window_current_style_bg = -1;
     gui_window_current_color_attr = 0;
 
-    wattroff (window, A_ALL_ATTR);
-    wattron (window, COLOR_PAIR(gui_color_weechat_get_pair (weechat_color)) |
-             gui_color[weechat_color]->attributes);
+    wattr_set (window, gui_color[weechat_color]->attributes,
+               gui_color_weechat_get_pair (weechat_color), NULL);
 }
 
 /*
@@ -297,8 +299,8 @@ gui_window_reset_color (WINDOW *window, int weechat_color)
     gui_window_current_style_fg = gui_color[weechat_color]->foreground;
     gui_window_current_style_bg = gui_color[weechat_color]->background;
 
-    wattron (window, COLOR_PAIR(gui_color_weechat_get_pair (weechat_color)) |
-             gui_color[weechat_color]->attributes);
+    wattron (window, gui_color[weechat_color]->attributes);
+    wcolor_set (window, gui_color_weechat_get_pair (weechat_color), NULL);
 }
 
 /*
@@ -333,7 +335,7 @@ gui_window_set_color (WINDOW *window, int fg, int bg)
     gui_window_current_style_fg = fg;
     gui_window_current_style_bg = bg;
 
-    wattron (window, COLOR_PAIR(gui_color_get_pair (fg, bg)));
+    wcolor_set (window, gui_color_get_pair (fg, bg), NULL);
 }
 
 /*
@@ -532,7 +534,7 @@ gui_window_set_custom_color_pair (WINDOW *window, int pair)
     if ((pair >= 0) && (pair <= gui_color_num_pairs))
     {
         gui_window_remove_color_style (window, A_ALL_ATTR);
-        wattron (window, COLOR_PAIR(pair));
+        wcolor_set (window, pair, NULL);
     }
 }
 

--- a/src/gui/curses/gui-curses.h
+++ b/src/gui/curses/gui-curses.h
@@ -25,6 +25,7 @@
 #ifdef WEECHAT_HEADLESS
 #include "ncurses-fake.h"
 #else
+#define NCURSES_WIDECHAR 1
 #ifdef HAVE_NCURSESW_CURSES_H
 #include <ncursesw/ncurses.h>
 #elif HAVE_NCURSES_H

--- a/src/gui/curses/headless/ncurses-fake.c
+++ b/src/gui/curses/headless/ncurses-fake.c
@@ -317,6 +317,25 @@ wbkgdset (WINDOW *win, chtype ch)
 }
 
 void
+wbkgrndset (WINDOW *win, const cchar_t *wcval)
+{
+    (void) win;
+    (void) wcval;
+}
+
+int
+setcchar (cchar_t *wcval, const wchar_t *wch, attr_t attrs, short pair, const void *opts)
+{
+    (void) wcval;
+    (void) wch;
+    (void) attrs;
+    (void) pair;
+    (void) opts;
+
+    return OK;
+}
+
+void
 wchgat (WINDOW *win, int n, attr_t attr, short color, const void *opts)
 {
     (void) win;

--- a/src/gui/curses/headless/ncurses-fake.h
+++ b/src/gui/curses/headless/ncurses-fake.h
@@ -20,6 +20,8 @@
 #ifndef WEECHAT_NCURSES_FAKE_H
 #define WEECHAT_NCURSES_FAKE_H
 
+#include <stddef.h>
+
 #define ERR (-1)
 #define OK  (0)
 
@@ -42,6 +44,7 @@
 #define COLOR_CYAN	6
 #define COLOR_WHITE	7
 
+#define A_NORMAL 0
 #define A_BOLD 0
 #define A_UNDERLINE 0
 #define A_REVERSE 0
@@ -69,6 +72,11 @@ typedef struct _window WINDOW;
 typedef unsigned char bool;
 typedef int attr_t;
 typedef unsigned chtype;
+
+struct _cchar_t
+{
+};
+typedef struct _cchar_t cchar_t;
 
 extern WINDOW *stdscr;
 extern chtype acs_map[];
@@ -107,6 +115,8 @@ extern int curs_set (int visibility);
 extern int nodelay (WINDOW *win, bool bf);
 extern int werase (WINDOW *win);
 extern int wbkgdset (WINDOW *win, chtype ch);
+extern void wbkgrndset (WINDOW *win, const cchar_t *wcval);
+extern int setcchar (cchar_t *wcval, const wchar_t *wch, attr_t attrs, short pair, const void *opts);
 extern void wchgat (WINDOW *win, int n, attr_t attr, short color,
                     const void *opts);
 extern int mvwchgat (WINDOW *win, int y, int x, int n, attr_t attr, short pair,


### PR DESCRIPTION
This PR fixes issue #1343:
1. All uses of the problematic `COLOR_PAIR` macro replaced with functions that allow up to 32767 color pairs (`short` datatype size limit in both the ncurses functions and WeeChat's color pair table).
2. Transposed the color table in `/color` buffer (and command line option `-c`) to sensibly allow showing more than 255 pairs.

For testing I used my [`colorspam.py`](https://gist.github.com/sim642/dde23725f23907bc960fce308ecda4f1) script.

Needs to be verified that the `setcchar` function with its `wchar_t*` argument is usable in all curses setups. Could be that this needs to be put behind a preprocessor flag to work on curses libraries without wide char support or something like that.