### PR TITLE
brew install does not take params any longer

### DIFF
--- a/doc/de/weechat_faq.de.adoc
+++ b/doc/de/weechat_faq.de.adoc
@@ -79,7 +79,7 @@ brew info weechat
 WeeChat kann durch folgenden Befehl installiert werden:
 
 ----
-brew install weechat --with-aspell --with-curl --with-python --with-perl --with-ruby --with-lua --with-guile
+brew install weechat
 ----
 
 [[lost]]

--- a/doc/en/weechat_faq.en.adoc
+++ b/doc/en/weechat_faq.en.adoc
@@ -69,7 +69,7 @@ brew info weechat
 You can install WeeChat with this command:
 
 ----
-brew install weechat --with-aspell --with-curl --with-python --with-perl --with-ruby --with-lua --with-guile
+brew install weechat
 ----
 
 [[lost]]

--- a/doc/fr/weechat_faq.fr.adoc
+++ b/doc/fr/weechat_faq.fr.adoc
@@ -73,7 +73,7 @@ brew info weechat
 Vous pouvez installer WeeChat avec cette commande :
 
 ----
-brew install weechat --with-aspell --with-curl --with-python --with-perl --with-ruby --with-lua --with-guile
+brew install weechat
 ----
 
 [[lost]]

--- a/doc/it/weechat_faq.it.adoc
+++ b/doc/it/weechat_faq.it.adoc
@@ -83,7 +83,7 @@ brew info weechat
 You can install WeeChat with this command:
 
 ----
-brew install weechat --with-aspell --with-curl --with-python --with-perl --with-ruby --with-lua --with-guile
+brew install weechat
 ----
 
 [[lost]]

--- a/doc/ja/weechat_faq.ja.adoc
+++ b/doc/ja/weechat_faq.ja.adoc
@@ -74,7 +74,7 @@ brew info weechat
 以下のコマンドで WeeChat をインストールします:
 
 ----
-brew install weechat --with-aspell --with-curl --with-python --with-perl --with-ruby --with-lua --with-guile
+brew install weechat
 ----
 
 [[lost]]


### PR DESCRIPTION
As of 2 February 2019, Homebrew no longer supports options. https://apple.stackexchange.com/questions/125129/how-do-i-give-options-to-homebrew-install