### PR TITLE
gui: support up to 65535 ncurses color pairs (issue #1343)

### DIFF
--- a/src/gui/curses/gui-curses-window.c
+++ b/src/gui/curses/gui-curses-window.c
@@ -196,7 +196,7 @@ gui_window_clear (WINDOW *window, int fg, int bg)
     pair = gui_color_get_pair (fg, bg);
 #ifdef NCURSES_EXT_COLORS
     cchar_t c;
-    setcchar (&c, L" ", attrs, 0, &pair);
+    setcchar (&c, L" ", attrs, pair, &pair);
     wbkgrndset (window, &c);
 #else
     wbkgdset (window, ' ' | COLOR_PAIR (pair) | attrs);
@@ -218,7 +218,7 @@ gui_window_clrtoeol (WINDOW *window)
                                gui_window_current_style_bg);
 #ifdef NCURSES_EXT_COLORS
     cchar_t c;
-    setcchar (&c, L" ", A_NORMAL, 0, &pair);
+    setcchar (&c, L" ", A_NORMAL, pair, &pair);
     wbkgrndset (window, &c);
 #else
     wbkgdset (window, ' ' | COLOR_PAIR (pair));
@@ -290,7 +290,7 @@ gui_window_restore_style (WINDOW *window)
     gui_window_current_color_attr = ptr_saved_style->color_attr;
     gui_window_current_emphasis = ptr_saved_style->emphasis;
 #ifdef NCURSES_EXT_COLORS
-    wattr_set (window, ptr_saved_style->attrs, 0, &ptr_saved_style->pair);
+    wattr_set (window, ptr_saved_style->attrs, ptr_saved_style->pair, &ptr_saved_style->pair);
 #else
     wattr_set (window, ptr_saved_style->attrs, ptr_saved_style->pair, NULL);
 #endif
@@ -300,7 +300,7 @@ gui_window_restore_style (WINDOW *window)
      * it again with wcolor_set
      */
 #ifdef NCURSES_EXT_COLORS
-    wcolor_set (window, 0, &ptr_saved_style->pair);
+    wcolor_set (window, ptr_saved_style->pair, &ptr_saved_style->pair);
 #else
     wcolor_set (window, ptr_saved_style->pair, NULL);
 #endif
@@ -322,7 +322,7 @@ gui_window_reset_style (WINDOW *window, int weechat_color)
     attrs = gui_color[weechat_color]->attributes;
     pair = gui_color_weechat_get_pair (weechat_color);
 #ifdef NCURSES_EXT_COLORS
-    wattr_set (window, attrs, 0, &pair);
+    wattr_set (window, attrs, pair, &pair);
 #else
     wattr_set (window, attrs, pair, NULL);
 #endif
@@ -343,7 +343,7 @@ gui_window_reset_color (WINDOW *window, int weechat_color)
     wattron (window, gui_color[weechat_color]->attributes);
     pair = gui_color_weechat_get_pair (weechat_color);
 #ifdef NCURSES_EXT_COLORS
-    wcolor_set (window, 0, &pair);
+    wcolor_set (window, pair, &pair);
 #else
     wcolor_set (window, pair, NULL);
 #endif
@@ -385,7 +385,7 @@ gui_window_set_color (WINDOW *window, int fg, int bg)
 
     pair = gui_color_get_pair (fg, bg);
 #ifdef NCURSES_EXT_COLORS
-    wcolor_set (window, 0, &pair);
+    wcolor_set (window, pair, &pair);
 #else
     wcolor_set (window, pair, NULL);
 #endif
@@ -588,7 +588,7 @@ gui_window_set_custom_color_pair (WINDOW *window, int pair)
     {
         gui_window_remove_color_style (window, A_ALL_ATTR);
 #ifdef NCURSES_EXT_COLORS
-        wcolor_set (window, 0, &pair);
+        wcolor_set (window, pair, &pair);
 #else
         wcolor_set (window, pair, NULL);
 #endif
@@ -626,7 +626,7 @@ gui_window_emphasize (WINDOW *window, int x, int y, int count)
         attrs = gui_color[GUI_COLOR_EMPHASIS]->attributes;
         pair = gui_color_weechat_get_pair (GUI_COLOR_EMPHASIS);
 #ifdef NCURSES_EXT_COLORS
-        mvwchgat (window, y, x, count, attrs, 0, &pair);
+        mvwchgat (window, y, x, count, attrs, pair, &pair);
 #else
         mvwchgat (window, y, x, count, attrs, pair, NULL);
 #endif
@@ -657,7 +657,7 @@ gui_window_emphasize (WINDOW *window, int x, int y, int count)
         if (config_emphasized_attributes & GUI_COLOR_EXTENDED_UNDERLINE_FLAG)
             attrs ^= A_UNDERLINE;
 #ifdef NCURSES_EXT_COLORS
-        mvwchgat (window, y, x, count, attrs, 0, ptr_pair);
+        mvwchgat (window, y, x, count, attrs, pair, ptr_pair);
 #else
         mvwchgat (window, y, x, count, attrs, short_pair, NULL);
 #endif

--- a/src/gui/curses/gui-curses.h
+++ b/src/gui/curses/gui-curses.h
@@ -60,7 +60,7 @@ struct t_gui_window_saved_style
     int color_attr;
     int emphasis;
     attr_t attrs;
-    short pair;
+    int pair;
 };
 
 struct t_gui_window_curses_objects

--- a/src/gui/curses/headless/ncurses-fake.c
+++ b/src/gui/curses/headless/ncurses-fake.c
@@ -237,6 +237,16 @@ init_pair (short pair, short f, short b)
     return OK;
 }
 
+int
+init_extended_pair (int pair, int f, int b)
+{
+    (void) pair;
+    (void) f;
+    (void) b;
+
+    return OK;
+}
+
 bool
 has_colors ()
 {

--- a/src/gui/curses/headless/ncurses-fake.h
+++ b/src/gui/curses/headless/ncurses-fake.h
@@ -104,6 +104,7 @@ extern int wnoutrefresh (WINDOW *win);
 extern int wclrtoeol (WINDOW *win);
 extern int mvwprintw (WINDOW *win, int y, int x, const char *fmt, ...);
 extern int init_pair (short pair, short f, short b);
+extern int init_extended_pair (int pair, int f, int b);
 extern bool has_colors ();
 extern int cbreak ();
 extern int start_color ();


### PR DESCRIPTION
This PR improves PR #1345 which fixed issue #1343. Because this introduces additional ncurses-specific behavior, it may be better to not immediately merge this but instead wait and see if #1345 itself has some regressions for someone. I'm still opening the PR because I have implemented the additional limit increase and it could be tested, but it's not as crucial because 32767 color pairs "ought to be enough for everyone".

## Changes

The standard curses API uses `short`s for color pair numbers, so values above 32767, which ncurses claims to support in 256-color modes, wouldn't actually work because they overflow. Two ncurses-specific extensions allow working around this limitation:
1. [`init_extended_pair`](https://invisible-island.net/ncurses/man/curs_color.3x.html#h3-init_extended_pair) instead of `init_pair` allows defining color pairs with `int` numbers.
2. [`opts` arguments](https://invisible-island.net/ncurses/man/curs_attr.3x.html#h2-EXTENSIONS) of many curses color and attribute functions allow passing the color pair with `int` number as an `int*` to be used instead of the usual color pair as `short`.

Because both are ncurses-specific extensions to the curses API, their uses have been implemented conditionally on `NCURSES_EXT_FUNCS` and `NCURSES_EXT_COLORS` (through helper macros to reduce duplicating the preprocessor conditions a lot) to attempt to be as compatible as possible.


## Potential problems

- [ ] Does this PR actually increase the usable limit from 32767 to 65535?

   I only tested it with [`colorspam.py`](https://gist.github.com/sim642/dde23725f23907bc960fce308ecda4f1), which outputs 1024 color pairs. It should actually be checked that when trying to display more than 32767 color pairs _at once_, before this PR it wouldn't display correctly but after this PR it would. It's kind of difficult to fit enough output into a buffer to use 32767 color pairs without scrolling and to visually check the its (in)correctness.

- [ ] Some conditions use `NCURSES_EXT_FUNCS`, others `NCURSES_EXT_COLORS` — is that exact/correct/sufficient or should both be required to be true?

   For example, is it possible to have an ncurses build that supports only one or the other?

