### PR TITLE
core: add option weechat.look.save_config_changed_only (issue #19)

### DIFF
--- a/src/core/wee-config-file.c
+++ b/src/core/wee-config-file.c
@@ -2452,6 +2452,13 @@ config_file_write_internal (struct t_config_file *config_file,
             for (ptr_option = ptr_section->options; ptr_option;
                  ptr_option = ptr_option->next_option)
             {
+                if (CONFIG_BOOLEAN(config_look_save_config_changed_only) &&
+                    /* TODO: bar options have user values as defaults,
+                     * would disappear because not changed */
+                    ptr_option->section != weechat_config_section_bar &&
+                    !config_file_option_has_changed (ptr_option))
+                    continue;
+
                 if (!config_file_write_option (config_file, ptr_option))
                     goto error;
             }

--- a/src/core/wee-config.c
+++ b/src/core/wee-config.c
@@ -181,6 +181,7 @@ struct t_config_option *config_look_read_marker_always_show;
 struct t_config_option *config_look_read_marker_string;
 struct t_config_option *config_look_save_config_on_exit;
 struct t_config_option *config_look_save_config_with_fsync;
+struct t_config_option *config_look_save_config_changed_only;
 struct t_config_option *config_look_save_layout_on_exit;
 struct t_config_option *config_look_scroll_amount;
 struct t_config_option *config_look_scroll_bottom_after_switch;
@@ -3510,6 +3511,14 @@ config_weechat_init_options ()
         NULL, 0, 0, "off", NULL, 0,
         NULL, NULL, NULL,
         &config_change_save_config_on_exit, NULL, NULL,
+        NULL, NULL, NULL);
+    config_look_save_config_changed_only = config_file_new_option (
+        weechat_config_file, ptr_section,
+        "save_config_changed_only", "boolean",
+        N_("TODO"), /* TODO: description */
+        NULL, 0, 0, "off", NULL, 0,
+        NULL, NULL, NULL,
+        NULL, NULL, NULL,
         NULL, NULL, NULL);
     config_look_save_layout_on_exit = config_file_new_option (
         weechat_config_file, ptr_section,

--- a/src/core/wee-config.h
+++ b/src/core/wee-config.h
@@ -232,6 +232,7 @@ extern struct t_config_option *config_look_read_marker_always_show;
 extern struct t_config_option *config_look_read_marker_string;
 extern struct t_config_option *config_look_save_config_on_exit;
 extern struct t_config_option *config_look_save_config_with_fsync;
+extern struct t_config_option *config_look_save_config_changed_only;
 extern struct t_config_option *config_look_save_layout_on_exit;
 extern struct t_config_option *config_look_scroll_amount;
 extern struct t_config_option *config_look_scroll_bottom_after_switch;


### PR DESCRIPTION
This PR contains a simple change to save changed options only as an attempt at fixing issue #19. It works for normal options but has many problems and far from production ready.

**Use at your own risk! While experimenting, I managed to completely break WeeChat (and the existing configuration) in multiple ways (see problems below).**

## Problems
- [ ] `config_file_new_section`/`weechat_config_new_section` allows specifying a `callback_write` which, if specified, is used instead of the default config section writer. Even though the default config section writer can ignore unchanged options, each section with a custom writer would also have to duplicate that logic for consistent behavior.

   Luckily most WeeChat core, plugins and scripts that create their own config files and sections don't use a custom write callback. Of those that do, most write no options by default, e.g. the `filters` section has its own write callback but by default no filters exist so no non-default options get written anyway. The remaining cases need to be carefully analyzed (and potentially somehow fixed).

- [ ] `bars` section consists of bar options. They are unusual because when they're read from the config file, the read values don't become option values but instead option _default_ values. This means that they appear as unchanged from default values, even though the user might have changed them previously. Writing such config again would omit those options and thus user customizations!

   It also affects default bars because they get created once and later are indistinguishable from any custom bars, breaking even the default bars. This PR uses a condition to always write all options in the bars section to avoid this issue.

   Similar problems might affect other sections, e.g. triggers.

- [ ] `key*` sections consists of key bindings for different contexts. They are written using special write callback which (in this PR) doesn't ignore unchanged key bindings. If unchanged key bindings were not written, no default keys would exist because the default keys are all written to the config initially. It would make WeeChat completely unusable because even enter is unbound and nothing can be sent/executed.