### PR TITLE
buflist: add infolist "buflist"

### DIFF
--- a/src/plugins/buflist/CMakeLists.txt
+++ b/src/plugins/buflist/CMakeLists.txt
@@ -22,6 +22,7 @@ buflist.c buflist.h
 buflist-bar-item.c buflist-bar-item.h
 buflist-command.c buflist-command.h
 buflist-config.c buflist-config.h
+buflist-info.c buflist-info.h
 buflist-mouse.c buflist-mouse.h)
 set_target_properties(buflist PROPERTIES PREFIX "")
 

--- a/src/plugins/buflist/buflist-info.c
+++ b/src/plugins/buflist/buflist-info.c
@@ -1,0 +1,114 @@
+/*
+ * buflist-info.c - infolist hook for buflist plugin
+ *
+ * Copyright (C) 2019 Simmo Saan <simmo.saan@gmail.com>
+ *
+ * This file is part of WeeChat, the extensible chat client.
+ *
+ * WeeChat is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * WeeChat is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with WeeChat.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "../weechat-plugin.h"
+#include "buflist.h"
+#include "buflist-bar-item.h"
+
+
+/*
+ * Adds a buffer in an infolist.
+ *
+ * Returns:
+ *   1: OK
+ *   0: error
+ */
+
+int
+buflist_buffer_add_to_infolist (struct t_infolist *infolist, struct t_gui_buffer *buffer)
+{
+    struct t_infolist_item *ptr_item;
+
+    if (!infolist || !buffer)
+        return 0;
+
+    ptr_item = weechat_infolist_new_item (infolist);
+    if (!ptr_item)
+        return 0;
+
+    if (!weechat_infolist_new_var_pointer (ptr_item, "buffer", buffer))
+        return 0;
+
+    return 1;
+}
+
+/*
+ * Returns infolist "buflist".
+ */
+
+struct t_infolist *
+buflist_info_infolist_buflist_cb (const void *pointer, void *data,
+                                  const char *infolist_name,
+                                  void *obj_pointer, const char *arguments)
+{
+    int item_index, i, size;
+    struct t_infolist *ptr_infolist;
+    struct t_gui_buffer *ptr_buffer;
+
+    /* make C compiler happy */
+    (void) pointer;
+    (void) data;
+    (void) infolist_name;
+    (void) obj_pointer;
+
+    if (arguments && arguments[0])
+    {
+        item_index = buflist_bar_item_get_index (arguments);
+        if (item_index < 0)
+            return NULL;
+    }
+    else
+        item_index = 0;
+
+    if (!buflist_list_buffers[item_index])
+        return NULL;
+
+    ptr_infolist = weechat_infolist_new ();
+    if (!ptr_infolist)
+        return NULL;
+
+    /* build list with all buffers in buflist */
+    size = weechat_arraylist_size (buflist_list_buffers[item_index]);
+    for (i = 0; i < size; i++)
+    {
+        ptr_buffer = weechat_arraylist_get (buflist_list_buffers[item_index], i);
+        if (!buflist_buffer_add_to_infolist (ptr_infolist, ptr_buffer))
+        {
+            weechat_infolist_free (ptr_infolist);
+            return NULL;
+        }
+    }
+    return ptr_infolist;
+}
+
+/*
+ * Hooks infolist for buflist plugin.
+ */
+
+void
+buflist_info_init ()
+{
+    weechat_hook_infolist (
+        "buflist", N_("list of buffers in a buflist"),
+        NULL,
+        N_("buflist item name (optional)"),
+        &buflist_info_infolist_buflist_cb, NULL, NULL);
+}

--- a/src/plugins/buflist/buflist-info.h
+++ b/src/plugins/buflist/buflist-info.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2019 Simmo Saan <simmo.saan@gmail.com>
+ *
+ * This file is part of WeeChat, the extensible chat client.
+ *
+ * WeeChat is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * WeeChat is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with WeeChat.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef WEECHAT_PLUGIN_BUFLIST_INFO_H
+#define WEECHAT_PLUGIN_BUFLIST_INFO_H
+
+extern void buflist_info_init ();
+
+#endif /* WEECHAT_PLUGIN_BUFLIST_INFO_H */

--- a/src/plugins/buflist/buflist.c
+++ b/src/plugins/buflist/buflist.c
@@ -29,6 +29,7 @@
 #include "buflist-bar-item.h"
 #include "buflist-command.h"
 #include "buflist-config.h"
+#include "buflist-info.h"
 #include "buflist-mouse.h"
 
 
@@ -505,6 +506,8 @@ weechat_plugin_init (struct t_weechat_plugin *plugin, int argc, char *argv[])
 
     weechat_hook_signal ("perl_script_loaded",
                          &buflist_script_loaded_cb, NULL, NULL);
+
+    buflist_info_init ();
 
     return WEECHAT_RC_OK;
 }


### PR DESCRIPTION
I added this infolist to make my experimental [go_buflist.py](https://github.com/sim642/go_buflist) script possible.

The point is to expose buffers displayed in the buflist in the same sort order to other scripts. An infolist seemed the easiest because buflist internally uses arraylists, so hdata wouldn't work. Also I just added the `buffer` pointer fields to the infolist because it's sufficient to be able to get any other information about the buffer with existing API.

Maybe there's a better way but any way to get this information in a script would be useful.