### PR TITLE
build: use pkg-config to properly link python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ before_script:
     - travis_retry sudo gem install asciidoctor
     - travis_retry sudo -H pip install --ignore-installed msgcheck pylint
     - phpenv local system
+      # work around broken travis environment variables, see https://github.com/travis-ci/travis-ci/issues/5301
+    - unset PYTHON_CFLAGS
 
 script:
     - ./tools/build-test.sh

--- a/cmake/FindPython.cmake
+++ b/cmake/FindPython.cmake
@@ -24,80 +24,14 @@
 # code sets the following variables:
 #
 #  PYTHON_EXECUTABLE   = full path to the python binary
-#  PYTHON_INCLUDE_PATH = path to where python.h can be found
-#  PYTHON_LIBRARY = path to where libpython.so* can be found
-#  PYTHON_LFLAGS = python compiler options for linking
+#  PYTHON_INCLUDE_DIRS = path to where python.h can be found
+#  PYTHON_LIBRARIES = path to where libpython.so* can be found
+#  PYTHON_LDFLAGS = python compiler options for linking
 
-if(PYTHON_FOUND)
-   # Already in cache, be silent
-   set(PYTHON_FIND_QUIETLY TRUE)
-endif()
+include(FindPkgConfig)
 
 if(ENABLE_PYTHON2)
-  find_program(PYTHON_EXECUTABLE
-    NAMES python2.7 python2.6 python2.5 python3.7 python3.6 python3.5 python3.4 python3.3 python3.2 python3.1 python3.0 python3 python
-    PATHS /usr/bin /usr/local/bin /usr/pkg/bin
-    )
+    pkg_check_modules(PYTHON python2)
 else()
-  find_program(PYTHON_EXECUTABLE
-    NAMES python3.7 python3.6 python3.5 python3.4 python3.3 python3.2 python3.1 python3.0 python3 python
-    PATHS /usr/bin /usr/local/bin /usr/pkg/bin
-    )
-endif()
-
-if(PYTHON_EXECUTABLE)
-  execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} -c "import sys; from distutils.sysconfig import *; sys.stdout.write(get_config_var('INCLUDEPY'))"
-    OUTPUT_VARIABLE PYTHON_INC_DIR
-    )
-
-  execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} -c "import sys; from distutils.sysconfig import *; sys.stdout.write(get_config_var('LIBPL'))"
-    OUTPUT_VARIABLE PYTHON_POSSIBLE_LIB_PATH
-    )
-
-  execute_process(
-    COMMAND ${PYTHON_EXECUTABLE} -c "import sys; from distutils.sysconfig import *; sys.stdout.write(get_config_var('LIBS') + ' ' + get_config_var('LINKFORSHARED'))"
-    OUTPUT_VARIABLE PYTHON_LFLAGS
-    )
-
-  find_path(PYTHON_INCLUDE_PATH
-    NAMES Python.h
-    HINTS ${PYTHON_INC_DIR}
-    )
-  if(ENABLE_PYTHON2)
-    find_library(PYTHON_LIBRARY
-      NAMES python2.7 python2.6 python2.5 python3.7 python3.6 python3.5 python3.4 python3.3 python3.2 python3.1 python3.0 python3 python
-      HINTS ${PYTHON_POSSIBLE_LIB_PATH}
-      )
-  else()
-    find_library(PYTHON_LIBRARY
-      NAMES python3.7 python3.6 python3.5 python3.4 python3.3 python3.2 python3.1 python3.0 python3 python
-      HINTS ${PYTHON_POSSIBLE_LIB_PATH}
-      )
-  endif()
-
-  if(PYTHON_LIBRARY AND PYTHON_INCLUDE_PATH)
-    execute_process(
-      COMMAND ${PYTHON_EXECUTABLE} -c "import sys; sys.stdout.write(sys.version[:3])"
-      OUTPUT_VARIABLE PYTHON_VERSION
-      )
-    execute_process(
-      COMMAND ${PYTHON_EXECUTABLE} -c "import sys; sys.stdout.write(str(sys.version_info < (2,5)))"
-      OUTPUT_VARIABLE PYTHON_OLD_VERSION
-      )
-    if(${PYTHON_OLD_VERSION} STREQUAL "True")
-      message("Python >= 2.5 is needed to build python plugin, version found: ${PYTHON_VERSION}")
-    else()
-      set(PYTHON_FOUND TRUE)
-    endif()
-  endif()
-
-  mark_as_advanced(
-    PYTHON_EXECUTABLE
-    PYTHON_INCLUDE_PATH
-    PYTHON_LIBRARY
-    PYTHON_LFLAGS
-    )
-
+    pkg_check_modules(PYTHON python3)
 endif()

--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,7 @@ AC_PROG_MAKE_SET
 AC_GNU_SOURCE
 AC_PROG_LN_S
 AM_PROG_LIBTOOL
+PKG_PROG_PKG_CONFIG
 
 # Files to generate
 AC_CONFIG_FILES([weechat.pc])
@@ -474,18 +475,20 @@ PYTHON_VERSION=
 
 if test "x$enable_python" = "xyes" ; then
     if test "x$enable_python2" = "xyes" ; then
+        PKG_CHECK_MODULES(PYTHON, [python2], [PYTHON_FOUND=yes], [PYTHON_FOUND=no])
         AC_PATH_PROGS(PYTHON, python2.7 python2.6 python2.5 python2 python3.7 python3.6 python3.5 python3.4 python3.3 python3.2 python3.1 python3.0 python3 python)
     else
+        PKG_CHECK_MODULES(PYTHON, [python3], [PYTHON_FOUND=yes], [PYTHON_FOUND=no])
         AC_PATH_PROGS(PYTHON, python3.7 python3.6 python3.5 python3.4 python3.3 python3.2 python3.1 python3.0 python3 python)
     fi
-    if test -z $PYTHON ; then
+    if test -z $PYTHON && test "x$PYTHON_FOUND" != "xyes" ; then
         AC_MSG_WARN([
 *** Python must be installed on your system but python interpreter couldn't be found in path.
 *** Please check that python is in path, or install it with your software package manager.
 *** WeeChat will be built without Python support.])
         enable_python="no"
         not_found="$not_found python"
-    else
+    elif test "x$PYTHON_FOUND" != "xyes"; then
         PYTHON_SYSPREFIX=`$PYTHON -c 'import sys; sys.stdout.write("%s" % sys.prefix)'`
         PYTHON_VERSION=`$PYTHON -c 'import sys; sys.stdout.write(sys.version[[:3]])'`
         PYTHON_INCLUDE=`$PYTHON -c "import sys, distutils.sysconfig, string; sys.stdout.write(distutils.sysconfig.get_config_var('INCLUDEPY'))"`
@@ -502,19 +505,19 @@ if test "x$enable_python" = "xyes" ; then
                 PYTHON_CFLAGS="-I$PYTHON_INCLUDE"
                 AC_MSG_RESULT(found)
                 PYTHON_LIB=`$PYTHON -c "import sys, distutils.sysconfig; sys.stdout.write(distutils.sysconfig.get_config_var('LIBPL'))"`
-                PYTHON_LFLAGS="-lpython$PYTHON_VERSION "`$PYTHON -c "import sys, distutils.sysconfig; sys.stdout.write(distutils.sysconfig.get_config_var('LIBS')+' '+distutils.sysconfig.get_config_var('SYSLIBS')+' '+distutils.sysconfig.get_config_var('LINKFORSHARED'))"`
+                PYTHON_LIBS="-lpython$PYTHON_VERSION "`$PYTHON -c "import sys, distutils.sysconfig; sys.stdout.write(distutils.sysconfig.get_config_var('LIBS')+' '+distutils.sysconfig.get_config_var('SYSLIBS')+' '+distutils.sysconfig.get_config_var('LINKFORSHARED'))"`
                 AC_MSG_CHECKING(for Python library)
                 if test -r "$PYTHON_LIB/libpython$PYTHON_VERSION.so"; then
-                   PYTHON_LFLAGS="-L$PYTHON_LIB $PYTHON_LFLAGS"
+                   PYTHON_LIBS="-L$PYTHON_LIB $PYTHON_LIBS"
                    AC_MSG_RESULT(found)
                 elif test -r "$PYTHON_LIB/libpython$PYTHON_VERSION.a"; then
-                   PYTHON_LFLAGS="-L$PYTHON_LIB $PYTHON_LFLAGS"
+                   PYTHON_LIBS="-L$PYTHON_LIB $PYTHON_LIBS"
                    AC_MSG_RESULT(found)
                 elif test -r "$PYTHON_LIB/libpython$PYTHON_VERSION.dll.a"; then
-                   PYTHON_LFLAGS="-L$PYTHON_LIB $PYTHON_LFLAGS"
+                   PYTHON_LIBS="-L$PYTHON_LIB $PYTHON_LIBS"
                    AC_MSG_RESULT(found)
                 elif test -r "$PYTHON_SYSPREFIX/lib/libpython$PYTHON_VERSION.so"; then
-                   PYTHON_LFLAGS="-L$PYTHON_SYSPREFIX/lib/ $PYTHON_LFLAGS"
+                   PYTHON_LIBS="-L$PYTHON_SYSPREFIX/lib/ $PYTHON_LIBS"
                    AC_MSG_RESULT(found)
                 else
                     AC_MSG_WARN([
@@ -540,7 +543,7 @@ fi
 
 if test "x$enable_python" = "xyes" ; then
     AC_SUBST(PYTHON_CFLAGS)
-    AC_SUBST(PYTHON_LFLAGS)
+    AC_SUBST(PYTHON_LIBS)
     AC_DEFINE(PLUGIN_PYTHON)
 fi
 

--- a/src/plugins/python/CMakeLists.txt
+++ b/src/plugins/python/CMakeLists.txt
@@ -23,9 +23,9 @@ weechat-python-api.c weechat-python-api.h)
 set_target_properties(python PROPERTIES PREFIX "")
 
 if(PYTHON_FOUND)
-  include_directories(${PYTHON_INCLUDE_PATH})
-  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${PYTHON_LFLAGS}")
-  target_link_libraries(python ${PYTHON_LIBRARY} weechat_plugins_scripts coverage_config)
+  include_directories(${PYTHON_INCLUDE_DIRS})
+  set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${PYTHON_LDFLAGS}")
+  target_link_libraries(python ${PYTHON_LIBRARIES} weechat_plugins_scripts coverage_config)
 endif()
 
 install(TARGETS python LIBRARY DESTINATION ${WEECHAT_LIBDIR}/plugins)

--- a/src/plugins/python/Makefile.am
+++ b/src/plugins/python/Makefile.am
@@ -28,6 +28,6 @@ python_la_SOURCES = weechat-python.c \
                     weechat-python-api.c \
                     weechat-python-api.h
 python_la_LDFLAGS = -module -no-undefined
-python_la_LIBADD  = ../lib_weechat_plugins_scripts.la $(PYTHON_LFLAGS)
+python_la_LIBADD  = ../lib_weechat_plugins_scripts.la $(PYTHON_LIBS)
 
 EXTRA_DIST = CMakeLists.txt


### PR DESCRIPTION
relevant: #1156 -- If some minimum version of python is desired, this can be easily expressed with pkg-config.