### PR TITLE
Fixed segfault during excessive evaluation.

### DIFF
--- a/src/core/wee-string.c
+++ b/src/core/wee-string.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
+#include <limits.h>
 #include <stdarg.h>
 #include <string.h>
 #include <ctype.h>
@@ -224,6 +225,10 @@ string_repeat (const char *string, int count)
         return strdup (string);
 
     length_string = strlen (string);
+
+    if (count >= INT_MAX / length_string)
+        return NULL;
+
     length_result = (length_string * count) + 1;
     result = malloc (length_result);
     if (!result)

--- a/tests/unit/core/test-core-string.cpp
+++ b/tests/unit/core/test-core-string.cpp
@@ -26,6 +26,7 @@ extern "C"
 #ifndef HAVE_CONFIG_H
 #define HAVE_CONFIG_H
 #endif
+#include <limits.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -300,6 +301,7 @@ TEST(CoreString, Reverse)
 TEST(CoreString, Repeat)
 {
     POINTERS_EQUAL(NULL, string_repeat (NULL, 1));
+    POINTERS_EQUAL(NULL, string_repeat ("----", INT_MAX / 4));
     STRCMP_EQUAL("", string_repeat ("", 1));
 
     STRCMP_EQUAL("", string_repeat ("x", -1));


### PR DESCRIPTION
It is possible to trigger a segmentation fault while processing
an evaluation of repeating string. On a Linux 64 bit system,
enter this (or adjust arguments for 32 bit accordingly):

/eval -n ${repeat:1073741824,----}

It will overflow an integer calculation because int instead of
size_t is used. Proper check of int limitations fixes this issue.

I haven't changed this specific piece of code to size_t because it
would crash in other parts of the code tree instead. For now, int
is a limitating factor when it comes to strings (and should be
enough for sane use cases).

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>