### PR TITLE
gui: add option weechat.look.window_unzoom_keep_buffer (issue #1372)

### DIFF
--- a/src/core/wee-config.c
+++ b/src/core/wee-config.c
@@ -191,6 +191,7 @@ struct t_config_option *config_look_separator_vertical;
 struct t_config_option *config_look_tab_width;
 struct t_config_option *config_look_time_format;
 struct t_config_option *config_look_window_auto_zoom;
+struct t_config_option *config_look_window_unzoom_keep_buffer;
 struct t_config_option *config_look_window_separator_horizontal;
 struct t_config_option *config_look_window_separator_vertical;
 struct t_config_option *config_look_window_title;
@@ -3591,6 +3592,13 @@ config_weechat_init_options ()
         N_("automatically zoom on current window if the terminal becomes too "
            "small to display all windows (use alt-z to unzoom windows when the "
            "terminal is big enough)"),
+        NULL, 0, 0, "off", NULL, 0,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+    config_look_window_unzoom_keep_buffer = config_file_new_option (
+        weechat_config_file, ptr_section,
+        "window_unzoom_keep_buffer", "boolean",
+        N_("keep current buffer when unzooming window after switching buffer "
+           "during zoom"),
         NULL, 0, 0, "off", NULL, 0,
         NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
     config_look_window_separator_horizontal = config_file_new_option (

--- a/src/core/wee-config.h
+++ b/src/core/wee-config.h
@@ -242,6 +242,7 @@ extern struct t_config_option *config_look_separator_vertical;
 extern struct t_config_option *config_look_tab_width;
 extern struct t_config_option *config_look_time_format;
 extern struct t_config_option *config_look_window_auto_zoom;
+extern struct t_config_option *config_look_window_unzoom_keep_buffer;
 extern struct t_config_option *config_look_window_separator_horizontal;
 extern struct t_config_option *config_look_window_separator_vertical;
 extern struct t_config_option *config_look_window_title;

--- a/src/gui/gui-window.c
+++ b/src/gui/gui-window.c
@@ -1780,6 +1780,7 @@ void
 gui_window_zoom (struct t_gui_window *window)
 {
     struct t_gui_layout *ptr_layout;
+    struct t_gui_buffer *ptr_buffer;
 
     if (!gui_init_ok || !window)
         return;
@@ -1791,9 +1792,12 @@ gui_window_zoom (struct t_gui_window *window)
         (void) hook_signal_send ("window_unzoom",
                                  WEECHAT_HOOK_SIGNAL_POINTER,
                                  gui_current_window);
+        ptr_buffer = gui_current_window->buffer;
         gui_layout_window_apply (ptr_layout,
                                  ptr_layout->internal_id_current_window);
         gui_layout_remove (ptr_layout);
+        if (CONFIG_BOOLEAN(config_look_window_unzoom_keep_buffer))
+            gui_window_switch_to_buffer (gui_current_window, ptr_buffer, 0);
         (void) hook_signal_send ("window_unzoomed",
                                  WEECHAT_HOOK_SIGNAL_POINTER,
                                  gui_current_window);


### PR DESCRIPTION
Closes issue #1372.

Maybe the default for the option should be `on` to give a more intuitive behavior out of the box, instead of having it `off`.

Happy Hacktoberfest!