### PR TITLE
gui: add active or zoomed merged buffer support to layout (issue #562)

### DIFF
--- a/src/core/wee-command.c
+++ b/src/core/wee-command.c
@@ -3875,10 +3875,15 @@ COMMAND_CALLBACK(layout)
                      ptr_layout_buffer;
                      ptr_layout_buffer = ptr_layout_buffer->next_layout)
                 {
-                    gui_chat_printf (NULL, "    %d. %s.%s",
+                    gui_chat_printf (NULL, "    %d. %s.%s%s",
                                      ptr_layout_buffer->number,
                                      ptr_layout_buffer->plugin_name,
-                                     ptr_layout_buffer->buffer_name);
+                                     ptr_layout_buffer->buffer_name,
+                                     /* TODO: use array for these? */
+                                     (ptr_layout_buffer->active == 1) ?
+                                        _(" (active)") :
+                                     (ptr_layout_buffer->active == 2) ?
+                                        _(" (zoomed)") : "");
                 }
                 if (ptr_layout->layout_windows)
                     command_layout_display_tree (ptr_layout->layout_windows, 1);

--- a/src/core/wee-config.c
+++ b/src/core/wee-config.c
@@ -1991,8 +1991,14 @@ config_weechat_layout_read_cb (const void *pointer, void *data,
             {
                 error1 = NULL;
                 number1 = strtol (argv[2], &error1, 10);
-                if (error1 && !error1[0])
-                    gui_layout_buffer_add (ptr_layout, argv[0], argv[1], number1);
+                error2 = NULL;
+                if (argc >= 4)
+                    number2 = strtol (argv[3], &error2, 10);
+                else
+                    number2 = 0; /* TODO: 1 for first buffer under each number for backwards compatibility? */
+                if (error1 && !error1[0] && error2 && !error2[0])
+                    gui_layout_buffer_add (ptr_layout, argv[0], argv[1],
+                                           number1, number2);
             }
             string_free_split (argv);
         }
@@ -2122,10 +2128,11 @@ config_weechat_layout_write_cb (const void *pointer, void *data,
             snprintf (option_name, sizeof (option_name),
                       "%s.buffer", ptr_layout->name);
             if (!config_file_write_line (config_file, option_name,
-                                         "\"%s;%s;%d\"",
+                                         "\"%s;%s;%d;%d\"",
                                          ptr_layout_buffer->plugin_name,
                                          ptr_layout_buffer->buffer_name,
-                                         ptr_layout_buffer->number))
+                                         ptr_layout_buffer->number,
+                                         ptr_layout_buffer->active))
                 return WEECHAT_CONFIG_WRITE_ERROR;
         }
 

--- a/src/core/wee-upgrade.c
+++ b/src/core/wee-upgrade.c
@@ -413,7 +413,8 @@ upgrade_weechat_read_buffer (struct t_infolist *infolist)
     name = infolist_string (infolist, "name");
     gui_layout_buffer_add (upgrade_layout,
                            plugin_name, name,
-                           infolist_integer (infolist, "number"));
+                           infolist_integer (infolist, "number"),
+                           infolist_integer (infolist, "active")); /* TODO: actual active in upgrade infolist */
     main_buffer = gui_buffer_is_main (plugin_name, name);
     if (main_buffer)
     {

--- a/src/gui/gui-buffer.c
+++ b/src/gui/gui-buffer.c
@@ -3670,24 +3670,22 @@ gui_buffer_unmerge (struct t_gui_buffer *buffer, int number)
 void
 gui_buffer_unmerge_all ()
 {
-    struct t_gui_buffer *ptr_buffer, *ptr_next_buffer;
+    struct t_gui_buffer *ptr_buffer, *ptr_prev_buffer;
     int number;
 
-    ptr_buffer = gui_buffers;
+    ptr_buffer = last_gui_buffer;
     while (ptr_buffer)
     {
         number = ptr_buffer->number;
         while (gui_buffer_count_merged_buffers (number) > 1)
         {
-            ptr_next_buffer = ptr_buffer->next_buffer;
+            ptr_prev_buffer = ptr_buffer->prev_buffer;
             gui_buffer_unmerge (ptr_buffer, -1);
-            ptr_buffer = ptr_next_buffer;
+            ptr_buffer = ptr_prev_buffer;
         }
-        /* go to the next number */
-        while (ptr_buffer && (ptr_buffer->number == number))
-        {
-            ptr_buffer = ptr_buffer->next_buffer;
-        }
+        /* go to the previous number */
+        if (ptr_buffer)
+            ptr_buffer = ptr_buffer->prev_buffer;
     }
 }
 

--- a/src/gui/gui-buffer.c
+++ b/src/gui/gui-buffer.c
@@ -688,7 +688,8 @@ gui_buffer_new (struct t_weechat_plugin *plugin,
                                   plugin_get_name (plugin),
                                   name,
                                   &(new_buffer->layout_number),
-                                  &(new_buffer->layout_number_merge_order));
+                                  &(new_buffer->layout_number_merge_order),
+                                  &(new_buffer->layout_active));
     new_buffer->name = strdup (name);
     new_buffer->full_name = NULL;
     gui_buffer_build_full_name (new_buffer);
@@ -1127,6 +1128,8 @@ gui_buffer_get_integer (struct t_gui_buffer *buffer, const char *property)
         return buffer->layout_number;
     else if (string_strcasecmp (property, "layout_number_merge_order") == 0)
         return buffer->layout_number_merge_order;
+    else if (string_strcasecmp (property, "layout_active") == 0)
+        return buffer->layout_active;
     else if (string_strcasecmp (property, "short_name_is_set") == 0)
         return (buffer->short_name) ? 1 : 0;
     else if (string_strcasecmp (property, "type") == 0)
@@ -4204,6 +4207,7 @@ gui_buffer_hdata_buffer_cb (const void *pointer, void *data,
         HDATA_VAR(struct t_gui_buffer, number, INTEGER, 0, NULL, NULL);
         HDATA_VAR(struct t_gui_buffer, layout_number, INTEGER, 0, NULL, NULL);
         HDATA_VAR(struct t_gui_buffer, layout_number_merge_order, INTEGER, 0, NULL, NULL);
+        HDATA_VAR(struct t_gui_buffer, layout_active, INTEGER, 0, NULL, NULL);
         HDATA_VAR(struct t_gui_buffer, name, STRING, 0, NULL, NULL);
         HDATA_VAR(struct t_gui_buffer, full_name, STRING, 0, NULL, NULL);
         HDATA_VAR(struct t_gui_buffer, short_name, STRING, 0, NULL, NULL);
@@ -4384,6 +4388,8 @@ gui_buffer_add_to_infolist (struct t_infolist *infolist,
     if (!infolist_new_var_integer (ptr_item, "layout_number", buffer->layout_number))
         return 0;
     if (!infolist_new_var_integer (ptr_item, "layout_number_merge_order", buffer->layout_number_merge_order))
+        return 0;
+    if (!infolist_new_var_integer (ptr_item, "layout_active", buffer->layout_active))
         return 0;
     if (!infolist_new_var_string (ptr_item, "name", buffer->name))
         return 0;
@@ -4614,6 +4620,7 @@ gui_buffer_print_log ()
         log_printf ("  number. . . . . . . . . : %d",    ptr_buffer->number);
         log_printf ("  layout_number . . . . . : %d",    ptr_buffer->layout_number);
         log_printf ("  layout_number_merge_order: %d",    ptr_buffer->layout_number_merge_order);
+        log_printf ("  layout_active . . . . . : %d",    ptr_buffer->layout_active);
         log_printf ("  name. . . . . . . . . . : '%s'",  ptr_buffer->name);
         log_printf ("  full_name . . . . . . . : '%s'",  ptr_buffer->full_name);
         log_printf ("  short_name. . . . . . . : '%s'",  ptr_buffer->short_name);

--- a/src/gui/gui-buffer.h
+++ b/src/gui/gui-buffer.h
@@ -84,6 +84,7 @@ struct t_gui_buffer
     int number;                        /* buffer number (first is 1)        */
     int layout_number;                 /* number of buffer stored in layout */
     int layout_number_merge_order;     /* order in merge for layout         */
+    int layout_active;
     char *name;                        /* buffer name                       */
     char *full_name;                   /* plugin name + '.' + buffer name   */
     char *short_name;                  /* short buffer name                 */

--- a/src/gui/gui-layout.c
+++ b/src/gui/gui-layout.c
@@ -34,6 +34,7 @@
 #include "../core/wee-log.h"
 #include "../core/wee-string.h"
 #include "../plugins/plugin.h"
+#include "gui-input.h"
 #include "gui-layout.h"
 #include "gui-buffer.h"
 #include "gui-window.h"
@@ -217,7 +218,7 @@ gui_layout_buffer_reset ()
 struct t_gui_layout_buffer *
 gui_layout_buffer_add (struct t_gui_layout *layout,
                        const char *plugin_name, const char *buffer_name,
-                       int number)
+                       int number, int active)
 {
     struct t_gui_layout_buffer *new_layout_buffer;
 
@@ -231,6 +232,7 @@ gui_layout_buffer_add (struct t_gui_layout *layout,
         new_layout_buffer->plugin_name = strdup (plugin_name);
         new_layout_buffer->buffer_name = strdup (buffer_name);
         new_layout_buffer->number = number;
+        new_layout_buffer->active = active;
 
         /* add layout buffer to list */
         new_layout_buffer->prev_layout = layout->last_layout_buffer;
@@ -253,7 +255,8 @@ void
 gui_layout_buffer_get_number (struct t_gui_layout *layout,
                               const char *plugin_name, const char *buffer_name,
                               int *layout_number,
-                              int *layout_number_merge_order)
+                              int *layout_number_merge_order,
+                              int *layout_active)
 {
     struct t_gui_layout_buffer *ptr_layout_buffer;
     int old_number, merge_order;
@@ -283,6 +286,7 @@ gui_layout_buffer_get_number (struct t_gui_layout *layout,
         {
             *layout_number = ptr_layout_buffer->number;
             *layout_number_merge_order = merge_order;
+            *layout_active = ptr_layout_buffer->active;
             return;
         }
     }
@@ -304,7 +308,8 @@ gui_layout_buffer_get_number_all (struct t_gui_layout *layout)
                                       gui_buffer_get_plugin_name (ptr_buffer),
                                       ptr_buffer->name,
                                       &(ptr_buffer->layout_number),
-                                      &(ptr_buffer->layout_number_merge_order));
+                                      &(ptr_buffer->layout_number_merge_order),
+                                      &(ptr_buffer->layout_active));
     }
 }
 
@@ -328,7 +333,8 @@ gui_layout_buffer_store (struct t_gui_layout *layout)
         gui_layout_buffer_add (layout,
                                gui_buffer_get_plugin_name (ptr_buffer),
                                ptr_buffer->name,
-                               ptr_buffer->number);
+                               ptr_buffer->number,
+                               ptr_buffer->active);
     }
 
     /* get layout number for all buffers */
@@ -361,10 +367,12 @@ gui_layout_buffer_apply (struct t_gui_layout *layout)
          ptr_buffer = ptr_buffer->next_buffer)
     {
         if ((gui_buffer_count_merged_buffers (ptr_buffer->number) > 1)
-            && (ptr_buffer->layout_number == ptr_buffer->number)
-            && (ptr_buffer->layout_number_merge_order == 0))
+            && (ptr_buffer->layout_number == ptr_buffer->number))
         {
-            gui_buffer_set_active_buffer (ptr_buffer);
+            if (ptr_buffer->layout_active == 1)
+                gui_buffer_set_active_buffer (ptr_buffer);
+            else if (ptr_buffer->layout_active == 2)
+                gui_input_zoom_merged_buffer (ptr_buffer);
         }
     }
 }
@@ -899,6 +907,7 @@ gui_layout_hdata_layout_buffer_cb (const void *pointer, void *data,
         HDATA_VAR(struct t_gui_layout_buffer, plugin_name, STRING, 0, NULL, NULL);
         HDATA_VAR(struct t_gui_layout_buffer, buffer_name, STRING, 0, NULL, NULL);
         HDATA_VAR(struct t_gui_layout_buffer, number, INTEGER, 0, NULL, NULL);
+        HDATA_VAR(struct t_gui_layout_buffer, active, INTEGER, 0, NULL, NULL);
         HDATA_VAR(struct t_gui_layout_buffer, prev_layout, POINTER, 0, NULL, hdata_name);
         HDATA_VAR(struct t_gui_layout_buffer, next_layout, POINTER, 0, NULL, hdata_name);
     }
@@ -993,6 +1002,8 @@ gui_layout_buffer_add_to_infolist (struct t_infolist *infolist,
     if (!infolist_new_var_string (ptr_item, "buffer_name", layout_buffer->buffer_name))
         return 0;
     if (!infolist_new_var_integer (ptr_item, "number", layout_buffer->number))
+        return 0;
+    if (!infolist_new_var_integer (ptr_item, "active", layout_buffer->active))
         return 0;
 
     return 1;
@@ -1140,6 +1151,7 @@ gui_layout_print_log ()
             log_printf ("    plugin_name. . . . . : '%s'",  ptr_layout_buffer->plugin_name);
             log_printf ("    buffer_name. . . . . : '%s'",  ptr_layout_buffer->buffer_name);
             log_printf ("    number . . . . . . . : %d",    ptr_layout_buffer->number);
+            log_printf ("    active . . . . . . . : %d",    ptr_layout_buffer->active);
             log_printf ("    prev_layout. . . . . : 0x%lx", ptr_layout_buffer->prev_layout);
             log_printf ("    next_layout. . . . . : 0x%lx", ptr_layout_buffer->next_layout);
         }

--- a/src/gui/gui-layout.h
+++ b/src/gui/gui-layout.h
@@ -33,6 +33,7 @@ struct t_gui_layout_buffer
     char *plugin_name;
     char *buffer_name;
     int number;
+    int active;
     struct t_gui_layout_buffer *prev_layout; /* link to previous layout     */
     struct t_gui_layout_buffer *next_layout; /* link to next layout         */
 };
@@ -83,12 +84,14 @@ extern void gui_layout_buffer_reset ();
 extern struct t_gui_layout_buffer *gui_layout_buffer_add (struct t_gui_layout *layout,
                                                           const char *plugin_name,
                                                           const char *buffer_name,
-                                                          int number);
+                                                          int number,
+                                                          int active);
 extern void gui_layout_buffer_get_number (struct t_gui_layout *layout,
                                           const char *plugin_name,
                                           const char *buffer_name,
                                           int *layout_number,
-                                          int *layout_number_merge_order);
+                                          int *layout_number_merge_order,
+                                          int *layout_active);
 extern void gui_layout_buffer_get_number_all (struct t_gui_layout *layout);
 extern void gui_layout_buffer_store (struct t_gui_layout *layout);
 extern void gui_layout_buffer_apply (struct t_gui_layout *layout);


### PR DESCRIPTION
Closes issue #562.

The main change in this PR is the added `active` field to layout buffers, which additionally gets stored and handled during layout apply. Since the `active` field for merged buffers is also used to indicate merged buffer zoom to a single buffer, it will also be persisted in the layout for free.
Same is true for persisting layout during upgrade.

The secondary change in this PR is fixing `gui_buffer_unmerge_all` such that the unmerged buffers are in the same order as they were merged, not in the reverse order as before. This is used when applying layouts and is needed to make that idempotent and restore merged buffers in the correct order.