### PR TITLE
irc: add server option ssl_password for SSL certificate private key password (issue #115)

### DIFF
--- a/src/plugins/irc/irc-command.c
+++ b/src/plugins/irc/irc-command.c
@@ -4756,6 +4756,14 @@ irc_command_display_server (struct t_irc_server *server, int with_detail)
             weechat_printf (NULL, "  ssl_cert . . . . . . : %s'%s'",
                             IRC_COLOR_CHAT_VALUE,
                             weechat_config_string (server->options[IRC_SERVER_OPTION_SSL_CERT]));
+        /* ssl_password */
+        if (weechat_config_option_is_null (server->options[IRC_SERVER_OPTION_SSL_PASSWORD]))
+            weechat_printf (NULL, "  ssl_password . . . . :   %s",
+                            _("(hidden)"));
+        else
+            weechat_printf (NULL, "  ssl_password . . . . : %s%s",
+                            IRC_COLOR_CHAT_VALUE,
+                            _("(hidden)"));
         /* ssl_priorities */
         if (weechat_config_option_is_null (server->options[IRC_SERVER_OPTION_SSL_PRIORITIES]))
             weechat_printf (NULL, "  ssl_priorities . . . :   ('%s')",

--- a/src/plugins/irc/irc-config.c
+++ b/src/plugins/irc/irc-config.c
@@ -1700,6 +1700,25 @@ irc_config_server_new_option (struct t_config_file *config_file,
                 callback_change_data,
                 NULL, NULL, NULL);
             break;
+        case IRC_SERVER_OPTION_SSL_PASSWORD:
+            new_option = weechat_config_new_option (
+                config_file, section,
+                option_name, "string",
+                N_("password for SSL certificate's private key "
+                   "(note: content is evaluated, see /help eval; server "
+                   "options are evaluated with ${irc_server.xxx} and "
+                   "${server} is replaced by the server name)"),
+                NULL, 0, 0,
+                default_value, value,
+                null_value_allowed,
+                callback_check_value,
+                callback_check_value_pointer,
+                callback_check_value_data,
+                callback_change,
+                callback_change_pointer,
+                callback_change_data,
+                NULL, NULL, NULL);
+            break;
         case IRC_SERVER_OPTION_SSL_PRIORITIES:
             new_option = weechat_config_new_option (
                 config_file, section,

--- a/src/plugins/irc/irc-server.h
+++ b/src/plugins/irc/irc-server.h
@@ -56,6 +56,7 @@ enum t_irc_server_option
     IRC_SERVER_OPTION_IPV6,          /* use IPv6 protocol                    */
     IRC_SERVER_OPTION_SSL,           /* SSL protocol                         */
     IRC_SERVER_OPTION_SSL_CERT,      /* client ssl certificate file          */
+    IRC_SERVER_OPTION_SSL_PASSWORD,   /* client ssl certificate key password */
     IRC_SERVER_OPTION_SSL_PRIORITIES, /* gnutls priorities                   */
     IRC_SERVER_OPTION_SSL_DHKEY_SIZE, /* Diffie Hellman key size             */
     IRC_SERVER_OPTION_SSL_FINGERPRINT, /* SHA1 fingerprint of certificate    */


### PR DESCRIPTION
Closes issue #115.

In my (limited) testing, it seems fine to pass `""` as password when the certificate's private key is not encrypted.

Happy Hacktoberfest!