### PR TITLE
irc: fix compilation with GnuTLS < 3.1.0 (issue #115)

### DIFF
--- a/src/plugins/irc/irc-config.c
+++ b/src/plugins/irc/irc-config.c
@@ -1705,7 +1705,8 @@ irc_config_server_new_option (struct t_config_file *config_file,
             new_option = weechat_config_new_option (
                 config_file, section,
                 option_name, "string",
-                N_("password for SSL certificate's private key "
+                N_("password for SSL certificate's private key; "
+                   "only used with gnutls version >= 3.1.0 "
                    "(note: content is evaluated, see /help eval; server "
                    "options are evaluated with ${irc_server.xxx} and "
                    "${server} is replaced by the server name)"),

--- a/src/plugins/irc/irc-server.c
+++ b/src/plugins/irc/irc-server.c
@@ -4710,11 +4710,24 @@ irc_server_gnutls_callback (const void *pointer, void *data,
 
                     /* key */
                     gnutls_x509_privkey_init (&server->tls_cert_key);
+
+/*
+ * gnutls_x509_privkey_import2 has no "Since: ..." in GnuTLS manual but
+ * GnuTLS NEWS file lists it being added in 3.1.0:
+ * https://gitlab.com/gnutls/gnutls/blob/2b715b9564681acb3008a5574dcf25464de8b038/NEWS#L2552
+ */
+#if LIBGNUTLS_VERSION_NUMBER >= 0x030100 /* 3.1.0 */
                     ret = gnutls_x509_privkey_import2 (server->tls_cert_key,
                                                        &filedatum,
                                                        GNUTLS_X509_FMT_PEM,
                                                        ssl_password,
                                                        0);
+#else
+                    ret = gnutls_x509_privkey_import (server->tls_cert_key,
+                                                      &filedatum,
+                                                      GNUTLS_X509_FMT_PEM);
+#endif /* LIBGNUTLS_VERSION_NUMBER >= 0x0301000 */
+
                     if (ret < 0)
                     {
                         ret = gnutls_x509_privkey_import_pkcs8 (


### PR DESCRIPTION
Due to this ssl_password will be partially unused with GnuTLS < 3.1.0.
In that case an encrypted SSL client cert import will simply fail.

Even though GnuTLS 3.0.21 seems to have `gnutls_x509_privkey_import2` according to its git log, it is again missing from 3.0.22, which is weird. Based on their NEWS file, it was added in 3.1.0 so I decided to be safe and rely on that.