### PR TITLE
api: add info "weechat_headless"

### DIFF
--- a/doc/de/autogen/plugin_api/infos.adoc
+++ b/doc/de/autogen/plugin_api/infos.adoc
@@ -130,6 +130,8 @@
 
 | weechat | weechat_dir | WeeChat Verzeichnis | -
 
+| weechat | weechat_headless | 1 if WeeChat is running headless | -
+
 | weechat | weechat_libdir | WeeChat "lib" Verzeichnis | -
 
 | weechat | weechat_localedir | "lokales" Verzeichnis von WeeChat | -

--- a/doc/en/autogen/plugin_api/infos.adoc
+++ b/doc/en/autogen/plugin_api/infos.adoc
@@ -130,6 +130,8 @@
 
 | weechat | weechat_dir | WeeChat directory | -
 
+| weechat | weechat_headless | 1 if WeeChat is running headless | -
+
 | weechat | weechat_libdir | WeeChat "lib" directory | -
 
 | weechat | weechat_localedir | WeeChat "locale" directory | -

--- a/doc/fr/autogen/plugin_api/infos.adoc
+++ b/doc/fr/autogen/plugin_api/infos.adoc
@@ -130,6 +130,8 @@
 
 | weechat | weechat_dir | répertoire de WeeChat | -
 
+| weechat | weechat_headless | 1 if WeeChat is running headless | -
+
 | weechat | weechat_libdir | répertoire "lib" de WeeChat | -
 
 | weechat | weechat_localedir | répertoire "locale" de WeeChat | -

--- a/doc/it/autogen/plugin_api/infos.adoc
+++ b/doc/it/autogen/plugin_api/infos.adoc
@@ -130,6 +130,8 @@
 
 | weechat | weechat_dir | directory WeeChat | -
 
+| weechat | weechat_headless | 1 if WeeChat is running headless | -
+
 | weechat | weechat_libdir | directory "lib" di WeeChat | -
 
 | weechat | weechat_localedir | directory "locale" di WeeChat | -

--- a/doc/ja/autogen/plugin_api/infos.adoc
+++ b/doc/ja/autogen/plugin_api/infos.adoc
@@ -130,6 +130,8 @@
 
 | weechat | weechat_dir | WeeChat ディレクトリ | -
 
+| weechat | weechat_headless | 1 if WeeChat is running headless | -
+
 | weechat | weechat_libdir | WeeChat "lib" ディレクトリ | -
 
 | weechat | weechat_localedir | WeeChat "locale" ディレクトリ | -

--- a/doc/pl/autogen/plugin_api/infos.adoc
+++ b/doc/pl/autogen/plugin_api/infos.adoc
@@ -130,6 +130,8 @@
 
 | weechat | weechat_dir | katalog WeeChat | -
 
+| weechat | weechat_headless | 1 if WeeChat is running headless | -
+
 | weechat | weechat_libdir | katalog "lib" WeeChata | -
 
 | weechat | weechat_localedir | katalog "locale" WeeChata | -

--- a/src/plugins/plugin-api-info.c
+++ b/src/plugins/plugin-api-info.c
@@ -316,6 +316,27 @@ plugin_api_info_weechat_upgrading_cb (const void *pointer, void *data,
 }
 
 /*
+ * Returns WeeChat info "weechat_headless".
+ */
+
+char *
+plugin_api_info_weechat_headless_cb (const void *pointer, void *data,
+                                     const char *info_name,
+                                     const char *arguments)
+{
+    char value[32];
+
+    /* make C compiler happy */
+    (void) pointer;
+    (void) data;
+    (void) info_name;
+    (void) arguments;
+
+    snprintf (value, sizeof (value), "%d", weechat_headless);
+    return strdup (value);
+}
+
+/*
  * Returns WeeChat info "charset_terminal".
  */
 
@@ -1736,6 +1757,9 @@ plugin_api_info_init ()
     hook_info (NULL, "weechat_upgrading",
                N_("1 if WeeChat is upgrading (command `/upgrade`)"),
                NULL, &plugin_api_info_weechat_upgrading_cb, NULL, NULL);
+    hook_info (NULL, "weechat_headless",
+               N_("1 if WeeChat is running headless"),
+               NULL, &plugin_api_info_weechat_headless_cb, NULL, NULL);
     hook_info (NULL, "charset_terminal",
                N_("terminal charset"),
                NULL, &plugin_api_info_charset_terminal_cb, NULL, NULL);


### PR DESCRIPTION
Add info "weechat_headless" so scripts can determine if weechat is running headless. Useful for remote interfaces that utilize push notifications only when weechat is inactive.