### PR TITLE
irc: fix realname delimiter color in WHO/WHOX response

### DIFF
--- a/src/plugins/irc/irc-protocol.c
+++ b/src/plugins/irc/irc-protocol.c
@@ -4878,7 +4878,7 @@ IRC_PROTOCOL_CALLBACK(352)
                 server, NULL, command, "who", NULL),
             date,
             irc_protocol_tags (command, "irc_numeric", NULL, NULL),
-            "%s%s[%s%s%s] %s%s %s(%s%s@%s%s)%s %s%s%s%s(%s)",
+            "%s%s[%s%s%s] %s%s %s(%s%s@%s%s)%s %s%s%s%s%s(%s%s%s)",
             weechat_prefix ("network"),
             IRC_COLOR_CHAT_DELIMITERS,
             IRC_COLOR_CHAT_CHANNEL,
@@ -4896,7 +4896,10 @@ IRC_PROTOCOL_CALLBACK(352)
             (pos_attr) ? " " : "",
             (pos_hopcount) ? pos_hopcount : "",
             (pos_hopcount) ? " " : "",
-            (pos_realname) ? pos_realname : "");
+            IRC_COLOR_CHAT_DELIMITERS,
+            IRC_COLOR_RESET,
+            (pos_realname) ? pos_realname : "",
+            IRC_COLOR_CHAT_DELIMITERS);
     }
 
     return WEECHAT_RC_OK;
@@ -5163,7 +5166,7 @@ IRC_PROTOCOL_CALLBACK(354)
                 server, NULL, command, "who", NULL),
             date,
             irc_protocol_tags (command, "irc_numeric", NULL, NULL),
-            "%s%s[%s%s%s] %s%s %s%s%s%s%s%s(%s%s@%s%s)%s %s%s%s%s(%s)",
+            "%s%s[%s%s%s] %s%s %s%s%s%s%s%s(%s%s@%s%s)%s %s%s%s%s%s(%s%s%s)",
             weechat_prefix ("network"),
             IRC_COLOR_CHAT_DELIMITERS,
             IRC_COLOR_CHAT_CHANNEL,
@@ -5186,7 +5189,10 @@ IRC_PROTOCOL_CALLBACK(354)
             (pos_attr) ? " " : "",
             (pos_hopcount) ? pos_hopcount : "",
             (pos_hopcount) ? " " : "",
-            (pos_realname) ? pos_realname : "");
+            IRC_COLOR_CHAT_DELIMITERS,
+            IRC_COLOR_RESET,
+            (pos_realname) ? pos_realname : "",
+            IRC_COLOR_CHAT_DELIMITERS);
     }
 
     return WEECHAT_RC_OK;


### PR DESCRIPTION
This PR fixes a bug reported on IRC:
```
17:28:11 < oxek> I want to verify a possible bug in weechat. If I do `/who grumble` the last part of (RAINBOW GECOS), i.e. the 'S' and ')' are both colored. Afaik the ')' should not be colored.
17:28:40 < oxek> can someone please verify?
17:29:03 < grumble> oxek: yup the closing paren is bold and pink :)
17:29:20 < grumble> i wouldve put a color reset char in the ident but actually that doesnt fit
17:29:35 < grumble> er i mean in the gecos not ident
17:29:47 < oxek> but shouldn't weechat handle that?
17:30:14 < oxek> i.e. the () are added by weechat, right?
17:31:22 < oxek> grumble: btw sorry if I spammed you with /whois /who etc. I know you're freenode staff, please don't ban me.
17:31:44 < grumble> yes, ideally weechat would reset its colors i guess
17:31:55 < jess> my weechat shows it correctly
17:32:37 < jess> oh, no, ignore me
```