### PR TITLE
core: properly display newlines in input for all buffers

### DIFF
--- a/src/gui/gui-bar-item.c
+++ b/src/gui/gui-bar-item.c
@@ -964,18 +964,15 @@ gui_bar_item_input_text_cb (const void *pointer, void *data,
     }
 
     /*
-     * if multiline is enabled in buffer, transform '\n' to '\r' to the
-     * newlines are displayed as real new lines instead of spaces
+     * transform '\n' to '\r' so the newlines are displayed as real new lines
+     * instead of spaces
      */
-    if (buffer->input_multiline)
+    ptr_input2 = ptr_input;
+    while (ptr_input2 && ptr_input2[0])
     {
-        ptr_input2 = ptr_input;
-        while (ptr_input2 && ptr_input2[0])
-        {
-            if (ptr_input2[0] == '\n')
-                ptr_input2[0] = '\r';
-            ptr_input2 = (char *)utf8_next_char (ptr_input2);
-        }
+        if (ptr_input2[0] == '\n')
+            ptr_input2[0] = '\r';
+        ptr_input2 = (char *)utf8_next_char (ptr_input2);
     }
 
     return ptr_input;


### PR DESCRIPTION
Supporting multiple lines in the input bar is useful even for buffers
without input_multiline set, because it enables you to compose multiple
lines at once, even if it is sent as multiple messages. It is
particularly useful when you paste multiple lines and want to edit some
of it before you send the message.