### PR TITLE
Insert multiple pasted lines in input, instead of sending immediately

### DIFF
--- a/src/core/wee-config.c
+++ b/src/core/wee-config.c
@@ -178,7 +178,6 @@ struct t_config_option *config_look_nick_color_hash_salt;
 struct t_config_option *config_look_nick_color_stop_chars;
 struct t_config_option *config_look_nick_prefix;
 struct t_config_option *config_look_nick_suffix;
-struct t_config_option *config_look_paste_auto_add_newline;
 struct t_config_option *config_look_paste_bracketed;
 struct t_config_option *config_look_paste_bracketed_timer_delay;
 struct t_config_option *config_look_paste_max_lines;
@@ -3548,13 +3547,6 @@ config_weechat_init_options ()
         NULL, NULL, NULL,
         &config_change_nick_prefix_suffix, NULL, NULL,
         NULL, NULL, NULL);
-    config_look_paste_auto_add_newline = config_file_new_option (
-        weechat_config_file, weechat_config_section_look,
-        "paste_auto_add_newline", "boolean",
-        N_("automatically add a newline at the end of pasted text if there "
-           "are at least two lines and if a confirmation is asked"),
-           NULL, 0, 0, "on", NULL, 0,
-        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
     config_look_paste_bracketed = config_file_new_option (
         weechat_config_file, weechat_config_section_look,
         "paste_bracketed", "boolean",

--- a/src/core/wee-config.c
+++ b/src/core/wee-config.c
@@ -3574,7 +3574,7 @@ config_weechat_init_options ()
            "(-1 = disable this feature); this option is used only if the bar "
            "item \"input_paste\" is used in at least one bar (by default it "
            "is used in \"input\" bar)"),
-        NULL, -1, INT_MAX, "1", NULL, 0,
+        NULL, -1, INT_MAX, "100", NULL, 0,
         NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
     config_look_prefix[GUI_CHAT_PREFIX_ERROR] = config_file_new_option (
         weechat_config_file, weechat_config_section_look,

--- a/src/gui/curses/gui-curses-key.c
+++ b/src/gui/curses/gui-curses-key.c
@@ -524,37 +524,37 @@ gui_key_read_cb (const void *pointer, void *data, int fd)
         }
     }
 
-    if (gui_key_paste_pending)
+    if (!gui_key_paste_bracketed)
     {
-        if (accept_paste)
+        pos = gui_key_buffer_search (0, -1, GUI_KEY_BRACKETED_PASTE_START);
+        if (pos >= 0)
         {
-            /* user is OK for pasting text, let's paste! */
-            gui_key_paste_accept ();
-        }
-        else if (cancel_paste)
-        {
-            /* user doesn't want to paste text: clear whole buffer! */
-            gui_key_paste_cancel ();
-        }
-        else if (text_added_to_buffer)
-        {
-            /* new text received while asking for paste, update message */
-            gui_input_paste_pending_signal ();
+            gui_key_buffer_remove (pos, GUI_KEY_BRACKETED_PASTE_LENGTH);
+            gui_key_paste_bracketed_start ();
         }
     }
-    else
+
+    if (!gui_key_paste_bracketed)
     {
-        if (!gui_key_paste_bracketed)
+        if (gui_key_paste_pending)
         {
-            pos = gui_key_buffer_search (0, -1, GUI_KEY_BRACKETED_PASTE_START);
-            if (pos >= 0)
+            if (accept_paste)
             {
-                gui_key_buffer_remove (pos, GUI_KEY_BRACKETED_PASTE_LENGTH);
-                gui_key_paste_bracketed_start ();
+                /* user is OK for pasting text, let's paste! */
+                gui_key_paste_accept ();
+            }
+            else if (cancel_paste)
+            {
+                /* user doesn't want to paste text: clear whole buffer! */
+                gui_key_paste_cancel ();
+            }
+            else if (text_added_to_buffer)
+            {
+                /* new text received while asking for paste, update message */
+                gui_input_paste_pending_signal ();
             }
         }
-
-        if (!gui_key_paste_bracketed)
+        else
             gui_key_paste_check (0);
     }
 

--- a/src/gui/curses/gui-curses-key.c
+++ b/src/gui/curses/gui-curses-key.c
@@ -294,17 +294,27 @@ gui_key_flush (int paste)
     for (i = 0; i < gui_key_buffer_size; i++)
     {
         key = gui_key_buffer[i];
+
+        /*
+         * Many terminal emulators sends \n as \r when pasting, so replace them
+         * back
+         */
+        if (paste && key == '\r')
+        {
+            key = '\n';
+        }
+
         insert_ok = 1;
         utf_partial_char[0] = '\0';
 
-        if (gui_mouse_event_pending)
+        if (!paste && gui_mouse_event_pending)
         {
             insert_ok = 0;
             key_str[0] = (char)key;
             key_str[1] = '\0';
             length_key_str = 1;
         }
-        else if (key < 32)
+        else if (!paste && key < 32)
         {
             insert_ok = 0;
             key_str[0] = '\x01';
@@ -319,7 +329,7 @@ gui_key_flush (int paste)
             key_str[2] = '\0';
             length_key_str = 2;
         }
-        else if (key == 127)
+        else if (!paste && key == 127)
         {
             insert_ok = 0;
             key_str[0] = '\x01';
@@ -379,7 +389,7 @@ gui_key_flush (int paste)
              * or if the mouse code is valid UTF-8 (do not send partial mouse
              * code which is not UTF-8 valid)
              */
-            if (!gui_mouse_event_pending || utf8_is_valid (key_str, -1, NULL))
+            if (!paste && (!gui_mouse_event_pending || utf8_is_valid (key_str, -1, NULL)))
             {
                 (void) hook_signal_send ("key_pressed",
                                          WEECHAT_HOOK_SIGNAL_STRING, key_str);
@@ -392,7 +402,7 @@ gui_key_flush (int paste)
                 input_old = NULL;
             old_buffer = gui_current_window->buffer;
 
-            if ((gui_key_pressed (key_str) != 0) && (insert_ok)
+            if ((paste || gui_key_pressed (key_str) != 0) && (insert_ok)
                 && (!gui_cursor_mode))
             {
                 if (!paste || !undo_done)

--- a/src/gui/curses/gui-curses-key.c
+++ b/src/gui/curses/gui-curses-key.c
@@ -578,19 +578,16 @@ gui_key_read_cb (const void *pointer, void *data, int fd)
             /* remove the code for end of bracketed paste (ESC[201~) */
             gui_key_buffer_remove (pos, GUI_KEY_BRACKETED_PASTE_LENGTH);
 
-            /* remove final newline (if needed) */
-            gui_key_paste_remove_newline ();
-
-            /* replace tabs by spaces */
-            gui_key_paste_replace_tabs ();
-
             /* stop bracketed mode */
             gui_key_paste_bracketed_timer_remove ();
             gui_key_paste_bracketed_stop ();
 
             /* if paste confirmation not displayed, flush buffer now */
             if (!gui_key_paste_pending)
+            {
+                gui_key_paste_finish ();
                 gui_key_flush (1);
+            }
         }
     }
 

--- a/src/gui/gui-key.c
+++ b/src/gui/gui-key.c
@@ -2996,19 +2996,6 @@ gui_key_paste_bracketed_stop ()
 void
 gui_key_paste_accept ()
 {
-    /*
-     * add final newline if there is not in pasted text
-     * (for at least 2 lines pasted)
-     */
-    if (CONFIG_BOOLEAN(config_look_paste_auto_add_newline)
-        && (gui_key_get_paste_lines () > 1)
-        && (gui_key_buffer_size > 0)
-        && (gui_key_buffer[gui_key_buffer_size - 1] != '\r')
-        && (gui_key_buffer[gui_key_buffer_size - 1] != '\n'))
-    {
-        gui_key_buffer_add ('\n');
-    }
-
     gui_key_paste_pending = 0;
     gui_input_paste_pending_signal ();
     gui_key_paste_finish ();

--- a/src/gui/gui-key.c
+++ b/src/gui/gui-key.c
@@ -2836,10 +2836,19 @@ gui_key_paste_replace_tabs ()
 void
 gui_key_paste_start ()
 {
-    gui_key_paste_remove_newline ();
-    gui_key_paste_replace_tabs ();
     gui_key_paste_pending = 1;
     gui_input_paste_pending_signal ();
+}
+
+/*
+ * Finishes paste of text. Does necessary modifications before flush of text.
+ */
+
+void
+gui_key_paste_finish ()
+{
+    gui_key_paste_remove_newline ();
+    gui_key_paste_replace_tabs ();
 }
 
 /*
@@ -3003,6 +3012,7 @@ gui_key_paste_accept ()
 
     gui_key_paste_pending = 0;
     gui_input_paste_pending_signal ();
+    gui_key_paste_finish ();
 }
 
 /*

--- a/src/gui/gui-key.c
+++ b/src/gui/gui-key.c
@@ -2797,19 +2797,18 @@ gui_key_buffer_remove (int index, int number)
 }
 
 /*
- * Removes final newline at end of paste if there is only one line to paste.
+ * Removes final newline at end of paste.
  */
 
 void
 gui_key_paste_remove_newline ()
 {
-    if ((gui_key_paste_lines <= 1)
-        && (gui_key_buffer_size > 0)
+    if ((gui_key_buffer_size > 0)
         && ((gui_key_buffer[gui_key_buffer_size - 1] == '\r')
             || (gui_key_buffer[gui_key_buffer_size - 1] == '\n')))
     {
         gui_key_buffer_size--;
-        gui_key_paste_lines = 0;
+        gui_key_paste_lines--;
     }
 }
 

--- a/src/gui/gui-key.c
+++ b/src/gui/gui-key.c
@@ -2718,9 +2718,7 @@ gui_key_buffer_add (unsigned char key)
     {
         gui_key_buffer[gui_key_buffer_size - 1] = key;
         if (((key == '\r') || (key == '\n'))
-            && (gui_key_buffer_size > 1)
-            && (gui_key_buffer[gui_key_buffer_size - 2] != '\r')
-            && (gui_key_buffer[gui_key_buffer_size - 2] != '\n'))
+            && (gui_key_buffer_size > 1))
         {
             gui_key_paste_lines++;
         }

--- a/src/gui/gui-key.h
+++ b/src/gui/gui-key.h
@@ -135,6 +135,7 @@ extern void gui_key_buffer_remove (int index, int number);
 extern void gui_key_paste_remove_newline ();
 extern void gui_key_paste_replace_tabs ();
 extern void gui_key_paste_start ();
+extern void gui_key_paste_finish ();
 extern int gui_key_get_paste_lines ();
 extern int gui_key_paste_check (int bracketed_paste);
 extern void gui_key_paste_bracketed_timer_remove ();


### PR DESCRIPTION
This changes the paste behavior so that instead of sending the lines immediately when pasting multiple lines, the lines are inserted into the input bar. This allows you to edit the paste before sending it. Then to send all the lines press enter.

To get this behavior, these changes have been done:
- Don't interpret keys when pasting, just insert the text to the input bar. This prevents the line from being sent when pasting text with newlines.
- Remove the final newline when pasting. This is so you don't end up with a blank line at the end of the input when pasting full lines.
- Remove option `weechat.look.paste_auto_add_newline`. Since you now always can edit pasted text before sending it, this option isn't useful anymore.
- Disable paste confirmation by default. Since pasted text isn't sent immediately, the confirmation isn't really necessary anymore. If you paste by mistake you can press ctrl-_ to undo it. I kept the option in case someone still wants it though.