### PR TITLE
core: Add an option to start multiline input text on a new line

### DIFF
--- a/src/core/wee-config.c
+++ b/src/core/wee-config.c
@@ -157,6 +157,7 @@ struct t_config_option *config_look_hotlist_suffix;
 struct t_config_option *config_look_hotlist_unique_numbers;
 struct t_config_option *config_look_hotlist_update_on_buffer_switch;
 struct t_config_option *config_look_input_cursor_scroll;
+struct t_config_option *config_look_input_multiline_lead_linebreak;
 struct t_config_option *config_look_input_share;
 struct t_config_option *config_look_input_share_overwrite;
 struct t_config_option *config_look_input_undo_max;
@@ -3369,6 +3370,13 @@ config_weechat_init_options ()
         N_("number of chars displayed after end of input line when scrolling "
            "to display end of line"),
         NULL, 0, 100, "20", NULL, 0,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+    config_look_input_multiline_lead_linebreak = config_file_new_option (
+        weechat_config_file, weechat_config_section_look,
+        "input_multiline_lead_linebreak", "boolean",
+        N_("start the input text on a new line when the input contains "
+           "multiple lines, so that the start of the lines align"),
+        NULL, 0, 0, "on", NULL, 0,
         NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
     config_look_input_share = config_file_new_option (
         weechat_config_file, weechat_config_section_look,

--- a/src/core/wee-config.h
+++ b/src/core/wee-config.h
@@ -209,6 +209,7 @@ extern struct t_config_option *config_look_hotlist_suffix;
 extern struct t_config_option *config_look_hotlist_unique_numbers;
 extern struct t_config_option *config_look_hotlist_update_on_buffer_switch;
 extern struct t_config_option *config_look_input_cursor_scroll;
+extern struct t_config_option *config_look_input_multiline_lead_linebreak;
 extern struct t_config_option *config_look_input_share;
 extern struct t_config_option *config_look_input_share_overwrite;
 extern struct t_config_option *config_look_input_undo_max;


### PR DESCRIPTION
This does the same as the lead_linebreak option in multiline.pl. That
is, when the input contains more than one line, the first line will be
displayed beneath the previous items in the bar. This is practical
because all the lines in the input will be aligned.

Related to #1498