### PR TITLE
gui: store hidden status of buffers in layout (implements #152)

### DIFF
--- a/doc/en/includes/autogen_api_hdata.en.adoc
+++ b/doc/en/includes/autogen_api_hdata.en.adoc
@@ -876,6 +876,7 @@ _next_layout_   (pointer, hdata: "layout") +
 | _plugin_name_   (string) +
 _buffer_name_   (string) +
 _number_   (integer) +
+_hidden_   (integer) +
 _prev_layout_   (pointer, hdata: "layout_buffer") +
 _next_layout_   (pointer, hdata: "layout_buffer") +
 

--- a/src/core/wee-command.c
+++ b/src/core/wee-command.c
@@ -3924,10 +3924,11 @@ COMMAND_CALLBACK(layout)
                      ptr_layout_buffer;
                      ptr_layout_buffer = ptr_layout_buffer->next_layout)
                 {
-                    gui_chat_printf (NULL, "    %d. %s.%s",
+                    gui_chat_printf (NULL, "    %d. %s.%s%s",
                                      ptr_layout_buffer->number,
                                      ptr_layout_buffer->plugin_name,
-                                     ptr_layout_buffer->buffer_name);
+                                     ptr_layout_buffer->buffer_name,
+                                     ptr_layout_buffer->hidden ? _(" (hidden)") : "");
                 }
                 if (ptr_layout->layout_windows)
                     command_layout_display_tree (ptr_layout->layout_windows, 1);

--- a/src/core/wee-config.c
+++ b/src/core/wee-config.c
@@ -1992,8 +1992,15 @@ config_weechat_layout_read_cb (const void *pointer, void *data,
             {
                 error1 = NULL;
                 number1 = strtol (argv[2], &error1, 10);
+
+                if (argc >= 4)
+                    number2 = strtol (argv[3], &error2, 10);
+                else
+                    number2 = 0;
+
                 if (error1 && !error1[0])
-                    gui_layout_buffer_add (ptr_layout, argv[0], argv[1], number1);
+                    gui_layout_buffer_add (ptr_layout, argv[0], argv[1],
+                                           number1, number2);
             }
             string_free_split (argv);
         }
@@ -2123,10 +2130,11 @@ config_weechat_layout_write_cb (const void *pointer, void *data,
             snprintf (option_name, sizeof (option_name),
                       "%s.buffer", ptr_layout->name);
             if (!config_file_write_line (config_file, option_name,
-                                         "\"%s;%s;%d\"",
+                                         "\"%s;%s;%d;%d\"",
                                          ptr_layout_buffer->plugin_name,
                                          ptr_layout_buffer->buffer_name,
-                                         ptr_layout_buffer->number))
+                                         ptr_layout_buffer->number,
+                                         ptr_layout_buffer->hidden))
                 return WEECHAT_CONFIG_WRITE_ERROR;
         }
 

--- a/src/core/wee-upgrade.c
+++ b/src/core/wee-upgrade.c
@@ -407,13 +407,20 @@ upgrade_weechat_read_buffer (struct t_infolist *infolist)
     const char *key, *var_name, *name, *plugin_name;
     const char *str;
     char option_name[64], *option_key, *option_var;
-    int index, length, main_buffer;
+    int index, length, main_buffer, hidden;
+
+    /* "hidden" is new in WeeChat 1.0 */
+    if (infolist_search_var (infolist, "hidden"))
+        hidden = infolist_integer (infolist, "hidden");
+    else
+        hidden = 0;
 
     plugin_name = infolist_string (infolist, "plugin_name");
     name = infolist_string (infolist, "name");
     gui_layout_buffer_add (upgrade_layout,
                            plugin_name, name,
-                           infolist_integer (infolist, "number"));
+                           infolist_integer (infolist, "number"),
+                           hidden);
     main_buffer = gui_buffer_is_main (plugin_name, name);
     if (main_buffer)
     {
@@ -464,11 +471,7 @@ upgrade_weechat_read_buffer (struct t_infolist *infolist)
     /* notify level */
     ptr_buffer->notify = infolist_integer (infolist, "notify");
 
-    /* "hidden" is new in WeeChat 1.0 */
-    if (infolist_search_var (infolist, "hidden"))
-        ptr_buffer->hidden = infolist_integer (infolist, "hidden");
-    else
-        ptr_buffer->hidden = 0;
+    ptr_buffer->hidden = hidden;
 
     /* day change */
     if (infolist_search_var (infolist, "day_change"))

--- a/src/gui/gui-buffer.c
+++ b/src/gui/gui-buffer.c
@@ -87,8 +87,8 @@ char *gui_buffer_notify_string[GUI_BUFFER_NUM_NOTIFY] =
 
 char *gui_buffer_properties_get_integer[] =
 { "number", "layout_number", "layout_number_merge_order", "type", "notify",
-  "num_displayed", "active", "hidden", "zoomed", "print_hooks_enabled",
-  "day_change", "clear", "filter", "closing", "lines_hidden",
+  "num_displayed", "active", "hidden", "layout_hidden", "zoomed",
+  "print_hooks_enabled", "day_change", "clear", "filter", "closing", "lines_hidden",
   "prefix_max_length", "time_for_each_line", "nicklist",
   "nicklist_case_sensitive", "nicklist_max_length", "nicklist_display_groups",
   "nicklist_count", "nicklist_visible_count",
@@ -690,7 +690,8 @@ gui_buffer_new (struct t_weechat_plugin *plugin,
                                   plugin_get_name (plugin),
                                   name,
                                   &(new_buffer->layout_number),
-                                  &(new_buffer->layout_number_merge_order));
+                                  &(new_buffer->layout_number_merge_order),
+                                  &(new_buffer->layout_hidden));
     new_buffer->name = strdup (name);
     new_buffer->full_name = NULL;
     new_buffer->old_full_name = NULL;
@@ -700,7 +701,7 @@ gui_buffer_new (struct t_weechat_plugin *plugin,
     new_buffer->notify = CONFIG_INTEGER(config_look_buffer_notify_default);
     new_buffer->num_displayed = 0;
     new_buffer->active = 1;
-    new_buffer->hidden = 0;
+    new_buffer->hidden = new_buffer->layout_hidden;
     new_buffer->zoomed = 0;
     new_buffer->print_hooks_enabled = 1;
     new_buffer->day_change = 1;
@@ -1140,6 +1141,8 @@ gui_buffer_get_integer (struct t_gui_buffer *buffer, const char *property)
         return buffer->active;
     else if (string_strcasecmp (property, "hidden") == 0)
         return buffer->hidden;
+    else if (string_strcasecmp (property, "layout_hidden") == 0)
+        return buffer->layout_hidden;
     else if (string_strcasecmp (property, "zoomed") == 0)
         return buffer->zoomed;
     else if (string_strcasecmp (property, "print_hooks_enabled") == 0)

--- a/src/gui/gui-buffer.h
+++ b/src/gui/gui-buffer.h
@@ -98,6 +98,7 @@ struct t_gui_buffer
                                        /* 1 = active (merged or not)        */
                                        /* 2 = the only active (merged)      */
     int hidden;                        /* 1 = buffer hidden                 */
+    int layout_hidden;                 /* hidden in layout                  */
     int zoomed;                        /* 1 if a merged buffer is zoomed    */
                                        /* (it can be another buffer)        */
     int print_hooks_enabled;           /* 1 if print hooks are enabled      */

--- a/src/gui/gui-layout.h
+++ b/src/gui/gui-layout.h
@@ -33,6 +33,7 @@ struct t_gui_layout_buffer
     char *plugin_name;
     char *buffer_name;
     int number;
+    int hidden;
     struct t_gui_layout_buffer *prev_layout; /* link to previous layout     */
     struct t_gui_layout_buffer *next_layout; /* link to next layout         */
 };
@@ -83,12 +84,14 @@ extern void gui_layout_buffer_reset ();
 extern struct t_gui_layout_buffer *gui_layout_buffer_add (struct t_gui_layout *layout,
                                                           const char *plugin_name,
                                                           const char *buffer_name,
-                                                          int number);
+                                                          int number,
+                                                          int hidden);
 extern void gui_layout_buffer_get_number (struct t_gui_layout *layout,
                                           const char *plugin_name,
                                           const char *buffer_name,
                                           int *layout_number,
-                                          int *layout_number_merge_order);
+                                          int *layout_number_merge_order,
+                                          int *layout_hidden);
 extern void gui_layout_buffer_get_number_all (struct t_gui_layout *layout);
 extern void gui_layout_buffer_store (struct t_gui_layout *layout);
 extern void gui_layout_buffer_apply (struct t_gui_layout *layout);


### PR DESCRIPTION
This allows buffers to be persistently hidden between sessions of
weechat if the layout is saved to the configuration.