### PR TITLE
guile: fix output to buffers and re-enable /guile eval

### DIFF
--- a/src/plugins/guile/weechat-guile-api.c
+++ b/src/plugins/guile/weechat-guile-api.c
@@ -4974,7 +4974,9 @@ weechat_guile_api_module_init (void *data)
     port_type = scm_make_port_type ("weechat_stdout",
                                     &weechat_guile_port_fill_input,
                                     &weechat_guile_port_write);
-    guile_port = scm_c_make_port (port_type, 0, 0);
+    guile_port = scm_c_make_port (port_type, SCM_WRTNG | SCM_BUF0, 0);
+    scm_set_current_output_port (guile_port);
+    scm_set_current_error_port (guile_port);
 #else
     /* Guile < 2.2 */
     scm_t_bits port_type;

--- a/src/plugins/guile/weechat-guile.c
+++ b/src/plugins/guile/weechat-guile.c
@@ -916,24 +916,9 @@ weechat_guile_command_cb (const void *pointer, void *data,
                 else
                     break;
             }
-            /*
-             * FIXME: this does not yet work with Guile >= 2.2, so the eval
-             * feature is temporarily disabled, waiting for a fix
-             */
-            /*
             if (!weechat_guile_eval (buffer, send_to_buffer_as_input,
                                      exec_commands, ptr_code))
                 WEECHAT_COMMAND_ERROR;
-            */
-            /* TODO: fix /guile eval */
-            (void) buffer;
-            (void) ptr_code;
-            (void) send_to_buffer_as_input;
-            (void) exec_commands;
-            weechat_printf (NULL,
-                            _("%sCommand \"/%s eval\" is not yet implemented"),
-                            weechat_prefix ("error"),
-                            weechat_guile_plugin->name);
         }
         else
             WEECHAT_COMMAND_ERROR;

--- a/src/plugins/guile/weechat-guile.c
+++ b/src/plugins/guile/weechat-guile.c
@@ -1188,6 +1188,8 @@ weechat_guile_port_write (SCM port, SCM src, size_t start, size_t count)
     }
     weechat_string_dyn_concat (guile_buffer_output, ptr_data);
 
+    free (data2);
+
     return count;
 }
 #else
@@ -1217,6 +1219,8 @@ weechat_guile_port_write (SCM port, const void *data, size_t size)
         ptr_data = ++ptr_newline;
     }
     weechat_string_dyn_concat (guile_buffer_output, ptr_data);
+
+    free (data2);
 }
 #endif
 

--- a/src/plugins/guile/weechat-guile.c
+++ b/src/plugins/guile/weechat-guile.c
@@ -1151,11 +1151,10 @@ weechat_guile_port_fill_input (SCM port, SCM dst, size_t start, size_t count)
 {
     /* make C compiler happy */
     (void) port;
-    (void) dst;
-    (void) start;
-    (void) count;
 
-    return ' ';
+    memset (SCM_BYTEVECTOR_CONTENTS (dst) + start, ' ', count);
+
+    return count;
 }
 #else
 /* Guile < 2.2 */
@@ -1184,7 +1183,7 @@ weechat_guile_port_write (SCM port, SCM src, size_t start, size_t count)
     /* make C compiler happy */
     (void) port;
 
-    data = scm_to_locale_string (src);
+    data = SCM_BYTEVECTOR_CONTENTS (src);
 
     data2 = malloc (count + 1);
     if (!data2)


### PR DESCRIPTION
The commit messages should speak for themselves. This functionality broke when support for Guile 2.2 was added in #1098.

The documentation for Guile I/O Extensions is [here](https://www.gnu.org/software/guile/docs/docs-2.2/guile-ref/I_002fO-Extensions.html).
