### PR TITLE
core: fix beginning of line in iterated regexec (closes #1521)

### DIFF
--- a/src/core/wee-eval.c
+++ b/src/core/wee-eval.c
@@ -1534,7 +1534,7 @@ eval_replace_regex (const char *string, regex_t *regex, const char *replace,
 {
     char *result, *result2, *str_replace;
     int length, length_replace, start_offset, i, rc, end;
-    int empty_replace_allowed;
+    int empty_replace_allowed, notbol;
     struct t_eval_regex eval_regex;
 
     EVAL_DEBUG("eval_replace_regex(\"%s\", 0x%lx, \"%s\")",
@@ -1552,6 +1552,7 @@ eval_replace_regex (const char *string, regex_t *regex, const char *replace,
     eval_context->regex = &eval_regex;
 
     start_offset = 0;
+    notbol = 0;
 
     /* we allow one empty replace if input string is empty */
     empty_replace_allowed = (result[0]) ? 0 : 1;
@@ -1564,7 +1565,7 @@ eval_replace_regex (const char *string, regex_t *regex, const char *replace,
         }
 
         rc = regexec (regex, result + start_offset, 100, eval_regex.match,
-                      (start_offset != 0) ? REG_NOTBOL : 0);
+                      (notbol) ? REG_NOTBOL : 0);
 
         /* no match found: exit the loop */
         if ((rc != 0) || (eval_regex.match[0].rm_so < 0))
@@ -1630,6 +1631,7 @@ eval_replace_regex (const char *string, regex_t *regex, const char *replace,
             break;
 
         start_offset = eval_regex.match[0].rm_so + length_replace;
+        notbol += eval_regex.match[0].rm_eo;
 
         if (!result[start_offset])
             break;

--- a/src/core/wee-string.c
+++ b/src/core/wee-string.c
@@ -1433,19 +1433,19 @@ string_has_highlight (const char *string, const char *highlight_words)
 int
 string_has_highlight_regex_compiled (const char *string, regex_t *regex)
 {
-    int rc, start_offset, startswith, endswith;
+    int rc, startswith, endswith, notbol;
     regmatch_t regex_match;
     const char *match_pre;
 
     if (!string || !regex)
         return 0;
 
-    start_offset = 0;
+    notbol = 0;
 
     while (string && string[0])
     {
         rc = regexec (regex, string,  1, &regex_match,
-                      (start_offset != 0) ? REG_NOTBOL : 0);
+                      (notbol) ? REG_NOTBOL : 0);
 
         /*
          * no match found: exit the loop (if rm_eo == 0, it is an empty match
@@ -1471,7 +1471,7 @@ string_has_highlight_regex_compiled (const char *string, regex_t *regex)
             return 1;
 
         string += regex_match.rm_eo;
-        start_offset += regex_match.rm_eo;
+        notbol += regex_match.rm_eo;
     }
 
     /* no highlight found */
@@ -1769,6 +1769,7 @@ string_replace_regex (const char *string, void *regex, const char *replace,
 {
     char *result, *result2, *str_replace;
     int length, length_replace, start_offset, i, rc, end, last_match;
+    int notbol;
     regmatch_t regex_match[100];
 
     if (!string || !regex)
@@ -1781,6 +1782,7 @@ string_replace_regex (const char *string, void *regex, const char *replace,
     snprintf (result, length, "%s", string);
 
     start_offset = 0;
+    notbol = 0;
     while (result && result[start_offset])
     {
         for (i = 0; i < 100; i++)
@@ -1789,7 +1791,7 @@ string_replace_regex (const char *string, void *regex, const char *replace,
         }
 
         rc = regexec ((regex_t *)regex, result + start_offset, 100, regex_match,
-                      (start_offset != 0) ? REG_NOTBOL : 0);
+                      (notbol) ? REG_NOTBOL : 0);
         /*
          * no match found: exit the loop (if rm_eo == 0, it is an empty match
          * at beginning of string: we consider there is no match, to prevent an
@@ -1853,6 +1855,7 @@ string_replace_regex (const char *string, void *regex, const char *replace,
             break;
 
         start_offset = regex_match[0].rm_so + length_replace;
+        notbol += regex_match[0].rm_eo;
     }
 
     return result;

--- a/src/gui/gui-color.c
+++ b/src/gui/gui-color.c
@@ -1483,7 +1483,7 @@ gui_color_emphasize (const char *string,
     char *result, *result2, *string_no_color;
     const char *ptr_string, *ptr_no_color, *color_emphasis, *pos;
     int rc, length_search, length_emphasis, length_result;
-    int pos1, pos2, real_pos1, real_pos2, count_emphasis, start_offset;
+    int pos1, pos2, real_pos1, real_pos2, count_emphasis, notbol;
 
     /* string is required */
     if (!string)
@@ -1526,7 +1526,7 @@ gui_color_emphasize (const char *string,
     ptr_string = string;
     ptr_no_color = string_no_color;
 
-    start_offset = 0;
+    notbol = 0;
     count_emphasis = 0;
 
     while (ptr_no_color && ptr_no_color[0])
@@ -1536,7 +1536,7 @@ gui_color_emphasize (const char *string,
             /* search next match using the regex */
             regex_match.rm_so = -1;
             rc = regexec (regex, ptr_no_color, 1, &regex_match,
-                          (start_offset != 0) ? REG_NOTBOL : 0);
+                          (notbol) ? REG_NOTBOL : 0);
 
             /*
              * no match found: exit the loop (if rm_no == 0, it is an empty
@@ -1599,7 +1599,7 @@ gui_color_emphasize (const char *string,
         /* restart next loop after the matching string */
         ptr_string += real_pos2;
         ptr_no_color += pos2;
-        start_offset += pos2;
+        notbol += pos2;
 
         /* check if we should allocate more space for emphasis color codes */
         count_emphasis++;

--- a/tests/unit/core/test-core-eval.cpp
+++ b/tests/unit/core/test-core-eval.cpp
@@ -811,6 +811,12 @@ TEST(CoreEval, EvalReplaceRegex)
     hashtable_set (options, "regex_replace", "c");
     WEE_CHECK_EVAL("cb", "ab");
 
+    /* replace removes prefix (issue #1521) */
+    hashtable_remove (pointers, "regex");
+    hashtable_set (options, "regex", "^[^ ]+ ");
+    hashtable_set (options, "regex_replace", "");
+    WEE_CHECK_EVAL("ca va", "allo ca va");
+
     hashtable_free (pointers);
     hashtable_free (extra_vars);
     hashtable_free (options);

--- a/tests/unit/core/test-core-string.cpp
+++ b/tests/unit/core/test-core-string.cpp
@@ -947,6 +947,7 @@ TEST(CoreString, Highlight)
     WEE_HAS_HL_REGEX(0, 1, "tested here", "test.*");
     WEE_HAS_HL_REGEX(0, 0, "this is a test", "teste.*");
     WEE_HAS_HL_REGEX(0, 0, "test here", "teste.*");
+    /* REG_NOTBOL (issue #1521) */
     WEE_HAS_HL_REGEX(0, 1, "test here", "^test");
     WEE_HAS_HL_REGEX(0, 0, "testtest", "^test");
 }
@@ -1021,7 +1022,10 @@ TEST(CoreString, ReplaceRegex)
                       "^(test +)(.*)", "$1/ $.*2", '$', NULL);
     WEE_REPLACE_REGEX(0, "%%%", "test foo",
                       "^(test +)(.*)", "$.%+", '$', NULL);
+    /* REG_NOTBOL (issue #1521) */
     WEE_REPLACE_REGEX(0, "cb", "ab", "^(a|b)", "c", '$', NULL);
+    /* replace removes prefix (issue #1521) */
+    WEE_REPLACE_REGEX(0, "ca va", "allo ca va", "^[^ ]+ ", "", '$', NULL);
 }
 
 /*

--- a/tests/unit/gui/test-gui-color.cpp
+++ b/tests/unit/gui/test-gui-color.cpp
@@ -736,7 +736,7 @@ TEST(GuiColor, ColorEmphasize)
     WEE_CHECK_EMPHASIZE(string1, string1, NULL, 0, &regex);
     regfree (&regex);
 
-    /* build strings for tests */
+    /* REG_NOTBOL (issue #1521) */
     snprintf (string1, sizeof (string1),
               "ab");
     snprintf (string2, sizeof (string2),
@@ -746,6 +746,19 @@ TEST(GuiColor, ColorEmphasize)
 
     /* search regex (found) */
     string_regcomp (&regex, "^(a|b)", REG_EXTENDED);
+    WEE_CHECK_EMPHASIZE(string2, string1, NULL, 0, &regex);
+    regfree (&regex);
+
+    /* replace removes prefix (issue #1521) */
+    snprintf (string1, sizeof (string1),
+              "allo ca va");
+    snprintf (string2, sizeof (string2),
+              "%sallo %sca va",
+              gui_color_get_custom ("emphasis"),
+              gui_color_get_custom ("emphasis"));
+
+    /* search regex (found) */
+    string_regcomp (&regex, "^[^ ]+ ", REG_EXTENDED);
     WEE_CHECK_EMPHASIZE(string2, string1, NULL, 0, &regex);
     regfree (&regex);
 }


### PR DESCRIPTION
Besides the original issue in `eval_replace_regex` I found three more iterated `regexec` calls where similar issue can be observed. I added tests for all four.