### PR TITLE
docker: add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM debian:stable-slim
+
+RUN apt-get update && apt-get install apt-utils \
+    libgcrypt20-dev \
+    cmake \
+    gnutls-dev \
+    zlib1g-dev \
+    libcurl4-gnutls-dev \
+    libncurses-dev \
+    libaspell-dev \
+    pkg-config \
+    php7.3-dev \
+    python3-dev \
+    libperl-dev \
+    liblua5.2-dev \
+    ruby-dev \
+    guile-2.2-dev \
+    tcl-dev \
+    libphp-embed \
+    libargon2-dev \
+    libxml2-dev \
+    libsodium-dev -y
+
+RUN mkdir -p /usr/local/weechat/build
+WORKDIR /usr/local/weechat
+COPY . .
+
+WORKDIR /usr/local/weechat/build
+RUN cmake ..
+RUN make && make install
+ENTRYPOINT ["weechat"]

--- a/README.adoc
+++ b/README.adoc
@@ -112,6 +112,22 @@ They can be launched after compilation from the build directory:
 $ ctest -V
 ----
 
+=== Docker
+
+To optionally build WeeChat with docker:
+
+Build the container:
+
+----
+$ docker build . -t weechat
+----
+
+Run the container to launch WeeChat:
+
+----
+$ docker run -ti weechat
+----
+
 == Copyright
 
 Copyright (C) 2003-2020 Sébastien Helleu <flashcode@flashtux.org>


### PR DESCRIPTION
This PR adds a Dockerfile to the root directory of the project allowing source builds to be reproducible and isolated in a container: https://github.com/weechat/weechat/issues/1446.  I used [Alpine linux](https://alpinelinux.org/about/) for the base image because it is small and security focused: (binaries are compiled using PIE to prevent stack smashing).  Some script dependencies are difficult to add to Alpine such as V8, so I've left some script dependencies disabled for now in the Dockerfile.  We could use `debian:slim` as the base image instead which would be easier to add script dependencies I think. 