### PR TITLE
strip colon, if present, from ACCOUNT value

### DIFF
--- a/src/plugins/irc/irc-protocol.c
+++ b/src/plugins/irc/irc-protocol.c
@@ -339,7 +339,8 @@ IRC_PROTOCOL_CALLBACK(account)
 
     local_account = (irc_server_strcasecmp (server, nick, server->nick) == 0);
 
-    pos_account = (strcmp (argv[2], "*") != 0) ? argv[2] : NULL;
+    pos_account = (argv[2][0] == ':') ? argv[2] + 1 : argv[2];
+    pos_account = (strcmp (pos_account, "*") != 0) ? pos_account : NULL;
 
     str_account[0] = '\0';
     if (pos_account)


### PR DESCRIPTION
I noticed this after updating to a 2.9-dev build that prints `ACCOUNT` lines:

` -- user has identified as :user`

this pull request is a band-aid. the real solution here is to correctly tokenise IRC data as soon as it's read so `:trailing` parameters are just treated as another param in the argv array.