### PR TITLE
irc: add pointer "irc_nick" in hashtable sent to hook focus callback (closes #1535)

### DIFF
--- a/src/plugins/irc/irc-bar-item.c
+++ b/src/plugins/irc/irc-bar-item.c
@@ -656,6 +656,7 @@ irc_bar_item_focus_buffer_nicklist (const void *pointer, void *data,
     struct t_gui_buffer *buffer;
     struct t_irc_nick *ptr_nick;
     const char *str_buffer, *nick;
+    char str_value[128];
 
     str_buffer = weechat_hashtable_get (info, "_buffer");
     if (!str_buffer || !str_buffer[0])
@@ -679,9 +680,15 @@ irc_bar_item_focus_buffer_nicklist (const void *pointer, void *data,
         if (nick)
         {
             ptr_nick = irc_nick_search (ptr_server, ptr_channel, nick);
-            if (ptr_nick && ptr_nick->host)
+            if (ptr_nick)
             {
-                weechat_hashtable_set (info, "irc_host", ptr_nick->host);
+                snprintf (str_value, sizeof (str_value),
+                          "0x%lx", (unsigned long)ptr_nick);
+                weechat_hashtable_set (info, "irc_nick", str_value);
+
+                if (ptr_nick->host)
+                    weechat_hashtable_set (info, "irc_host", ptr_nick->host);
+
                 return info;
             }
         }


### PR DESCRIPTION
Closes #1535.

#### TODO when merging
- [ ] Add `irc_nick` under `hook_focus` in plugin API docs with corresponding WeeChat version constraint.