### PR TITLE
core: Allow to read secrets from external programs (closes #141)

### DIFF
--- a/src/core/wee-command.c
+++ b/src/core/wee-command.c
@@ -5578,6 +5578,17 @@ COMMAND_CALLBACK(secure)
         return WEECHAT_RC_OK;
     }
 
+    /* set secured data cmd */
+    if (string_strcasecmp (argv[1], "setcmd") == 0)
+    {
+        COMMAND_MIN_ARGS(4, "setcmd");
+        hashtable_set (secure_hashtable_cmds, argv[2], argv_eol[3]);
+        gui_chat_printf (NULL, _("Secured data cmd \"%s\" set"), argv[2]);
+        command_save_file (secure_config_file);
+        secure_buffer_display ();
+        return WEECHAT_RC_OK;
+    }
+
     /* delete a secured data */
     if (string_strcasecmp (argv[1], "del") == 0)
     {
@@ -5593,6 +5604,27 @@ COMMAND_CALLBACK(secure)
         {
             gui_chat_printf (NULL,
                              _("%sSecured data \"%s\" not found"),
+                             gui_chat_prefix[GUI_CHAT_PREFIX_ERROR],
+                             argv[2]);
+        }
+        return WEECHAT_RC_OK;
+    }
+
+    /* delete secured data cmd */
+    if (string_strcasecmp (argv[1], "delcmd") == 0)
+    {
+        COMMAND_MIN_ARGS(3, "delcmd");
+        if (hashtable_has_key (secure_hashtable_cmds, argv[2]))
+        {
+            hashtable_remove (secure_hashtable_cmds, argv[2]);
+            gui_chat_printf (NULL, _("Secured data cmd \"%s\" deleted"), argv[2]);
+            command_save_file (secure_config_file);
+            secure_buffer_display ();
+        }
+        else
+        {
+            gui_chat_printf (NULL,
+                             _("%sSecured data cmd \"%s\" not found"),
                              gui_chat_prefix[GUI_CHAT_PREFIX_ERROR],
                              argv[2]);
         }

--- a/src/core/wee-eval.c
+++ b/src/core/wee-eval.c
@@ -1070,6 +1070,28 @@ eval_replace_vars_cb (void *data, const char *text)
         ptr_value = hashtable_get (secure_hashtable_data, text + 9);
         return strdup ((ptr_value) ? ptr_value : "");
     }
+    if (strncmp (text, "sec.cmd.", 8) == 0)
+    {
+        const char *program;
+        char *value, *status;
+        FILE *in;
+
+        status = NULL;
+        if (!(program = hashtable_get (secure_hashtable_cmds, text + 8)))
+        {
+            return strdup("");
+        }
+        if (!(in = popen (program, "r")))
+        {
+            return strdup("");
+        }
+
+        if ((value = alloca(1024))) {
+            status = fgets (value, 1024, in);
+        }
+        pclose (in);
+        return strdup (status ? value : "");
+    }
     config_file_search_with_string (text, NULL, NULL, &ptr_option, NULL);
     if (ptr_option)
     {

--- a/src/core/wee-secure-buffer.c
+++ b/src/core/wee-secure-buffer.c
@@ -79,13 +79,37 @@ secure_buffer_display_data (void *data,
 }
 
 /*
+ * Displays a secured data cmd.
+ */
+
+void
+secure_buffer_display_cmd (void *data,
+                            struct t_hashtable *hashtable,
+                            const void *key, const void *value)
+{
+    (void) hashtable;
+    int *line;
+
+    line = (int *)data;
+
+    gui_chat_printf_y (secure_buffer, (*line)++,
+                       "  %s%s = %s\"%s%s%s\"",
+                       key,
+                       GUI_COLOR(GUI_COLOR_CHAT_DELIMITERS),
+                       GUI_COLOR(GUI_COLOR_CHAT),
+                       GUI_COLOR(GUI_COLOR_CHAT_VALUE),
+                       value,
+                       GUI_COLOR(GUI_COLOR_CHAT));
+}
+
+/*
  * Displays content of secured data buffer.
  */
 
 void
 secure_buffer_display ()
 {
-    int line, count, count_encrypted;
+    int line, count, count_encrypted, count_cmds;
 
     if (!secure_buffer)
         return;
@@ -114,6 +138,7 @@ secure_buffer_display ()
     /* display secured data */
     count = secure_hashtable_data->items_count;
     count_encrypted = secure_hashtable_data_encrypted->items_count;
+    count_cmds = secure_hashtable_cmds->items_count;
     if (count > 0)
     {
         line++;
@@ -133,7 +158,16 @@ secure_buffer_display ()
         hashtable_map (secure_hashtable_data_encrypted,
                        &secure_buffer_display_data, &line);
     }
-    if ((count == 0) && (count_encrypted == 0))
+    /* display cmds configured to retrive secured data */
+    if (count_cmds > 0)
+    {
+        line++;
+        gui_chat_printf_y (secure_buffer, line++, _("Secure cmds:"));
+        line++;
+        hashtable_map (secure_hashtable_cmds,
+                       &secure_buffer_display_cmd, &line);
+    }
+    if ((count == 0) && (count_encrypted == 0) && (count_cmds == 0))
     {
         line++;
         gui_chat_printf_y (secure_buffer, line++, _("No secured data set"));

--- a/src/core/wee-secure.c
+++ b/src/core/wee-secure.c
@@ -45,6 +45,8 @@ struct t_hashtable *secure_hashtable_data = NULL;
 /* data still encrypted (if passphrase not set) */
 struct t_hashtable *secure_hashtable_data_encrypted = NULL;
 
+struct t_hashtable *secure_hashtable_cmds = NULL;
+
 /* hash algorithms */
 char *secure_hash_algo_string[] = { "sha224", "sha256", "sha384", "sha512",
                                     NULL };
@@ -535,6 +537,13 @@ secure_init ()
         return 0;
     }
 
+    secure_hashtable_cmds = hashtable_new (32,
+                                           WEECHAT_HASHTABLE_STRING,
+                                           WEECHAT_HASHTABLE_STRING,
+                                           NULL, NULL);
+    if (!secure_hashtable_cmds)
+        return 0;
+
     return 1;
 }
 
@@ -559,5 +568,10 @@ secure_end ()
     {
         hashtable_free (secure_hashtable_data_encrypted);
         secure_hashtable_data_encrypted = NULL;
+    }
+    if (secure_hashtable_cmds)
+    {
+        hashtable_free (secure_hashtable_cmds);
+        secure_hashtable_cmds = NULL;
     }
 }

--- a/src/core/wee-secure.h
+++ b/src/core/wee-secure.h
@@ -46,6 +46,7 @@ enum t_secure_config_cipher
 extern char *secure_passphrase;
 extern struct t_hashtable *secure_hashtable_data;
 extern struct t_hashtable *secure_hashtable_data_encrypted;
+extern struct t_hashtable *secure_hashtable_cmds;
 extern char *secure_hash_algo_string[];
 extern int secure_hash_algo[];
 extern char *secure_cipher_string[];


### PR DESCRIPTION
This is my go at #141.

There is some stuff still to do that I know of:
- [ ] Tab auto completion does not work for `/secure setcmd | delcmd`. Not sure where to add this yet
- [ ] The screen becomes a jumbled mess when the called program does something with the terminal. Find a way to repaint the screen.
- [ ] Documentation
- [ ] Add to Changelog

There are probably also some TODOs I missed. 

I opened this PR as a draft to discuss if this approach looks good before I spend more time on this.