### PR TITLE
irc: add pointer "irc_server" and "irc_channel" in hashtable sent to buflist bar item hook focus callback (closes #1543)

### DIFF
--- a/src/plugins/buflist/buflist-mouse.c
+++ b/src/plugins/buflist/buflist-mouse.c
@@ -328,11 +328,14 @@ int
 buflist_mouse_init ()
 {
     int i;
+    char name[128];
 
     for (i = 0; i < BUFLIST_BAR_NUM_ITEMS; i++)
     {
-        weechat_hook_focus (buflist_bar_item_get_name (i),
-                            &buflist_focus_cb, NULL, NULL);
+        /* priority 2000 to run before irc plugin */
+        snprintf (name, sizeof (name), "2000|%s",
+                  buflist_bar_item_get_name (i));
+        weechat_hook_focus (name, &buflist_focus_cb, NULL, NULL);
     }
 
     weechat_hook_hsignal (BUFLIST_MOUSE_HSIGNAL,


### PR DESCRIPTION
Closes #1543.


#### TODO when merging
- [ ] Create new table for `buflist` bar item extra focus variables under `hook_focus` in plugin API docs.
- [ ] Add `irc_server` and `irc_channel` to that table with corresponding WeeChat version constraint.