### PR TITLE
Add paths used by clangd language server to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,11 +14,13 @@
 *.so.0.0.0
 *.1
 
+.cache/*
 ABOUT-NLS
 autom4te*
 build/*
 builddir/*
 compile
+compile_commands.json
 config.guess
 config.h
 config.h.in*


### PR DESCRIPTION
In order for the clangd language server to function properly it requires a file called compile_commands.json in the root directory of the project. It also creates a .cache folder.