### PR TITLE
core: Prevent switching to start of visited buffers when jumping to next

### DIFF
--- a/src/gui/gui-buffer.c
+++ b/src/gui/gui-buffer.c
@@ -4257,6 +4257,7 @@ int
 gui_buffer_visited_get_index_next ()
 {
     if ((gui_buffers_visited_count < 2)
+        || (gui_buffers_visited_index < 0)
         || (gui_buffers_visited_index >= gui_buffers_visited_count - 1))
         return -1;
 


### PR DESCRIPTION
If you run /input jump_next_visited_buffer right after switching to a
buffer, weechat changes to the first buffer in the visited buffers list.
That is, it wraps around and goes to the buffer you visited the longest
ago. This patch fixes that.

The reason it happens is that when you switch to a buffer (normally,
i.e. in another way than using jump_previously_visited_buffer/
jump_next_visited_buffer) gui_buffers_visited_index is set to -1 (in
gui_buffer_visited_add). This makes gui_buffer_visited_get_index_next
return 0 because it returns gui_buffers_visited_index + 1, which makes
gui_input_jump_next_visited_buffer jump to the first buffer in the list
of visited buffers.

Fixes #1591