### PR TITLE
add -yes to output of /help voice

### DIFF
--- a/src/plugins/irc/irc-command.c
+++ b/src/plugins/irc/irc-command.c
@@ -7190,7 +7190,7 @@ irc_command_init ()
     weechat_hook_command (
         "voice",
         N_("give voice to nick(s)"),
-        N_("<nick> [<nick>...]"),
+        N_("<nick> [<nick>...] || * -yes"),
         N_("nick: nick or mask (wildcard \"*\" is allowed)\n"
            "   *: give voice to everybody on channel"),
         "%(nicks)|%*", &irc_command_voice, NULL, NULL);


### PR DESCRIPTION
currently /help voice does not tell you that you need -yes if you are using *. i have changed it to match /help op, /help deop and /help devoice