### PR TITLE
irc: make default chantypes configurable

### DIFF
--- a/ChangeLog.adoc
+++ b/ChangeLog.adoc
@@ -26,6 +26,7 @@ New features::
   * core: add option "recreate" in command /filter
   * core: add evaluation of conditions in evaluation of expressions with "eval_cond:" (issue #1582)
   * trigger: add variable "${tg_trigger_name}" in command trigger evaluated strings (issue #1580)
+  * irc: make the default chantypes to use when the server does not specify them configurable (irc.server.xxx.default_chantypes)
 
 Bug fixes::
 

--- a/src/plugins/irc/irc-channel.c
+++ b/src/plugins/irc/irc-channel.c
@@ -673,10 +673,13 @@ irc_channel_is_channel (struct t_irc_server *server, const char *string)
 
     first_char[0] = string[0];
     first_char[1] = '\0';
-    return (strpbrk (first_char,
-                     (server && server->chantypes) ?
-                     server->chantypes : irc_channel_default_chantypes)) ?
-        1 : 0;
+    return strpbrk(
+        first_char,
+        (server ?
+            (server->chantypes ?
+                server->chantypes :
+                IRC_SERVER_OPTION_STRING(server, IRC_SERVER_OPTION_DEFAULT_CHANTYPES))
+            : irc_channel_default_chantypes)) ? 1 : 0;
 }
 
 /*

--- a/src/plugins/irc/irc-command.c
+++ b/src/plugins/irc/irc-command.c
@@ -5112,6 +5112,14 @@ irc_command_display_server (struct t_irc_server *server, int with_detail)
             weechat_printf (NULL, "  charset_message. . . : %s'%s'",
                             IRC_COLOR_CHAT_VALUE,
                             weechat_config_string (server->options[IRC_SERVER_OPTION_CHARSET_MESSAGE]));
+        /* chantypes */
+        if (weechat_config_option_is_null (server->options[IRC_SERVER_OPTION_DEFAULT_CHANTYPES]))
+            weechat_printf (NULL, "  chantypes. . . . . . :   ('%s')",
+                            IRC_SERVER_OPTION_STRING(server, IRC_SERVER_OPTION_DEFAULT_CHANTYPES));
+        else
+            weechat_printf (NULL, "  chantypes. . . . . . : %s'%s'",
+                            IRC_COLOR_CHAT_VALUE,
+                            weechat_config_string (server->options[IRC_SERVER_OPTION_DEFAULT_CHANTYPES]));
     }
     else
     {

--- a/src/plugins/irc/irc-config.c
+++ b/src/plugins/irc/irc-config.c
@@ -2434,6 +2434,23 @@ irc_config_server_new_option (struct t_config_file *config_file,
                 callback_change_data,
                 NULL, NULL, NULL);
             break;
+        case IRC_SERVER_OPTION_DEFAULT_CHANTYPES:
+            new_option = weechat_config_new_option (
+                config_file, section,
+                option_name, "string",
+                N_("channel type prefixes to use if the server does not "
+                   "specify them (default is #&)"),
+                NULL, 0, 0,
+                default_value, value,
+                null_value_allowed,
+                callback_check_value,
+                callback_check_value_pointer,
+                callback_check_value_data,
+                callback_change,
+                callback_change_pointer,
+                callback_change_data,
+                NULL, NULL, NULL);
+            break;
         case IRC_SERVER_NUM_OPTIONS:
             break;
     }

--- a/src/plugins/irc/irc-server.c
+++ b/src/plugins/irc/irc-server.c
@@ -119,6 +119,7 @@ char *irc_server_options[IRC_SERVER_NUM_OPTIONS][2] =
   { "notify",               ""                        },
   { "split_msg_max_length", "512"                     },
   { "charset_message",      "message"                 },
+  { "default_chantypes",    "#&"                      },
 };
 
 char *irc_server_casemapping_string[IRC_SERVER_NUM_CASEMAPPING] =

--- a/src/plugins/irc/irc-server.h
+++ b/src/plugins/irc/irc-server.h
@@ -92,6 +92,7 @@ enum t_irc_server_option
     IRC_SERVER_OPTION_NOTIFY,               /* notify list                   */
     IRC_SERVER_OPTION_SPLIT_MSG_MAX_LENGTH, /* max length of messages        */
     IRC_SERVER_OPTION_CHARSET_MESSAGE,      /* what to decode/encode in msg  */
+    IRC_SERVER_OPTION_DEFAULT_CHANTYPES,  /* chantypes if server doesn't say */
     /* number of server options */
     IRC_SERVER_NUM_OPTIONS,
 };


### PR DESCRIPTION
`!` was removed from the default chantypes in 4a42cda3a5f5b02d8ba9afae129499c26250d334 which broke `!channels` on at least one old server where the ircd doesn't send a `005` to specify the chantypes at all. If channels aren't recognized as channels, any incoming messages on them are shown as private messages which makes the channel a bit hard to use.

This PR adds a configuration option for chantypes which is only used if the server doesn't specify them, so that such servers can manually be fixed on the client side.

If supporting outdated servers is out of scope, feel free to close.