### PR TITLE
Changed SIGHUP callback to exit WeeChat when not running as headless or daemon

### DIFF
--- a/src/core/weechat.c
+++ b/src/core/weechat.c
@@ -689,13 +689,20 @@ weechat_locale_check ()
 }
 
 /*
- * Callback for system signal SIGHUP: reloads configuration.
+ * Callback for system signal SIGHUP: reload configuration if running as headless or daemon, quit otherwise.
  */
 
 void
 weechat_sighup ()
 {
-    weechat_reload_signal = SIGHUP;
+    if (weechat_headless || weechat_daemon)
+    {
+        weechat_reload_signal = SIGHUP;
+    }
+    else
+    {
+        weechat_quit_signal = SIGHUP;
+    }
 }
 
 /*


### PR DESCRIPTION
I have changed the SIGHUP callback to set SIGHUP as weechat_reload_signal if running as headless or daemon and to set SIGHUP as weechat_quit_signal otherwise, fixing issue #1595.

Documentation and tests have not been changed, only the sighup callback function in src/core/weechat.s and the accompanying comment have been changed.

I have followed the CONTRIBUTING guide to the best of my abilities, but let me know if I should implement the fix in another way, or if something else needs to be done to either prettify it or quality it for merging.