### PR TITLE
buflist: Fix wrong pointers being used in hdata_compare

### DIFF
--- a/src/plugins/buflist/buflist.c
+++ b/src/plugins/buflist/buflist.c
@@ -271,7 +271,7 @@ buflist_compare_buffers (void *data, struct t_arraylist *arraylist,
             else
             {
                 rc = weechat_hdata_compare (buflist_hdata_hotlist,
-                                            pointer1, pointer2,
+                                            ptr_hotlist1, ptr_hotlist2,
                                             ptr_field + 8,
                                             case_sensitive);
             }


### PR DESCRIPTION
This used pointer1 and pointer2 which are pointers to the buffers, but
it should use ptr_hotlist1 and ptr_hotlist1 which are pointers to the
hotlists it is trying to compare.