### PR TITLE
irc: don't consume ',' in mirc color code if missing foreground color

### DIFF
--- a/src/plugins/irc/irc-color.c
+++ b/src/plugins/irc/irc-color.c
@@ -188,19 +188,19 @@ irc_color_decode (const char *string, int keep_colors)
                         str_fg[2] = '\0';
                         ptr_string++;
                     }
-                }
-                if ((ptr_string[0] == ',') && (isdigit (ptr_string[1])))
-                {
-                    /* background */
-                    ptr_string++;
-                    str_bg[0] = ptr_string[0];
-                    str_bg[1] = '\0';
-                    ptr_string++;
-                    if (isdigit (ptr_string[0]))
+                    if ((ptr_string[0] == ',') && (isdigit (ptr_string[1])))
                     {
-                        str_bg[1] = ptr_string[0];
-                        str_bg[2] = '\0';
+                        /* background */
                         ptr_string++;
+                        str_bg[0] = ptr_string[0];
+                        str_bg[1] = '\0';
+                        ptr_string++;
+                        if (isdigit (ptr_string[0]))
+                        {
+                            str_bg[1] = ptr_string[0];
+                            str_bg[2] = '\0';
+                            ptr_string++;
+                        }
                     }
                 }
                 if (keep_colors)
@@ -315,56 +315,57 @@ irc_color_encode (const char *string, int keep_colors)
                 if (keep_colors)
                     weechat_string_dyn_concat (out, IRC_COLOR_COLOR_STR, -1);
                 ptr_string++;
+                if (!isdigit (ptr_string[0]))
+		    break;
+
+                /* foreground */
+                if (keep_colors)
+                {
+                    weechat_string_dyn_concat (out,
+                                               (const char *)ptr_string,
+                                               1);
+                }
+                ptr_string++;
                 if (isdigit (ptr_string[0]))
                 {
-                    /* foreground */
                     if (keep_colors)
                     {
-                        weechat_string_dyn_concat (out,
-                                                   (const char *)ptr_string,
-                                                   1);
+                        weechat_string_dyn_concat (
+                            out,
+                            (const char *)ptr_string,
+                            1);
                     }
                     ptr_string++;
-                    if (isdigit (ptr_string[0]))
-                    {
-                        if (keep_colors)
-                        {
-                            weechat_string_dyn_concat (
-                                out,
-                                (const char *)ptr_string,
-                                1);
-                        }
-                        ptr_string++;
-                    }
                 }
+
                 if (ptr_string[0] == ',')
                 {
-                    /* background */
-                    if (keep_colors)
-                        weechat_string_dyn_concat (out, ",", -1);
-                    ptr_string++;
-                    if (isdigit (ptr_string[0]))
-                    {
-                        if (keep_colors)
-                        {
-                            weechat_string_dyn_concat (
-                                out,
-                                (const char *)ptr_string,
-                                1);
-                        }
-                        ptr_string++;
-                        if (isdigit (ptr_string[0]))
-                        {
-                            if (keep_colors)
-                            {
-                                weechat_string_dyn_concat (
-                                    out,
-                                    (const char *)ptr_string,
-                                    1);
-                            }
-                            ptr_string++;
-                        }
-                    }
+                  /* background */
+                  if (keep_colors)
+                      weechat_string_dyn_concat (out, ",", -1);
+                  ptr_string++;
+                  if (isdigit (ptr_string[0]))
+                  {
+                      if (keep_colors)
+                      {
+                          weechat_string_dyn_concat (
+                              out,
+                              (const char *)ptr_string,
+                              1);
+                      }
+                      ptr_string++;
+                      if (isdigit (ptr_string[0]))
+                      {
+                          if (keep_colors)
+                          {
+                              weechat_string_dyn_concat (
+                                  out,
+                                  (const char *)ptr_string,
+                                  1);
+                          }
+                          ptr_string++;
+                      }
+                  }
                 }
                 break;
             case 0x0F: /* ^O */

--- a/src/plugins/irc/irc-color.h
+++ b/src/plugins/irc/irc-color.h
@@ -41,7 +41,7 @@
 #define IRC_COLOR_BOLD_CHAR      '\x02'  /* bold text                       */
 #define IRC_COLOR_BOLD_STR       "\x02"  /*   [02]...[02]                   */
 
-#define IRC_COLOR_COLOR_CHAR     '\x03'  /* text color: fg / fg,bg / ,bg    */
+#define IRC_COLOR_COLOR_CHAR     '\x03'  /* text color: fg / fg,bg          */
 #define IRC_COLOR_COLOR_STR      "\x03"  /*   [03]15,05...[03]              */
 
 #define IRC_COLOR_RESET_CHAR     '\x0F'  /* reset color/attributes          */


### PR DESCRIPTION
"To specify a background color, a foreground color has to be given. So a
^C,8 attribute is not valid and thus ignored."

Chomping the ',' will corrupt some mirc color scenes.