### PR TITLE
Track registration status in irc server hdata

### DIFF
--- a/src/plugins/irc/irc-config.c
+++ b/src/plugins/irc/irc-config.c
@@ -34,6 +34,7 @@
 #include "irc-channel.h"
 #include "irc-ctcp.h"
 #include "irc-ignore.h"
+#include "irc-mode.h"
 #include "irc-msgbuffer.h"
 #include "irc-nick.h"
 #include "irc-notify.h"
@@ -1218,6 +1219,20 @@ irc_config_server_check_value_cb (const void *pointer, void *data,
                     return 0;
                 }
                 break;
+            case IRC_SERVER_OPTION_REGISTERED_MODE:
+                if (!value || !value[0])
+                    break;
+                /* Only one character should be accepted */
+                if (value[1])
+                {
+                    weechat_printf (
+                            NULL,
+                            _("%s%s: invalid registered mode, must be a single "
+                              "character"),
+                            weechat_prefix ("error"), IRC_PLUGIN_NAME);
+                    return 0;
+                }
+                break;
         }
     }
 
@@ -1269,6 +1284,9 @@ irc_config_server_change_cb (const void *pointer, void *data,
                     break;
                 case IRC_SERVER_OPTION_NOTIFY:
                     irc_notify_new_for_server (ptr_server);
+                    break;
+                case IRC_SERVER_OPTION_REGISTERED_MODE:
+                    irc_mode_registered_mode_change (ptr_server);
                     break;
             }
         }

--- a/src/plugins/irc/irc-config.c
+++ b/src/plugins/irc/irc-config.c
@@ -2502,6 +2502,23 @@ irc_config_server_new_option (struct t_config_file *config_file,
                 callback_change_data,
                 NULL, NULL, NULL);
             break;
+        case IRC_SERVER_OPTION_REGISTERED_MODE:
+            new_option = weechat_config_new_option (
+                config_file, section,
+                option_name, "string",
+                N_("mode type that is set on regeistered users (default is "
+                   "\"r\")"),
+                NULL, 0, 0,
+                default_value, value,
+                null_value_allowed,
+                callback_check_value,
+                callback_check_value_pointer,
+                callback_check_value_data,
+                callback_change,
+                callback_change_pointer,
+                callback_change_data,
+                NULL, NULL, NULL);
+            break;
         case IRC_SERVER_NUM_OPTIONS:
             break;
     }

--- a/src/plugins/irc/irc-config.c
+++ b/src/plugins/irc/irc-config.c
@@ -2506,7 +2506,7 @@ irc_config_server_new_option (struct t_config_file *config_file,
             new_option = weechat_config_new_option (
                 config_file, section,
                 option_name, "string",
-                N_("mode type that is set on regeistered users (default is "
+                N_("mode type that is set on registered users (default is "
                    "\"r\")"),
                 NULL, 0, 0,
                 default_value, value,

--- a/src/plugins/irc/irc-mode.c
+++ b/src/plugins/irc/irc-mode.c
@@ -620,7 +620,7 @@ irc_mode_user_add (struct t_irc_server *server, char mode)
     }
 
     registered_mode = IRC_SERVER_OPTION_STRING(server, IRC_SERVER_OPTION_REGISTERED_MODE);
-    if (registered_mode && *registered_mode && *registered_mode == mode &&
+    if (registered_mode && *registered_mode == mode &&
         server->authentication_method == IRC_SERVER_AUTH_METHOD_NONE)
     {
         server->authentication_method = IRC_SERVER_AUTH_METHOD_OTHER;
@@ -654,8 +654,7 @@ irc_mode_user_remove (struct t_irc_server *server, char mode)
     }
 
     registered_mode = IRC_SERVER_OPTION_STRING(server, IRC_SERVER_OPTION_REGISTERED_MODE);
-    if (registered_mode && *registered_mode && *registered_mode == mode &&
-        server->authentication_method == IRC_SERVER_AUTH_METHOD_OTHER)
+    if (registered_mode && *registered_mode && *registered_mode == mode)
     {
         server->authentication_method = IRC_SERVER_AUTH_METHOD_NONE;
     }

--- a/src/plugins/irc/irc-mode.c
+++ b/src/plugins/irc/irc-mode.c
@@ -585,6 +585,7 @@ void
 irc_mode_user_add (struct t_irc_server *server, char mode)
 {
     char str_mode[2], *nick_modes2;
+    const char *registered_mode;
 
     str_mode[0] = mode;
     str_mode[1] = '\0';
@@ -617,6 +618,13 @@ irc_mode_user_add (struct t_irc_server *server, char mode)
         weechat_bar_item_update ("input_prompt");
         weechat_bar_item_update ("irc_nick_modes");
     }
+
+    registered_mode = IRC_SERVER_OPTION_STRING(server, IRC_SERVER_OPTION_REGISTERED_MODE);
+    if (registered_mode && *registered_mode && *registered_mode == mode &&
+        server->authentication_method == IRC_SERVER_AUTH_METHOD_NONE)
+    {
+        server->authentication_method = IRC_SERVER_AUTH_METHOD_OTHER;
+    }
 }
 
 /*
@@ -628,6 +636,7 @@ irc_mode_user_remove (struct t_irc_server *server, char mode)
 {
     char *pos, *nick_modes2;
     int new_size;
+    const char *registered_mode;
 
     if (server->nick_modes)
     {
@@ -642,6 +651,13 @@ irc_mode_user_remove (struct t_irc_server *server, char mode)
             weechat_bar_item_update ("input_prompt");
             weechat_bar_item_update ("irc_nick_modes");
         }
+    }
+
+    registered_mode = IRC_SERVER_OPTION_STRING(server, IRC_SERVER_OPTION_REGISTERED_MODE);
+    if (registered_mode && *registered_mode && *registered_mode == mode &&
+        server->authentication_method == IRC_SERVER_AUTH_METHOD_OTHER)
+    {
+        server->authentication_method = IRC_SERVER_AUTH_METHOD_NONE;
     }
 }
 

--- a/src/plugins/irc/irc-mode.c
+++ b/src/plugins/irc/irc-mode.c
@@ -654,7 +654,7 @@ irc_mode_user_remove (struct t_irc_server *server, char mode)
     }
 
     registered_mode = IRC_SERVER_OPTION_STRING(server, IRC_SERVER_OPTION_REGISTERED_MODE);
-    if (registered_mode && *registered_mode && *registered_mode == mode)
+    if (registered_mode && *registered_mode == mode)
     {
         server->authentication_method = IRC_SERVER_AUTH_METHOD_NONE;
     }
@@ -709,4 +709,43 @@ irc_mode_user_set (struct t_irc_server *server, const char *modes,
     }
     weechat_bar_item_update ("input_prompt");
     weechat_bar_item_update ("irc_nick_modes");
+}
+
+/*
+ * Update authentication_method when IRC_SERVER_OPTION_REGISTERED_MODE changes
+ */
+void
+irc_mode_registered_mode_change (struct t_irc_server *server)
+{
+    const char *modes, *registered_mode;
+    int found;
+
+    modes = "";
+    found = 0;
+    registered_mode = IRC_SERVER_OPTION_STRING(server, IRC_SERVER_OPTION_REGISTERED_MODE);
+
+    if (server->nick_modes)
+    {
+        modes = server->nick_modes;
+    }
+
+    for (; *modes; modes++)
+    {
+        if (*registered_mode == *modes)
+        {
+            found = 1;
+            break;
+        }
+    }
+
+    if (found)
+    {
+        if (server->authentication_method == IRC_SERVER_AUTH_METHOD_NONE)
+            server->authentication_method = IRC_SERVER_AUTH_METHOD_OTHER;
+    }
+    else
+    {
+        if (server->authentication_method == IRC_SERVER_AUTH_METHOD_OTHER)
+            server->authentication_method = IRC_SERVER_AUTH_METHOD_NONE;
+    }
 }

--- a/src/plugins/irc/irc-mode.h
+++ b/src/plugins/irc/irc-mode.h
@@ -33,5 +33,6 @@ extern int irc_mode_channel_set (struct t_irc_server *server,
                                  const char *modes_arguments);
 extern void irc_mode_user_set (struct t_irc_server *server, const char *modes,
                                int reset_modes);
+extern void irc_mode_registered_mode_change (struct t_irc_server *server);
 
 #endif /* WEECHAT_PLUGIN_IRC_MODE_H */

--- a/src/plugins/irc/irc-protocol.c
+++ b/src/plugins/irc/irc-protocol.c
@@ -571,6 +571,10 @@ IRC_PROTOCOL_CALLBACK(authenticate)
                             IRC_PLUGIN_NAME,
                             sasl_error);
         }
+        else
+        {
+            server->sasl_mechanism_used = sasl_mechanism;
+        }
         irc_server_sendf (server, 0, NULL, "AUTHENTICATE %s", answer);
         free (answer);
     }
@@ -7281,6 +7285,8 @@ IRC_PROTOCOL_CALLBACK(sasl_end_ok)
 
     IRC_PROTOCOL_RUN_CALLBACK(numeric);
 
+    server->authentication_method = IRC_SERVER_AUTH_METHOD_SASL;
+
     if (!server->is_connected)
         irc_server_sendf (server, 0, NULL, "CAP END");
 
@@ -7305,6 +7311,8 @@ IRC_PROTOCOL_CALLBACK(sasl_end_fail)
         weechat_unhook (server->hook_timer_sasl);
         server->hook_timer_sasl = NULL;
     }
+
+    server->sasl_mechanism_used = -1;
 
     IRC_PROTOCOL_RUN_CALLBACK(numeric);
 

--- a/src/plugins/irc/irc-server.h
+++ b/src/plugins/irc/irc-server.h
@@ -94,6 +94,7 @@ enum t_irc_server_option
     IRC_SERVER_OPTION_SPLIT_MSG_MAX_LENGTH, /* max length of messages        */
     IRC_SERVER_OPTION_CHARSET_MESSAGE,      /* what to decode/encode in msg  */
     IRC_SERVER_OPTION_DEFAULT_CHANTYPES,    /* chantypes if not received     */
+    IRC_SERVER_OPTION_REGISTERED_MODE,      /* mode set on registered user   */
     /* number of server options */
     IRC_SERVER_NUM_OPTIONS,
 };
@@ -151,6 +152,14 @@ enum t_irc_server_utf8mapping
     IRC_SERVER_UTF8MAPPING_RFC8265,
     /* number of utf8mapping */
     IRC_SERVER_NUM_UTF8MAPPING,
+};
+
+/* authentication method */
+enum t_irc_server_auth_method
+{
+    IRC_SERVER_AUTH_METHOD_NONE = 0,
+    IRC_SERVER_AUTH_METHOD_SASL,
+    IRC_SERVER_AUTH_METHOD_OTHER,
 };
 
 /* output queue of messages to server (for sending slowly to server) */
@@ -255,6 +264,8 @@ struct t_irc_server
     time_t last_user_message;       /* time of last user message (anti flood)*/
     time_t last_away_check;         /* time of last away check on server     */
     time_t last_data_purge;         /* time of last purge (some hashtables)  */
+    int authentication_method;      /* authentication method used to login   */
+    int sasl_mechanism_used;        /* SASL method used at login time        */
     struct t_irc_outqueue *outqueue[2];      /* queue for outgoing messages  */
                                              /* with 2 priorities (high/low) */
     struct t_irc_outqueue *last_outqueue[2]; /* last outgoing message        */


### PR DESCRIPTION
I recently realized I had lost my nick registration for some time when my cert expired. So I'd like an easy way to track
(1) if I've been authenticated into an irc server,
(2) if I used SASL, I want to know which method was used.

So I've added this to the irc server hdata. I'm using it like this, but no default formats are changed. It lets me see where I'm using certfp vs SASL PLAIN vs just normal nickserv identify, and lets me remember to check the PLAIN servers every once in a while if they support certfp yet. And if login fails, I'll get a red marker that makes it obvious.
![Screenshot from 2021-03-31 13-53-21](https://user-images.githubusercontent.com/448915/113364552-b162dd80-9308-11eb-91a2-4f6317cd702e.png)

Summary of change:
If SASL login is successful, authentication_method is set to SASL and the sasl_mechanism_used is set to the sasl method used. 

Otherwise, whenever mode +r is set, authentication_method is set to OTHER. If a server uses another mode than 'r' for this, it is configurable. There's no protocol number for getting logged in from PASS or nickserv identify, so I think reacting to the mode is the only option.