### PR TITLE
doc: Update weechat.bar.*.condition to use info:term_width

### DIFF
--- a/doc/en/weechat_user.en.adoc
+++ b/doc/en/weechat_user.en.adoc
@@ -1597,17 +1597,17 @@ Following pointers are available:
 * `+${buffer}+`: the buffer of window where condition is evaluated
 
 Example to display nicklist bar in all buffers with a nicklist, and only if
-width of window is > 100:
+width of terminal is > 100:
 
 ----
-/set weechat.bar.nicklist.conditions "${nicklist} && ${window.win_width} > 100"
+/set weechat.bar.nicklist.conditions "${nicklist} && ${info:term_width} > 100"
 ----
 
-Same condition, but always display nicklist on buffer _&bitlbee_ (even if window
+Same condition, but always display nicklist on buffer _&bitlbee_ (even if terminal
 is small):
 
 ----
-/set weechat.bar.nicklist.conditions "${nicklist} && (${window.win_width} > 100 || ${buffer.full_name} == irc.bitlbee.&bitlbee)"
+/set weechat.bar.nicklist.conditions "${nicklist} && (${info:term_width} > 100 || ${buffer.full_name} == irc.bitlbee.&bitlbee)"
 ----
 
 [[bare_display]]


### PR DESCRIPTION
In cf93e953b the `weechat.bar.*.condition` examples have been changed to use `${info:term_width}` instead of `${window.win_width}`. The user guide still shows the old example. This commit syncs the user guide with the on-line help.

I stumbled over this while trying to configure a condition for the buflist. I don't know how doc updates are handled with weechat. I could replace the example in all doc/*/weechat_user.*.adoc` files, but I can't change the description of the example in all languages (all I can offer is german).