### PR TITLE
core: Use mallinfo2() when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ check_include_files("langinfo.h" HAVE_LANGINFO_CODESET)
 check_include_files("sys/resource.h" HAVE_SYS_RESOURCE_H)
 
 check_function_exists(mallinfo HAVE_MALLINFO)
+check_function_exists(mallinfo2 HAVE_MALLINFO2)
 
 check_symbol_exists("eat_newline_glitch" "term.h" HAVE_EAT_NEWLINE_GLITCH)
 

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -5,6 +5,7 @@
 #cmakedefine HAVE_BACKTRACE
 #cmakedefine ICONV_2ARG_IS_CONST 1
 #cmakedefine HAVE_MALLINFO
+#cmakedefine HAVE_MALLINFO2
 #cmakedefine HAVE_EAT_NEWLINE_GLITCH
 #cmakedefine HAVE_ASPELL_VERSION_STRING
 #cmakedefine HAVE_ENCHANT_GET_VERSION

--- a/src/core/wee-debug.c
+++ b/src/core/wee-debug.c
@@ -24,7 +24,7 @@
 #endif
 
 #include <stdlib.h>
-#ifdef HAVE_MALLINFO
+#if defined(HAVE_MALLINFO) || defined(HAVE_MALLINFO2)
 #include <malloc.h>
 #endif
 #include <string.h>
@@ -255,6 +255,24 @@ debug_windows_tree ()
 void
 debug_memory ()
 {
+#ifdef HAVE_MALLINFO2
+    struct mallinfo2 info;
+
+    info = mallinfo2 ();
+
+    gui_chat_printf (NULL, "");
+    gui_chat_printf (NULL, _("Memory usage (see \"man mallinfo\" for help):"));
+    gui_chat_printf (NULL, "  arena   :%10zu", info.arena);
+    gui_chat_printf (NULL, "  ordblks :%10zu", info.ordblks);
+    gui_chat_printf (NULL, "  smblks  :%10zu", info.smblks);
+    gui_chat_printf (NULL, "  hblks   :%10zu", info.hblks);
+    gui_chat_printf (NULL, "  hblkhd  :%10zu", info.hblkhd);
+    gui_chat_printf (NULL, "  usmblks :%10zu", info.usmblks);
+    gui_chat_printf (NULL, "  fsmblks :%10zu", info.fsmblks);
+    gui_chat_printf (NULL, "  uordblks:%10zu", info.uordblks);
+    gui_chat_printf (NULL, "  fordblks:%10zu", info.fordblks);
+    gui_chat_printf (NULL, "  keepcost:%10zu", info.keepcost);
+#else
 #ifdef HAVE_MALLINFO
     struct mallinfo info;
 
@@ -277,6 +295,7 @@ debug_memory ()
                      _("Memory usage not available (function \"mallinfo\" not "
                        "found)"));
 #endif /* HAVE_MALLINFO */
+#endif /* HAVE_MALLINFO2 */
 }
 
 /*


### PR DESCRIPTION
mallinfo() is deprecated in glibc 2.33

https://sourceware.org/pipermail/libc-alpha/2021-February/122207.html