### PR TITLE
core: fix build error if ENABLE_NLS is OFF

### DIFF
--- a/src/core/weechat.h
+++ b/src/core/weechat.h
@@ -50,6 +50,7 @@
     #define _(string) (string)
     #define NG_(single,plural,number) (plural)
     #define N_(string) (string)
+    #define gettext(string) (string)
 #endif /* !defined(_) */
 
 


### PR DESCRIPTION
wee-eval.c calls gettext directly, but gettext is not a function if
ENABLE_NLS is off. Fix by defining a gettext macro (that expands to its
first argument) if NLS support is disabled.