### PR TITLE
Annotate public symbols and hide the rest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,13 @@ set(CMAKE_SKIP_RPATH ON)
 set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -fsigned-char -Wall -Wextra -Werror-implicit-function-declaration")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsigned-char -Wall -Wextra")
 
+if(POLICY CMP0063)
+  cmake_policy(SET CMP0063 NEW)
+endif()
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+
 # version
 execute_process(COMMAND ${CMAKE_SOURCE_DIR}/version.sh devel-major OUTPUT_VARIABLE VERSION_MAJOR)
 execute_process(COMMAND ${CMAKE_SOURCE_DIR}/version.sh devel-minor OUTPUT_VARIABLE VERSION_MINOR)

--- a/src/plugins/weechat-plugin.h
+++ b/src/plugins/weechat-plugin.h
@@ -58,6 +58,15 @@ struct t_hashtable;
 struct t_hdata;
 struct timeval;
 
+
+#if defined(_WIN32)
+#define WEECHAT_PUBLIC  __declspec(dllimport)
+#elif (defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__) >= 303)
+#define WEECHAT_PUBLIC  __attribute__((visibility("default")))
+#else
+#define WEECHAT_PUBLIC
+#endif
+
 /*
  * IMPORTANT NOTE for WeeChat developers: if you update, add or remove
  * some functions in this file, then please update API version below.
@@ -72,18 +81,18 @@ struct timeval;
 
 /* macros for defining plugin infos */
 #define WEECHAT_PLUGIN_NAME(__name)                                     \
-    char weechat_plugin_name[] = __name;                                \
-    char weechat_plugin_api_version[] = WEECHAT_PLUGIN_API_VERSION;
+    WEECHAT_PUBLIC char weechat_plugin_name[] = __name;                        \
+    WEECHAT_PUBLIC char weechat_plugin_api_version[] = WEECHAT_PLUGIN_API_VERSION;
 #define WEECHAT_PLUGIN_AUTHOR(__author)         \
-    char weechat_plugin_author[] = __author;
+    WEECHAT_PUBLIC char weechat_plugin_author[] = __author;
 #define WEECHAT_PLUGIN_DESCRIPTION(__desc)      \
-    char weechat_plugin_description[] = __desc;
+    WEECHAT_PUBLIC char weechat_plugin_description[] = __desc;
 #define WEECHAT_PLUGIN_VERSION(__version)       \
-    char weechat_plugin_version[] = __version;
+    WEECHAT_PUBLIC char weechat_plugin_version[] = __version;
 #define WEECHAT_PLUGIN_LICENSE(__license)       \
-    char weechat_plugin_license[] = __license;
+    WEECHAT_PUBLIC char weechat_plugin_license[] = __license;
 #define WEECHAT_PLUGIN_PRIORITY(__priority)     \
-    int weechat_plugin_priority = __priority;
+    WEECHAT_PUBLIC int weechat_plugin_priority = __priority;
 
 /* return codes for plugin functions */
 #define WEECHAT_RC_OK                               0
@@ -1157,9 +1166,9 @@ struct t_weechat_plugin
     void (*upgrade_close) (struct t_upgrade_file *upgrade_file);
 };
 
-extern int weechat_plugin_init (struct t_weechat_plugin *plugin,
+WEECHAT_PUBLIC int weechat_plugin_init (struct t_weechat_plugin *plugin,
                                 int argc, char *argv[]);
-extern int weechat_plugin_end (struct t_weechat_plugin *plugin);
+WEECHAT_PUBLIC int weechat_plugin_end (struct t_weechat_plugin *plugin);
 
 /* macros for easy call to plugin API */
 


### PR DESCRIPTION
Currently we export all the symbols from both the weechat executable and
each of the plugins.

Introduce WEECHAT_PUBLIC macro annotating the respective symbols and
hide everything else.

As a result, we shave around 10% of the size of each binary. Savings
should be even more if LTO is used.

Note: since cmake is the only officially supported build system, I did
not bother with autotools.

Signed-off-by: Emil Velikov <emil.l.velikov@gmail.com>