### PR TITLE
irc: allow irc_raw_in/irc_in hooks to eat messages

### DIFF
--- a/src/plugins/irc/irc-protocol.c
+++ b/src/plugins/irc/irc-protocol.c
@@ -6719,14 +6719,22 @@ irc_protocol_recv_command (struct t_irc_server *server,
         host_no_color);
 
     /* send signal with received command, even if command is ignored */
-    irc_server_send_signal (server, "irc_raw_in", msg_command,
-                            irc_message, NULL);
+    return_code = irc_server_send_signal (server, "irc_raw_in", msg_command,
+                                          irc_message, NULL);
+    if (return_code == WEECHAT_RC_OK_EAT)
+    {
+        goto end;
+    }
 
     /* send signal with received command, only if message is not ignored */
     if (!message_ignored)
     {
-        irc_server_send_signal (server, "irc_in", msg_command,
-                                irc_message, NULL);
+        return_code = irc_server_send_signal (server, "irc_in", msg_command,
+                                              irc_message, NULL);
+        if (return_code == WEECHAT_RC_OK_EAT)
+        {
+            goto end;
+        }
     }
 
     /* look for IRC command */

--- a/src/plugins/irc/irc-server.c
+++ b/src/plugins/irc/irc-server.c
@@ -2338,13 +2338,14 @@ irc_server_reorder (const char **servers, int num_servers)
  * Sends a signal for an IRC message (received or sent).
  */
 
-void
+int
 irc_server_send_signal (struct t_irc_server *server, const char *signal,
                         const char *command, const char *full_message,
                         const char *tags)
 {
     int length;
     char *str_signal, *full_message_tags;
+    int rc = WEECHAT_RC_OK;
 
     length = strlen (server->name) + 1 + strlen (signal) + 1 + strlen (command) + 1;
     str_signal = malloc (length);
@@ -2360,20 +2361,22 @@ irc_server_send_signal (struct t_irc_server *server, const char *signal,
             {
                 snprintf (full_message_tags, length,
                           "%s;%s", tags, full_message);
-                (void) weechat_hook_signal_send (str_signal,
-                                                 WEECHAT_HOOK_SIGNAL_STRING,
-                                                 (void *)full_message_tags);
+                rc = weechat_hook_signal_send (str_signal,
+                                               WEECHAT_HOOK_SIGNAL_STRING,
+                                               (void *)full_message_tags);
                 free (full_message_tags);
             }
         }
         else
         {
-            (void) weechat_hook_signal_send (str_signal,
-                                             WEECHAT_HOOK_SIGNAL_STRING,
-                                             (void *)full_message);
+            rc = weechat_hook_signal_send (str_signal,
+                                           WEECHAT_HOOK_SIGNAL_STRING,
+                                           (void *)full_message);
         }
         free (str_signal);
     }
+
+    return rc;
 }
 
 /*

--- a/src/plugins/irc/irc-server.h
+++ b/src/plugins/irc/irc-server.h
@@ -355,7 +355,7 @@ extern struct t_irc_server *irc_server_copy (struct t_irc_server *server,
                                              const char *new_name);
 extern int irc_server_rename (struct t_irc_server *server, const char *new_name);
 extern int irc_server_reorder (const char **servers, int num_servers);
-extern void irc_server_send_signal (struct t_irc_server *server,
+extern int irc_server_send_signal (struct t_irc_server *server,
                                     const char *signal, const char *command,
                                     const char *full_message,
                                     const char *tags);


### PR DESCRIPTION
This is useful to implement IRC protocol extensions which introduce
new commands.