### PR TITLE
Update README for optional dependencies.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -68,7 +68,9 @@ WeeChat can be built with https://cmake.org/[CMake] (recommended) or autotools.
 [NOTE]
 Only CMake is officially supported to build WeeChat. You should only use
 autotools if you are not able to use CMake. +
-Building with autotools requires more dependencies and is slower than with CMake.
+Building with autotools is slower than with CMake.
+
+Note that to build with or without optional dependencies, `-DENABLE_<DEPENDENCY>=<ON/OFF>` must be provide to cmake.
 
 * Installation in system directories (requires _root_ privileges):
 


### PR DESCRIPTION
Many of the optional dependencies are enabled by default for cmake, and it isn't mentioned how to disable them.

Autotools actually seems a little more maintained in this regard, where, for me and unlike cmake, it will automatically disable some features requiring missing optional dependencies.