### PR TITLE
Treating reop list like other modelists.

### DIFF
--- a/src/plugins/irc/irc-redirect.c
+++ b/src/plugins/irc/irc-redirect.c
@@ -104,6 +104,22 @@ struct t_irc_redirect_pattern irc_redirect_patterns_default[] =
       NULL,
       NULL, NULL,
     },
+    { "mode_channel_reop", 0, 0, /* mode #channel R */
+      /*
+       * mode_channel_reop: start: 344: reop
+       *                     stop: 345: end of reop list
+       *                           403: no such channel
+       *                           442: not on channel
+       *                           472: unknown mode char to me
+       *                           479: cannot join channel (illegal name)
+       *                           482: you're not channel operator
+       *                    extra: -
+       */
+      "344:1",
+      "345:1,403:1,442:1,472,479:1,482:1",
+      NULL,
+      NULL, NULL,
+    },
     { "mode_channel_invite", 0, 0, /* mode #channel I */
       /*
        * mode_channel_invite: start: 346: invite

--- a/src/plugins/relay/irc/relay-irc.c
+++ b/src/plugins/relay/irc/relay-irc.c
@@ -1713,6 +1713,13 @@ relay_irc_recv (struct t_relay_client *client, const char *data)
                                     weechat_hashtable_set (hash_redirect, "pattern",
                                                            "mode_channel_ban_exception");
                                 }
+                                else if ((strcmp (irc_argv[1], "R") == 0)
+                                         || (strcmp (irc_argv[1], "+R") == 0))
+                                {
+                                    redirect_msg = 1;
+                                    weechat_hashtable_set (hash_redirect, "pattern",
+                                                           "mode_channel_reop");
+                                }
                                 else if ((strcmp (irc_argv[1], "I") == 0)
                                          || (strcmp (irc_argv[1], "+I") == 0))
                                 {


### PR DESCRIPTION
The main reason for this patch is to route reop list messages to the
appropriate channel buffer.