### PR TITLE
Remove old and unused config option weechat.plugin.debug

### DIFF
--- a/src/core/wee-config.c
+++ b/src/core/wee-config.c
@@ -299,7 +299,6 @@ struct t_config_option *config_network_proxy_curl;
 /* config, plugin section */
 
 struct t_config_option *config_plugin_autoload;
-struct t_config_option *config_plugin_debug;
 struct t_config_option *config_plugin_extension;
 struct t_config_option *config_plugin_path;
 struct t_config_option *config_plugin_save_config_on_unload;
@@ -4560,13 +4559,6 @@ config_weechat_init_options ()
            "wildcard \"*\" is allowed in names (examples: \"*\" or "
            "\"*,!lua,!tcl\")"),
         NULL, 0, 0, "*", NULL, 0,
-        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-    config_plugin_debug = config_file_new_option (
-        weechat_config_file, ptr_section,
-        "debug", "boolean",
-        N_("enable debug messages by default in all plugins (option disabled "
-           "by default, which is highly recommended)"),
-        NULL, 0, 0, "off", NULL, 0,
         NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
     config_plugin_extension = config_file_new_option (
         weechat_config_file, ptr_section,

--- a/src/core/wee-config.h
+++ b/src/core/wee-config.h
@@ -342,7 +342,6 @@ extern struct t_config_option *config_network_gnutls_handshake_timeout;
 extern struct t_config_option *config_network_proxy_curl;
 
 extern struct t_config_option *config_plugin_autoload;
-extern struct t_config_option *config_plugin_debug;
 extern struct t_config_option *config_plugin_extension;
 extern struct t_config_option *config_plugin_path;
 extern struct t_config_option *config_plugin_save_config_on_unload;


### PR DESCRIPTION
As far as I can see, this option is not used anywhere and should have
been removed in commit 6e69f7f3c.