### PR TITLE
core: Serbian message translation fixes

### DIFF
--- a/po/sr.po
+++ b/po/sr.po
@@ -21,7 +21,7 @@ msgstr ""
 "Project-Id-Version: WeeChat\n"
 "Report-Msgid-Bugs-To: flashcode@flashtux.org\n"
 "POT-Creation-Date: 2022-06-18 16:05+0200\n"
-"PO-Revision-Date: 2022-07-05 21:18+0200\n"
+"PO-Revision-Date: 2022-07-06 08:29+0400\n"
 "Last-Translator: Ivan Pešić <ivan.pesic@gmail.com>\n"
 "Language-Team: weechat-dev <weechat-dev@nongnu.org>\n"
 "Language: sr\n"
@@ -632,7 +632,7 @@ msgstr "%d пречица је обрисано из контекста „%s”
 #, c-format
 msgid "No key binding added, redefined or removed for context \"%s\""
 msgstr ""
-"Из контекста \"%s\" није додата, редефинисана или уклоњена ниједна пречица"
+"Из контекста „%s” није додата, редефинисана или уклоњена ниједна пречица"
 
 #, c-format
 msgid "%sUnable to bind key \"%s\""
@@ -1032,7 +1032,7 @@ msgstr "%sНије могуће чување сесије у фајл"
 #, c-format
 msgid "***** Error: exec failed (program: \"%s\"), exiting WeeChat"
 msgstr ""
-"***** Грешка: exec није успела (програм: „%s”), WeeChat завршава извршавање"
+"***** Грешка: exec није успела (програм: „%s”), WeeChat прекида извршавање"
 
 #. TRANSLATORS: "%s" after "started on" is a date
 #, c-format
@@ -7270,7 +7270,7 @@ msgid ""
 msgstr ""
 "услов којим се хвата /set команда и приказују резултати у fset баферу; могу "
 "да се користе следеће променљиве: ${name} (име опције које се даје /set "
-"команди), ${count} (број аргумената пронађених у аргументу команде /set ); "
+"команди), ${count} (број аргумената пронађених у аргументу команде /set); "
 "празан стринг искључује хватање /set команде; ако је вредност „1”, fset "
 "бафер се увек користи са /set командом"
 
@@ -8291,7 +8291,7 @@ msgid ""
 "[<key1>[,<key2>...]] || del [<channel1> [<channel2>...]] || apply || sort"
 msgstr ""
 "add [<канал1> [<канал2>...]] || addraw <канал1>[,<канал2>...] [<кључ1>[,"
-"<кључ2>...]] || del [<кључ1> [<кључ2>...]] || apply || sort"
+"<кључ2>...]] || del [<канал1> [<канал2>...]] || apply || sort"
 
 msgid ""
 "    add: add current channel or a list of channels (with optional keys) to "
@@ -8317,7 +8317,7 @@ msgid ""
 "  /autojoin apply\n"
 "  /autojoin sort"
 msgstr ""
-"   add: додаје текући канал или листу канала ( са необавезним кључевима) у "
+"   add: додаје текући канал или листу канала (са необавезним кључевима) у "
 "autojoin опцију; ако се налазите на каналу и не наведете кључ, он се чита са "
 "канала\n"
 "addraw: користи се IRC сирови формат (исто као за /join команду): сви канали "


### PR DESCRIPTION
I have spotted several issues. Removed some more extra spaces, but one is quite bad, so I had to ask for another pull request.
For the future submissions, I will also wrap the .po file to 79 columns...