### PR TITLE
don't require account-notify/away-notify for WHOX

### DIFF
--- a/src/plugins/irc/irc-channel.c
+++ b/src/plugins/irc/irc-channel.c
@@ -780,30 +780,18 @@ irc_channel_check_whox (struct t_irc_server *server,
 {
     if ((channel->type == IRC_CHANNEL_TYPE_CHANNEL) && channel->nicks)
     {
-        if (weechat_hashtable_has_key (server->cap_list, "away-notify")
-            || weechat_hashtable_has_key (server->cap_list, "account-notify")
-            || ((IRC_SERVER_OPTION_INTEGER(server, IRC_SERVER_OPTION_AWAY_CHECK) > 0)
-                && ((IRC_SERVER_OPTION_INTEGER(server, IRC_SERVER_OPTION_AWAY_CHECK_MAX_NICKS) == 0)
-                    || (channel->nicks_count <= IRC_SERVER_OPTION_INTEGER(server, IRC_SERVER_OPTION_AWAY_CHECK_MAX_NICKS)))))
+        channel->checking_whox++;
+        if (irc_server_get_isupport_value (server, "WHOX"))
         {
-            channel->checking_whox++;
-            if (irc_server_get_isupport_value (server, "WHOX"))
-            {
-                /* WHOX is supported */
-                irc_server_sendf (server, IRC_SERVER_SEND_OUTQ_PRIO_LOW, NULL,
-                                  "WHO %s %%cuhsnfdar", channel->name);
-            }
-            else
-            {
-                /* WHOX is NOT supported */
-                irc_server_sendf (server, IRC_SERVER_SEND_OUTQ_PRIO_LOW, NULL,
-                                  "WHO %s", channel->name);
-            }
+            /* WHOX is supported */
+            irc_server_sendf (server, IRC_SERVER_SEND_OUTQ_PRIO_LOW, NULL,
+                              "WHO %s %%cuhsnfdar", channel->name);
         }
         else
         {
-            irc_channel_remove_account (server, channel);
-            irc_channel_remove_away (server, channel);
+            /* WHOX is NOT supported */
+            irc_server_sendf (server, IRC_SERVER_SEND_OUTQ_PRIO_LOW, NULL,
+                              "WHO %s", channel->name);
         }
     }
 }


### PR DESCRIPTION
when you connect weechat to znc, you first get a `CAP` dance like this:

```
-> :irc.znc.in CAP unknown-nick LS :batch cap-notify echo-message multi-prefix server-time userhost-in-names znc.in/batch znc.in/self-message znc.in/server-time-iso
<- CAP REQ :cap-notify multi-prefix server-time userhost-in-names
<- CAP END
-> @time=2022-07-10T20:19:26.599Z :irc.znc.in CAP * ACK :cap-notify multi-prefix server-time userhost-in-names
```

and then once znc has figured out what network you're connecting to, you get this:
```
-> @time=2022-07-10T20:19:26.608Z :irc.znc.in CAP user NEW :account-notify away-notify extended-join
<- CAP REQ :account-notify away-notify extended-join
```

and then it takes until after znc has already finished replaying `NAMES` to you for you to get this
```
-> @time=2022-07-10T20:19:26.621Z :irc.znc.in CAP user ACK :account-notify away-notify extended-join
```

which means by the time you're hitting the code that I'm changing, you don't know that the network you're on supports `away-notify` or `account-notify`, which means this `if` will reliably fail and weechat simply won't send a WHOX request. this can be solved by simply sending WHOX whenever a network supports it.