### PR TITLE
doc/api: Add values for hook_process constants

### DIFF
--- a/doc/en/weechat_plugin_api.en.adoc
+++ b/doc/en/weechat_plugin_api.en.adoc
@@ -9468,9 +9468,9 @@ Arguments:
 **** _3_: not enough memory
 **** _4_: error with a file
 *** _< 0_:
-**** _WEECHAT_HOOK_PROCESS_RUNNING_: data available, but child still running
-**** _WEECHAT_HOOK_PROCESS_ERROR_: error when launching command
-**** _WEECHAT_HOOK_PROCESS_CHILD_: callback is called in the child process
+**** _WEECHAT_HOOK_PROCESS_RUNNING_ (-1): data available, but child still running
+**** _WEECHAT_HOOK_PROCESS_ERROR_ (-2): error when launching command
+**** _WEECHAT_HOOK_PROCESS_CHILD_ (-3): callback is called in the child process
      (used only in C API, not scripting API)
 ** _out_: standard output of command (stdout)
 ** _err_: error output of command (stderr)

--- a/doc/fr/weechat_plugin_api.fr.adoc
+++ b/doc/fr/weechat_plugin_api.fr.adoc
@@ -9635,10 +9635,10 @@ Paramètres :
 **** _3_ : pas assez de mémoire
 **** _4_ : erreur avec un fichier
 *** _< 0_ :
-**** _WEECHAT_HOOK_PROCESS_RUNNING_ : données disponibles, mais le fils tourne
+**** _WEECHAT_HOOK_PROCESS_RUNNING_ (-1) : données disponibles, mais le fils tourne
      toujours
-**** _WEECHAT_HOOK_PROCESS_ERROR_ : erreur en lançant la commande
-**** _WEECHAT_HOOK_PROCESS_CHILD_: la fonction de rappel est appelée dans le
+**** _WEECHAT_HOOK_PROCESS_ERROR_ (-2) : erreur en lançant la commande
+**** _WEECHAT_HOOK_PROCESS_CHILD_ (-3) : la fonction de rappel est appelée dans le
      processus fils (utilisé seulement dans l'API C, pas l'API script)
 ** _out_ : sortie standard de la commande (stdout)
 ** _err_ : erreurs de la commande (stderr)

--- a/doc/it/weechat_plugin_api.it.adoc
+++ b/doc/it/weechat_plugin_api.it.adoc
@@ -9770,11 +9770,11 @@ Argomenti:
 **** _3_: memoria non sufficiente
 **** _4_: errore con un file
 *** _< 0_:
-**** _WEECHAT_HOOK_PROCESS_RUNNING_: dati disponibili, ma figlio ancora in
+**** _WEECHAT_HOOK_PROCESS_RUNNING_ (-1): dati disponibili, ma figlio ancora in
      esecuzione
-**** _WEECHAT_HOOK_PROCESS_ERROR_: errore nella esecuzione del comando
+**** _WEECHAT_HOOK_PROCESS_ERROR_ (-2): errore nella esecuzione del comando
 // TRANSLATION MISSING
-**** _WEECHAT_HOOK_PROCESS_CHILD_: callback is called in the child process
+**** _WEECHAT_HOOK_PROCESS_CHILD_ (-3): callback is called in the child process
      (used only in C API, not scripting API)
 ** _out_: output standard del comando (stdout)
 ** _err_: output di errore del comando (stderr)

--- a/doc/ja/weechat_plugin_api.ja.adoc
+++ b/doc/ja/weechat_plugin_api.ja.adoc
@@ -9510,10 +9510,10 @@ struct t_hook *weechat_hook_process (const char *command,
 **** _3_: メモリ不足
 **** _4_: ファイルに関するエラー
 *** _< 0_:
-**** _WEECHAT_HOOK_PROCESS_RUNNING_: データは利用可能だが子プロセスは終了していない
-**** _WEECHAT_HOOK_PROCESS_ERROR_: コマンドの起動中にエラー
+**** _WEECHAT_HOOK_PROCESS_RUNNING_ (-1): データは利用可能だが子プロセスは終了していない
+**** _WEECHAT_HOOK_PROCESS_ERROR_ (-2): コマンドの起動中にエラー
 // TRANSLATION MISSING
-**** _WEECHAT_HOOK_PROCESS_CHILD_: 子プロセスからコールバックが呼び出された
+**** _WEECHAT_HOOK_PROCESS_CHILD_ (-3): 子プロセスからコールバックが呼び出された
      (used only in C API, not scripting API)
 ** _out_: コマンドの標準出力 (stdout)
 ** _err_: コマンドの標準エラー出力 (stderr)

--- a/doc/sr/weechat_plugin_api.sr.adoc
+++ b/doc/sr/weechat_plugin_api.sr.adoc
@@ -9166,10 +9166,10 @@ struct t_hook *weechat_hook_process (const char *command,
 **** _3_: нема довољно слободне меморије
 **** _4_: грешка са фајлом
 *** _< 0_:
-**** _WEECHAT_HOOK_PROCESS_RUNNING_: подаци су доступни, али се дете још увек извршава
-**** _WEECHAT_HOOK_PROCESS_ERROR_: грешка приликом покретања команде
+**** _WEECHAT_HOOK_PROCESS_RUNNING_ (-1): подаци су доступни, али се дете још увек извршава
+**** _WEECHAT_HOOK_PROCESS_ERROR_ (-2): грешка приликом покретања команде
 // TRANSLATION MISSING
-**** _WEECHAT_HOOK_PROCESS_CHILD_: у дете процесу је позвана функција повратног позива
+**** _WEECHAT_HOOK_PROCESS_CHILD_ (-3): у дете процесу је позвана функција повратног позива
      (used only in C API, not scripting API)
 ** _out_: стандардни излаз команде (stdout)
 ** _err_: излаз грешака команде (stderr)


### PR DESCRIPTION
When logging this value I just see a number so I have to look up what it means. Previously you would have to check the code or print the value of each of these constants to see it. Seeing the value directly in the documentation makes this much easier.