### PR TITLE
python: Fix return types for config option callbacks

### DIFF
--- a/doc/en/weechat_plugin_api.en.adoc
+++ b/doc/en/weechat_plugin_api.en.adoc
@@ -6604,10 +6604,10 @@ def option4_check_value_cb(data: str, option: str, value: str) -> int:
     return 1
     # return 0
 
-def option4_change_cb(data: str, option: str) -> int:
+def option4_change_cb(data: str, option: str) -> None:
     # ...
 
-def option4_delete_cb(data: str, option: str) -> int:
+def option4_delete_cb(data: str, option: str) -> None:
     # ...
 
 option1 = weechat.config_new_option(config_file, section, "option1", "boolean",

--- a/doc/fr/weechat_plugin_api.fr.adoc
+++ b/doc/fr/weechat_plugin_api.fr.adoc
@@ -6709,10 +6709,10 @@ def option4_check_value_cb(data: str, option: str, value: str) -> int:
     return 1
     # return 0
 
-def option4_change_cb(data: str, option: str) -> int:
+def option4_change_cb(data: str, option: str) -> None:
     # ...
 
-def option4_delete_cb(data: str, option: str) -> int:
+def option4_delete_cb(data: str, option: str) -> None:
     # ...
 
 option1 = weechat.config_new_option(config_file, section, "option1", "boolean",

--- a/doc/it/weechat_plugin_api.it.adoc
+++ b/doc/it/weechat_plugin_api.it.adoc
@@ -6836,10 +6836,10 @@ def option4_check_value_cb(data: str, option: str, value: str) -> int:
     return 1
     # return 0
 
-def option4_change_cb(data: str, option: str) -> int:
+def option4_change_cb(data: str, option: str) -> None:
     # ...
 
-def option4_delete_cb(data: str, option: str) -> int:
+def option4_delete_cb(data: str, option: str) -> None:
     # ...
 
 option1 = weechat.config_new_option(config_file, section, "option1", "boolean",

--- a/doc/ja/weechat_plugin_api.ja.adoc
+++ b/doc/ja/weechat_plugin_api.ja.adoc
@@ -6634,10 +6634,10 @@ def option4_check_value_cb(data: str, option: str, value: str) -> int:
     return 1
     # return 0
 
-def option4_change_cb(data: str, option: str) -> int:
+def option4_change_cb(data: str, option: str) -> None:
     # ...
 
-def option4_delete_cb(data: str, option: str) -> int:
+def option4_delete_cb(data: str, option: str) -> None:
     # ...
 
 option1 = weechat.config_new_option(config_file, section, "option1", "boolean",

--- a/doc/sr/weechat_plugin_api.sr.adoc
+++ b/doc/sr/weechat_plugin_api.sr.adoc
@@ -6391,10 +6391,10 @@ def option4_check_value_cb(data: str, option: str, value: str) -> int:
     return 1
     # return 0
 
-def option4_change_cb(data: str, option: str) -> int:
+def option4_change_cb(data: str, option: str) -> None:
     # ...
 
-def option4_delete_cb(data: str, option: str) -> int:
+def option4_delete_cb(data: str, option: str) -> None:
     # ...
 
 option1 = weechat.config_new_option(config_file, section, "option1", "boolean",

--- a/src/plugins/python/weechat.pyi
+++ b/src/plugins/python/weechat.pyi
@@ -550,10 +550,10 @@ def config_new_option(config_file: str, section: str, name: str, type: str, desc
             return 1
             # return 0
 
-        def option4_change_cb(data: str, option: str) -> int:
+        def option4_change_cb(data: str, option: str) -> None:
             # ...
 
-        def option4_delete_cb(data: str, option: str) -> int:
+        def option4_delete_cb(data: str, option: str) -> None:
             # ...
 
         option1 = weechat.config_new_option(config_file, section, "option1", "boolean",


### PR DESCRIPTION
I erroneously typed the return types for these to int in commit e0c117e14, but they should be None.