### PR TITLE
doc/api: Fix return values for callback_read and python examples for config_new_section

### DIFF
--- a/doc/en/weechat_plugin_api.en.adoc
+++ b/doc/en/weechat_plugin_api.en.adoc
@@ -6349,24 +6349,34 @@ def my_section_read_cb(data: str, config_file: str, section: str, option_name: s
     # ...
     return weechat.WEECHAT_CONFIG_OPTION_SET_OK_CHANGED
     # return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
-    # return weechat.WEECHAT_CONFIG_OPTION_SET_OPTION_NOT_FOUND
     # return weechat.WEECHAT_CONFIG_OPTION_SET_ERROR
+    # return weechat.WEECHAT_CONFIG_OPTION_SET_OPTION_NOT_FOUND
 
 def my_section_write_cb(data: str, config_file: str, section_name: str) -> int:
     # ...
     return weechat.WEECHAT_CONFIG_WRITE_OK
+    # return weechat.WEECHAT_CONFIG_WRITE_ERROR
+    # return weechat.WEECHAT_CONFIG_WRITE_MEMORY_ERROR
 
 def my_section_write_default_cb(data: str, config_file: str, section_name: str) -> int:
     # ...
     return weechat.WEECHAT_CONFIG_WRITE_OK
+    # return weechat.WEECHAT_CONFIG_WRITE_ERROR
+    # return weechat.WEECHAT_CONFIG_WRITE_MEMORY_ERROR
 
 def my_section_create_option_cb(data: str, config_file: str, section: str, option_name: str, value: str) -> int:
     # ...
-    return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
+    return weechat.WEECHAT_CONFIG_OPTION_SET_OK_CHANGED
+    # return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
+    # return weechat.WEECHAT_CONFIG_OPTION_SET_ERROR
+    # return weechat.WEECHAT_CONFIG_OPTION_SET_OPTION_NOT_FOUND
 
 def my_section_delete_option_cb(data: str, config_file: str, section: str, option: str) -> int:
     # ...
     return weechat.WEECHAT_CONFIG_OPTION_UNSET_OK_REMOVED
+    # return weechat.WEECHAT_CONFIG_OPTION_UNSET_OK_NO_RESET
+    # return weechat.WEECHAT_CONFIG_OPTION_UNSET_OK_RESET
+    # return weechat.WEECHAT_CONFIG_OPTION_UNSET_ERROR
 
 section = weechat.config_new_section(config_file, "section1", 1, 1,
     "my_section_read_cb", "",

--- a/doc/en/weechat_plugin_api.en.adoc
+++ b/doc/en/weechat_plugin_api.en.adoc
@@ -6156,9 +6156,10 @@ Arguments:
 ** _const char *option_name_: name of option
 ** _const char *value_: value
 ** return value:
-*** _WEECHAT_CONFIG_READ_OK_
-*** _WEECHAT_CONFIG_READ_MEMORY_ERROR_
-*** _WEECHAT_CONFIG_READ_FILE_NOT_FOUND_
+*** _WEECHAT_CONFIG_OPTION_SET_OK_CHANGED_
+*** _WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE_
+*** _WEECHAT_CONFIG_OPTION_SET_ERROR_
+*** _WEECHAT_CONFIG_OPTION_SET_OPTION_NOT_FOUND_
 * _callback_read_pointer_: pointer given to callback when it is called by
   WeeChat
 * _callback_read_data_: pointer given to callback when it is called by WeeChat;
@@ -6251,9 +6252,10 @@ my_section_read_cb (const void *pointer, void *data,
 {
     /* ... */
 
-    return WEECHAT_CONFIG_READ_OK;
-    /* return WEECHAT_CONFIG_READ_MEMORY_ERROR; */
-    /* return WEECHAT_CONFIG_READ_FILE_NOT_FOUND; */
+    return WEECHAT_CONFIG_OPTION_SET_OK_CHANGED;
+    /* return WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE; */
+    /* return WEECHAT_CONFIG_OPTION_SET_ERROR; */
+    /* return WEECHAT_CONFIG_OPTION_SET_OPTION_NOT_FOUND; */
 }
 
 int

--- a/doc/fr/weechat_plugin_api.fr.adoc
+++ b/doc/fr/weechat_plugin_api.fr.adoc
@@ -6448,24 +6448,34 @@ def my_section_read_cb(data: str, config_file: str, section: str, option_name: s
     # ...
     return weechat.WEECHAT_CONFIG_OPTION_SET_OK_CHANGED
     # return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
-    # return weechat.WEECHAT_CONFIG_OPTION_SET_OPTION_NOT_FOUND
     # return weechat.WEECHAT_CONFIG_OPTION_SET_ERROR
+    # return weechat.WEECHAT_CONFIG_OPTION_SET_OPTION_NOT_FOUND
 
 def my_section_write_cb(data: str, config_file: str, section_name: str) -> int:
     # ...
     return weechat.WEECHAT_CONFIG_WRITE_OK
+    # return weechat.WEECHAT_CONFIG_WRITE_ERROR
+    # return weechat.WEECHAT_CONFIG_WRITE_MEMORY_ERROR
 
 def my_section_write_default_cb(data: str, config_file: str, section_name: str) -> int:
     # ...
     return weechat.WEECHAT_CONFIG_WRITE_OK
+    # return weechat.WEECHAT_CONFIG_WRITE_ERROR
+    # return weechat.WEECHAT_CONFIG_WRITE_MEMORY_ERROR
 
 def my_section_create_option_cb(data: str, config_file: str, section: str, option_name: str, value: str) -> int:
     # ...
-    return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
+    return weechat.WEECHAT_CONFIG_OPTION_SET_OK_CHANGED
+    # return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
+    # return weechat.WEECHAT_CONFIG_OPTION_SET_ERROR
+    # return weechat.WEECHAT_CONFIG_OPTION_SET_OPTION_NOT_FOUND
 
 def my_section_delete_option_cb(data: str, config_file: str, section: str, option: str) -> int:
     # ...
     return weechat.WEECHAT_CONFIG_OPTION_UNSET_OK_REMOVED
+    # return weechat.WEECHAT_CONFIG_OPTION_UNSET_OK_NO_RESET
+    # return weechat.WEECHAT_CONFIG_OPTION_UNSET_OK_RESET
+    # return weechat.WEECHAT_CONFIG_OPTION_UNSET_ERROR
 
 section = weechat.config_new_section(config_file, "section1", 1, 1,
     "my_section_read_cb", "",

--- a/doc/fr/weechat_plugin_api.fr.adoc
+++ b/doc/fr/weechat_plugin_api.fr.adoc
@@ -6251,9 +6251,10 @@ Paramètres :
 ** _const char *option_name_ : nom de l'option
 ** _const char *value_ : valeur
 ** valeur de retour :
-*** _WEECHAT_CONFIG_READ_OK_
-*** _WEECHAT_CONFIG_READ_MEMORY_ERROR_
-*** _WEECHAT_CONFIG_READ_FILE_NOT_FOUND_
+*** _WEECHAT_CONFIG_OPTION_SET_OK_CHANGED_
+*** _WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE_
+*** _WEECHAT_CONFIG_OPTION_SET_ERROR_
+*** _WEECHAT_CONFIG_OPTION_SET_OPTION_NOT_FOUND_
 * _callback_read_pointer_ : pointeur donné à la fonction de rappel lorsqu'elle
   est appelée par WeeChat
 * _callback_read_data_ : pointeur donné à la fonction de rappel lorsqu'elle est

--- a/doc/it/weechat_plugin_api.it.adoc
+++ b/doc/it/weechat_plugin_api.it.adoc
@@ -6379,9 +6379,10 @@ Argomenti:
 ** _const char *option_name_: nome dell'opzione
 ** _const char *value_: valore
 ** valore restituito:
-*** _WEECHAT_CONFIG_READ_OK_
-*** _WEECHAT_CONFIG_READ_MEMORY_ERROR_
-*** _WEECHAT_CONFIG_READ_FILE_NOT_FOUND_
+*** _WEECHAT_CONFIG_OPTION_SET_OK_CHANGED_
+*** _WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE_
+*** _WEECHAT_CONFIG_OPTION_SET_ERROR_
+*** _WEECHAT_CONFIG_OPTION_SET_OPTION_NOT_FOUND_
 * _callback_read_pointer_: puntatore fornito alla callback quando chiamata da
   WeeChat
 // TRANSLATION MISSING

--- a/doc/it/weechat_plugin_api.it.adoc
+++ b/doc/it/weechat_plugin_api.it.adoc
@@ -6575,24 +6575,34 @@ def my_section_read_cb(data: str, config_file: str, section: str, option_name: s
     # ...
     return weechat.WEECHAT_CONFIG_OPTION_SET_OK_CHANGED
     # return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
-    # return weechat.WEECHAT_CONFIG_OPTION_SET_OPTION_NOT_FOUND
     # return weechat.WEECHAT_CONFIG_OPTION_SET_ERROR
+    # return weechat.WEECHAT_CONFIG_OPTION_SET_OPTION_NOT_FOUND
 
 def my_section_write_cb(data: str, config_file: str, section_name: str) -> int:
     # ...
     return weechat.WEECHAT_CONFIG_WRITE_OK
+    # return weechat.WEECHAT_CONFIG_WRITE_ERROR
+    # return weechat.WEECHAT_CONFIG_WRITE_MEMORY_ERROR
 
 def my_section_write_default_cb(data: str, config_file: str, section_name: str) -> int:
     # ...
     return weechat.WEECHAT_CONFIG_WRITE_OK
+    # return weechat.WEECHAT_CONFIG_WRITE_ERROR
+    # return weechat.WEECHAT_CONFIG_WRITE_MEMORY_ERROR
 
 def my_section_create_option_cb(data: str, config_file: str, section: str, option_name: str, value: str) -> int:
     # ...
-    return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
+    return weechat.WEECHAT_CONFIG_OPTION_SET_OK_CHANGED
+    # return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
+    # return weechat.WEECHAT_CONFIG_OPTION_SET_ERROR
+    # return weechat.WEECHAT_CONFIG_OPTION_SET_OPTION_NOT_FOUND
 
 def my_section_delete_option_cb(data: str, config_file: str, section: str, option: str) -> int:
     # ...
     return weechat.WEECHAT_CONFIG_OPTION_UNSET_OK_REMOVED
+    # return weechat.WEECHAT_CONFIG_OPTION_UNSET_OK_NO_RESET
+    # return weechat.WEECHAT_CONFIG_OPTION_UNSET_OK_RESET
+    # return weechat.WEECHAT_CONFIG_OPTION_UNSET_ERROR
 
 section = weechat.config_new_section(config_file, "section1", 1, 1,
     "my_section_read_cb", "",

--- a/doc/ja/weechat_plugin_api.ja.adoc
+++ b/doc/ja/weechat_plugin_api.ja.adoc
@@ -6187,9 +6187,10 @@ struct t_config_section *weechat_config_new_section (
 ** _const char *option_name_: オプションの名前
 ** _const char *value_: 値
 ** 戻り値:
-*** _WEECHAT_CONFIG_READ_OK_
-*** _WEECHAT_CONFIG_READ_MEMORY_ERROR_
-*** _WEECHAT_CONFIG_READ_FILE_NOT_FOUND_
+*** _WEECHAT_CONFIG_OPTION_SET_OK_CHANGED_
+*** _WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE_
+*** _WEECHAT_CONFIG_OPTION_SET_ERROR_
+*** _WEECHAT_CONFIG_OPTION_SET_OPTION_NOT_FOUND_
 * _callback_read_pointer_: WeeChat が _callback_read_
   コールバックを呼び出す際にコールバックに渡すポインタ
 * _callback_read_data_: WeeChat が _callback_read_ コールバックを呼び出す際にコールバックに渡すポインタ;

--- a/doc/ja/weechat_plugin_api.ja.adoc
+++ b/doc/ja/weechat_plugin_api.ja.adoc
@@ -6378,24 +6378,34 @@ def my_section_read_cb(data: str, config_file: str, section: str, option_name: s
     # ...
     return weechat.WEECHAT_CONFIG_OPTION_SET_OK_CHANGED
     # return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
-    # return weechat.WEECHAT_CONFIG_OPTION_SET_OPTION_NOT_FOUND
     # return weechat.WEECHAT_CONFIG_OPTION_SET_ERROR
+    # return weechat.WEECHAT_CONFIG_OPTION_SET_OPTION_NOT_FOUND
 
 def my_section_write_cb(data: str, config_file: str, section_name: str) -> int:
     # ...
     return weechat.WEECHAT_CONFIG_WRITE_OK
+    # return weechat.WEECHAT_CONFIG_WRITE_ERROR
+    # return weechat.WEECHAT_CONFIG_WRITE_MEMORY_ERROR
 
 def my_section_write_default_cb(data: str, config_file: str, section_name: str) -> int:
     # ...
     return weechat.WEECHAT_CONFIG_WRITE_OK
+    # return weechat.WEECHAT_CONFIG_WRITE_ERROR
+    # return weechat.WEECHAT_CONFIG_WRITE_MEMORY_ERROR
 
 def my_section_create_option_cb(data: str, config_file: str, section: str, option_name: str, value: str) -> int:
     # ...
-    return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
+    return weechat.WEECHAT_CONFIG_OPTION_SET_OK_CHANGED
+    # return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
+    # return weechat.WEECHAT_CONFIG_OPTION_SET_ERROR
+    # return weechat.WEECHAT_CONFIG_OPTION_SET_OPTION_NOT_FOUND
 
 def my_section_delete_option_cb(data: str, config_file: str, section: str, option: str) -> int:
     # ...
     return weechat.WEECHAT_CONFIG_OPTION_UNSET_OK_REMOVED
+    # return weechat.WEECHAT_CONFIG_OPTION_UNSET_OK_NO_RESET
+    # return weechat.WEECHAT_CONFIG_OPTION_UNSET_OK_RESET
+    # return weechat.WEECHAT_CONFIG_OPTION_UNSET_ERROR
 
 section = weechat.config_new_section(config_file, "section1", 1, 1,
     "my_section_read_cb", "",

--- a/doc/sr/weechat_plugin_api.sr.adoc
+++ b/doc/sr/weechat_plugin_api.sr.adoc
@@ -5982,9 +5982,10 @@ struct t_config_section *weechat_config_new_section (
 ** _const char *option_name_: име опције
 ** _const char *value_: вредност
 ** повратна вредност:
-*** _WEECHAT_CONFIG_READ_OK_
-*** _WEECHAT_CONFIG_READ_MEMORY_ERROR_
-*** _WEECHAT_CONFIG_READ_FILE_NOT_FOUND_
+*** _WEECHAT_CONFIG_OPTION_SET_OK_CHANGED_
+*** _WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE_
+*** _WEECHAT_CONFIG_OPTION_SET_ERROR_
+*** _WEECHAT_CONFIG_OPTION_SET_OPTION_NOT_FOUND_
 * _callback_read_pointer_: показивач који се прослеђује функцији повратног позива када је позове програм WeeChat
 * _callback_read_data_: показивач који се прослеђује функцији повратног позива када је позове програм WeeChat; ако није NULL, алоцирала га је malloc (или нека слична функција) и аутоматски се ослобађа када се ослободи одељак
 * _callback_write_: функција која се позива када се одељак уписује у фајл (у већини случајева би требало да буде NULL, осим ако је потребно да се одељак упише прилагођеном функцијом), аргументи и повратна вредност су:

--- a/doc/sr/weechat_plugin_api.sr.adoc
+++ b/doc/sr/weechat_plugin_api.sr.adoc
@@ -6152,24 +6152,34 @@ def my_section_read_cb(data: str, config_file: str, section: str, option_name: s
     # ...
     return weechat.WEECHAT_CONFIG_OPTION_SET_OK_CHANGED
     # return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
-    # return weechat.WEECHAT_CONFIG_OPTION_SET_OPTION_NOT_FOUND
     # return weechat.WEECHAT_CONFIG_OPTION_SET_ERROR
+    # return weechat.WEECHAT_CONFIG_OPTION_SET_OPTION_NOT_FOUND
 
 def my_section_write_cb(data: str, config_file: str, section_name: str) -> int:
     # ...
     return weechat.WEECHAT_CONFIG_WRITE_OK
+    # return weechat.WEECHAT_CONFIG_WRITE_ERROR
+    # return weechat.WEECHAT_CONFIG_WRITE_MEMORY_ERROR
 
 def my_section_write_default_cb(data: str, config_file: str, section_name: str) -> int:
     # ...
     return weechat.WEECHAT_CONFIG_WRITE_OK
+    # return weechat.WEECHAT_CONFIG_WRITE_ERROR
+    # return weechat.WEECHAT_CONFIG_WRITE_MEMORY_ERROR
 
 def my_section_create_option_cb(data: str, config_file: str, section: str, option_name: str, value: str) -> int:
     # ...
-    return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
+    return weechat.WEECHAT_CONFIG_OPTION_SET_OK_CHANGED
+    # return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
+    # return weechat.WEECHAT_CONFIG_OPTION_SET_ERROR
+    # return weechat.WEECHAT_CONFIG_OPTION_SET_OPTION_NOT_FOUND
 
 def my_section_delete_option_cb(data: str, config_file: str, section: str, option: str) -> int:
     # ...
     return weechat.WEECHAT_CONFIG_OPTION_UNSET_OK_REMOVED
+    # return weechat.WEECHAT_CONFIG_OPTION_UNSET_OK_NO_RESET
+    # return weechat.WEECHAT_CONFIG_OPTION_UNSET_OK_RESET
+    # return weechat.WEECHAT_CONFIG_OPTION_UNSET_ERROR
 
 section = weechat.config_new_section(config_file, "section1", 1, 1,
     "my_section_read_cb", "",

--- a/src/plugins/python/weechat.pyi
+++ b/src/plugins/python/weechat.pyi
@@ -496,24 +496,34 @@ def config_new_section(config_file: str, name: str,
             # ...
             return weechat.WEECHAT_CONFIG_OPTION_SET_OK_CHANGED
             # return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
-            # return weechat.WEECHAT_CONFIG_OPTION_SET_OPTION_NOT_FOUND
             # return weechat.WEECHAT_CONFIG_OPTION_SET_ERROR
+            # return weechat.WEECHAT_CONFIG_OPTION_SET_OPTION_NOT_FOUND
 
         def my_section_write_cb(data: str, config_file: str, section_name: str) -> int:
             # ...
             return weechat.WEECHAT_CONFIG_WRITE_OK
+            # return weechat.WEECHAT_CONFIG_WRITE_ERROR
+            # return weechat.WEECHAT_CONFIG_WRITE_MEMORY_ERROR
 
         def my_section_write_default_cb(data: str, config_file: str, section_name: str) -> int:
             # ...
             return weechat.WEECHAT_CONFIG_WRITE_OK
+            # return weechat.WEECHAT_CONFIG_WRITE_ERROR
+            # return weechat.WEECHAT_CONFIG_WRITE_MEMORY_ERROR
 
         def my_section_create_option_cb(data: str, config_file: str, section: str, option_name: str, value: str) -> int:
             # ...
-            return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
+            return weechat.WEECHAT_CONFIG_OPTION_SET_OK_CHANGED
+            # return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
+            # return weechat.WEECHAT_CONFIG_OPTION_SET_ERROR
+            # return weechat.WEECHAT_CONFIG_OPTION_SET_OPTION_NOT_FOUND
 
         def my_section_delete_option_cb(data: str, config_file: str, section: str, option: str) -> int:
             # ...
             return weechat.WEECHAT_CONFIG_OPTION_UNSET_OK_REMOVED
+            # return weechat.WEECHAT_CONFIG_OPTION_UNSET_OK_NO_RESET
+            # return weechat.WEECHAT_CONFIG_OPTION_UNSET_OK_RESET
+            # return weechat.WEECHAT_CONFIG_OPTION_UNSET_ERROR
 
         section = weechat.config_new_section(config_file, "section1", 1, 1,
             "my_section_read_cb", "",


### PR DESCRIPTION
These return values were wrong in the description and C example. As can
be seen on lines 2835 and 2873-2903 of src/core/wee-config-file.c the
callback_read function should return the same as the function
config_file_option_set plus the value
WEECHAT_CONFIG_OPTION_SET_OPTION_NOT_FOUND (which is also the same as
the possible return values of config_file_option_set_with_string).

The Python example was already correct and the C example was already
correct in the other languages apart from English.

These errors were introduced in commit 02e2b21d3 and commit 5210ff1ae.

Additionally, the return values in the Python examples didn't include
all the return values. This updates the Python examples to include all
the possible return values for the callbacks in config_new_section, like
it is done in the C example. It also aligns the order of the values with
the C example.