### PR TITLE
scripts: Send null values to config section callbacks

### DIFF
--- a/doc/de/weechat_scripting.de.adoc
+++ b/doc/de/weechat_scripting.de.adoc
@@ -201,11 +201,22 @@ Funktionen werden aufgerufen mittels `+weechat.xxx(arg1, arg2, ...)+`.
 
 Funktionen werden aufgerufen mittels `+weechat::xxx arg1 arg2 ...+`.
 
-Da Tcl nur String-Typen hat, gibt es keinen Null-Typ, der als Argument übergeben werden kann
-wenn eine Funktion Nullwerte akzeptiert. Um dies zu überwinden, können Sie die Konstante
-`$::weechat::WEECHAT_NULL` verwenden, das als Nullwert fungiert. Diese Konstante ist definiert
-als `\uFFFF\uFFFF\uFFFFWEECHAT_NULL\uFFFF\uFFFF\uFFFF`, es ist somit sehr unwahrscheinlich
-das es ungewollt verwendet wird.
+// TRANSLATION MISSING
+[[tcl_null]]
+===== Null values
+
+Since Tcl only has string types, there's no null type to pass as an argument
+when a function accepts null values or to get as an argument in a callback
+function. To overcome this the WeeChat API defines the constant
+`$::weechat::WEECHAT_NULL` which acts as a null value. This constant is defined
+as `\uFFFF\uFFFF\uFFFFWEECHAT_NULL\uFFFF\uFFFF\uFFFF`, so it's very unlikely to
+appear unintentionally.
+
+You can pass this constant when a function accepts null as an argument and you
+will get it as the value of an argument in a callback function if the argument
+value is null. To see which functions accept null values and passes null values
+to callbacks, look at the Python prototypes in the
+link:weechat_plugin_api.en.html[WeeChat plugin API reference ^↗^,window=_blank].
 
 [[language_guile]]
 ==== Guile (Scheme)

--- a/doc/en/weechat_plugin_api.en.adoc
+++ b/doc/en/weechat_plugin_api.en.adoc
@@ -6343,7 +6343,7 @@ def config_new_section(config_file: str, name: str,
                        callback_delete_option: str, callback_delete_option_data: str) -> str: ...
 
 # example
-def my_section_read_cb(data: str, config_file: str, section: str, option_name: str, value: str) -> int:
+def my_section_read_cb(data: str, config_file: str, section: str, option_name: str, value: str | None) -> int:
     # ...
     return weechat.WEECHAT_CONFIG_OPTION_SET_OK_CHANGED
     # return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
@@ -6358,7 +6358,7 @@ def my_section_write_default_cb(data: str, config_file: str, section_name: str) 
     # ...
     return weechat.WEECHAT_CONFIG_WRITE_OK
 
-def my_section_create_option_cb(data: str, config_file: str, section: str, option_name: str, value: str) -> int:
+def my_section_create_option_cb(data: str, config_file: str, section: str, option_name: str, value: str | None) -> int:
     # ...
     return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
 

--- a/doc/en/weechat_scripting.en.adoc
+++ b/doc/en/weechat_scripting.en.adoc
@@ -191,11 +191,21 @@ Functions are called with `+weechat.xxx(arg1, arg2, ...)+`.
 
 Functions are called with `+weechat::xxx arg1 arg2 ...+`.
 
+[[tcl_null]]
+===== Null values
+
 Since Tcl only has string types, there's no null type to pass as an argument
-when a function accepts null values. To overcome this you can use the constant
+when a function accepts null values or to get as an argument in a callback
+function. To overcome this the WeeChat API defines the constant
 `$::weechat::WEECHAT_NULL` which acts as a null value. This constant is defined
 as `\uFFFF\uFFFF\uFFFFWEECHAT_NULL\uFFFF\uFFFF\uFFFF`, so it's very unlikely to
 appear unintentionally.
+
+You can pass this constant when a function accepts null as an argument and you
+will get it as the value of an argument in a callback function if the argument
+value is null. To see which functions accept null values and passes null values
+to callbacks, look at the Python prototypes in the
+link:weechat_plugin_api.en.html[WeeChat plugin API reference ^↗^,window=_blank].
 
 [[language_guile]]
 ==== Guile (Scheme)

--- a/doc/fr/weechat_plugin_api.fr.adoc
+++ b/doc/fr/weechat_plugin_api.fr.adoc
@@ -6443,7 +6443,7 @@ def config_new_section(config_file: str, name: str,
                        callback_delete_option: str, callback_delete_option_data: str) -> str: ...
 
 # exemple
-def my_section_read_cb(data: str, config_file: str, section: str, option_name: str, value: str) -> int:
+def my_section_read_cb(data: str, config_file: str, section: str, option_name: str, value: str | None) -> int:
     # ...
     return weechat.WEECHAT_CONFIG_OPTION_SET_OK_CHANGED
     # return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
@@ -6458,7 +6458,7 @@ def my_section_write_default_cb(data: str, config_file: str, section_name: str) 
     # ...
     return weechat.WEECHAT_CONFIG_WRITE_OK
 
-def my_section_create_option_cb(data: str, config_file: str, section: str, option_name: str, value: str) -> int:
+def my_section_create_option_cb(data: str, config_file: str, section: str, option_name: str, value: str | None) -> int:
     # ...
     return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
 

--- a/doc/fr/weechat_scripting.fr.adoc
+++ b/doc/fr/weechat_scripting.fr.adoc
@@ -201,12 +201,22 @@ Les fonctions sont appelées par `+weechat.xxx(arg1, arg2, ...)+`.
 
 Les fonctions sont appelées par `+weechat::xxx arg1 arg2 ...+`.
 
-Étant donné que Tcl n'a que des types "string", il n'y a pas de type null à
-donner comme paramètre quand une fonctionne accepte des valeurs nulles.
-Pour surmonter cela vous pouvez utiliser la constante `$::weechat::WEECHAT_NULL`
-qui agit comme la valeur nulle. Cette constante est définie avec la valeur
-`\uFFFF\uFFFF\uFFFFWEECHAT_NULL\uFFFF\uFFFF\uFFFF`, il est donc très peu probable
-qu'elle apparaisse de manière non intentionnelle.
+// TRANSLATION MISSING
+[[tcl_null]]
+===== Null values
+
+Since Tcl only has string types, there's no null type to pass as an argument
+when a function accepts null values or to get as an argument in a callback
+function. To overcome this the WeeChat API defines the constant
+`$::weechat::WEECHAT_NULL` which acts as a null value. This constant is defined
+as `\uFFFF\uFFFF\uFFFFWEECHAT_NULL\uFFFF\uFFFF\uFFFF`, so it's very unlikely to
+appear unintentionally.
+
+You can pass this constant when a function accepts null as an argument and you
+will get it as the value of an argument in a callback function if the argument
+value is null. To see which functions accept null values and passes null values
+to callbacks, look at the Python prototypes in the
+link:weechat_plugin_api.en.html[WeeChat plugin API reference ^↗^,window=_blank].
 
 [[language_guile]]
 ==== Guile (Scheme)

--- a/doc/it/weechat_plugin_api.it.adoc
+++ b/doc/it/weechat_plugin_api.it.adoc
@@ -6570,7 +6570,7 @@ def config_new_section(config_file: str, name: str,
                        callback_delete_option: str, callback_delete_option_data: str) -> str: ...
 
 # esempio
-def my_section_read_cb(data: str, config_file: str, section: str, option_name: str, value: str) -> int:
+def my_section_read_cb(data: str, config_file: str, section: str, option_name: str, value: str | None) -> int:
     # ...
     return weechat.WEECHAT_CONFIG_OPTION_SET_OK_CHANGED
     # return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
@@ -6585,7 +6585,7 @@ def my_section_write_default_cb(data: str, config_file: str, section_name: str) 
     # ...
     return weechat.WEECHAT_CONFIG_WRITE_OK
 
-def my_section_create_option_cb(data: str, config_file: str, section: str, option_name: str, value: str) -> int:
+def my_section_create_option_cb(data: str, config_file: str, section: str, option_name: str, value: str | None) -> int:
     # ...
     return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
 

--- a/doc/it/weechat_scripting.it.adoc
+++ b/doc/it/weechat_scripting.it.adoc
@@ -210,11 +210,22 @@ Functions are called with `+weechat.xxx(arg1, arg2, ...)+`.
 
 Functions are called with `+weechat::xxx arg1 arg2 ...+`.
 
+// TRANSLATION MISSING
+[[tcl_null]]
+===== Null values
+
 Since Tcl only has string types, there's no null type to pass as an argument
-when a function accepts null values. To overcome this you can use the constant
+when a function accepts null values or to get as an argument in a callback
+function. To overcome this the WeeChat API defines the constant
 `$::weechat::WEECHAT_NULL` which acts as a null value. This constant is defined
 as `\uFFFF\uFFFF\uFFFFWEECHAT_NULL\uFFFF\uFFFF\uFFFF`, so it's very unlikely to
 appear unintentionally.
+
+You can pass this constant when a function accepts null as an argument and you
+will get it as the value of an argument in a callback function if the argument
+value is null. To see which functions accept null values and passes null values
+to callbacks, look at the Python prototypes in the
+link:weechat_plugin_api.en.html[WeeChat plugin API reference ^↗^,window=_blank].
 
 [[language_guile]]
 ==== Guile (Scheme)

--- a/doc/ja/weechat_plugin_api.ja.adoc
+++ b/doc/ja/weechat_plugin_api.ja.adoc
@@ -6373,7 +6373,7 @@ def config_new_section(config_file: str, name: str,
                        callback_delete_option: str, callback_delete_option_data: str) -> str: ...
 
 # 例
-def my_section_read_cb(data: str, config_file: str, section: str, option_name: str, value: str) -> int:
+def my_section_read_cb(data: str, config_file: str, section: str, option_name: str, value: str | None) -> int:
     # ...
     return weechat.WEECHAT_CONFIG_OPTION_SET_OK_CHANGED
     # return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
@@ -6388,7 +6388,7 @@ def my_section_write_default_cb(data: str, config_file: str, section_name: str) 
     # ...
     return weechat.WEECHAT_CONFIG_WRITE_OK
 
-def my_section_create_option_cb(data: str, config_file: str, section: str, option_name: str, value: str) -> int:
+def my_section_create_option_cb(data: str, config_file: str, section: str, option_name: str, value: str | None) -> int:
     # ...
     return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
 

--- a/doc/ja/weechat_scripting.ja.adoc
+++ b/doc/ja/weechat_scripting.ja.adoc
@@ -208,11 +208,21 @@ Functions are called with `+weechat.xxx(arg1, arg2, ...)+`.
 Functions are called with `+weechat::xxx arg1 arg2 ...+`.
 
 // TRANSLATION MISSING
+[[tcl_null]]
+===== Null values
+
 Since Tcl only has string types, there's no null type to pass as an argument
-when a function accepts null values. To overcome this you can use the constant
+when a function accepts null values or to get as an argument in a callback
+function. To overcome this the WeeChat API defines the constant
 `$::weechat::WEECHAT_NULL` which acts as a null value. This constant is defined
 as `\uFFFF\uFFFF\uFFFFWEECHAT_NULL\uFFFF\uFFFF\uFFFF`, so it's very unlikely to
 appear unintentionally.
+
+You can pass this constant when a function accepts null as an argument and you
+will get it as the value of an argument in a callback function if the argument
+value is null. To see which functions accept null values and passes null values
+to callbacks, look at the Python prototypes in the
+link:weechat_plugin_api.en.html[WeeChat plugin API reference ^↗^,window=_blank].
 
 [[language_guile]]
 ==== Guile (Scheme)

--- a/doc/pl/weechat_scripting.pl.adoc
+++ b/doc/pl/weechat_scripting.pl.adoc
@@ -202,11 +202,21 @@ Funkcje są wywoływane za pomocą `+weechat.xxx(arg1, arg2, ...)+`.
 Funkcje są wywoływane za pomocą `+weechat::xxx arg1 arg2 ...+`.
 
 // TRANSLATION MISSING
+[[tcl_null]]
+===== Null values
+
 Since Tcl only has string types, there's no null type to pass as an argument
-when a function accepts null values. To overcome this you can use the constant
+when a function accepts null values or to get as an argument in a callback
+function. To overcome this the WeeChat API defines the constant
 `$::weechat::WEECHAT_NULL` which acts as a null value. This constant is defined
 as `\uFFFF\uFFFF\uFFFFWEECHAT_NULL\uFFFF\uFFFF\uFFFF`, so it's very unlikely to
 appear unintentionally.
+
+You can pass this constant when a function accepts null as an argument and you
+will get it as the value of an argument in a callback function if the argument
+value is null. To see which functions accept null values and passes null values
+to callbacks, look at the Python prototypes in the
+link:weechat_plugin_api.en.html[WeeChat plugin API reference ^↗^,window=_blank].
 
 [[language_guile]]
 ==== Guile (Scheme)

--- a/doc/sr/weechat_plugin_api.sr.adoc
+++ b/doc/sr/weechat_plugin_api.sr.adoc
@@ -6147,7 +6147,7 @@ def config_new_section(config_file: str, name: str,
                        callback_delete_option: str, callback_delete_option_data: str) -> str: ...
 
 # пример
-def my_section_read_cb(data: str, config_file: str, section: str, option_name: str, value: str) -> int:
+def my_section_read_cb(data: str, config_file: str, section: str, option_name: str, value: str | None) -> int:
     # ...
     return weechat.WEECHAT_CONFIG_OPTION_SET_OK_CHANGED
     # return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
@@ -6162,7 +6162,7 @@ def my_section_write_default_cb(data: str, config_file: str, section_name: str) 
     # ...
     return weechat.WEECHAT_CONFIG_WRITE_OK
 
-def my_section_create_option_cb(data: str, config_file: str, section: str, option_name: str, value: str) -> int:
+def my_section_create_option_cb(data: str, config_file: str, section: str, option_name: str, value: str | None) -> int:
     # ...
     return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
 

--- a/doc/sr/weechat_scripting.sr.adoc
+++ b/doc/sr/weechat_scripting.sr.adoc
@@ -176,11 +176,22 @@ Weechat.bar_new("name", "off", "0", "window", "", "left", "vertical", "vertical"
 
 Функције се позивају са `+weechat::xxx арг1 арг2 ...+`.
 
-Пошто Tcl има само стринг типове, не постоји null тип који се прослеђује као
-аргумент када функција прихвата null вредности. Ако то желите да заобиђете,
-употребите константу `$::weechat::WEECHAT_NULL` која се има улогу null вредности.
-Ова константа је дефинисана као `\uFFFF\uFFFF\uFFFFWEECHAT_NULL\uFFFF\uFFFF\uFFFF`,
-тако да је скоро немогуће да се појави без намере.
+// TRANSLATION MISSING
+[[tcl_null]]
+===== Null values
+
+Since Tcl only has string types, there's no null type to pass as an argument
+when a function accepts null values or to get as an argument in a callback
+function. To overcome this the WeeChat API defines the constant
+`$::weechat::WEECHAT_NULL` which acts as a null value. This constant is defined
+as `\uFFFF\uFFFF\uFFFFWEECHAT_NULL\uFFFF\uFFFF\uFFFF`, so it's very unlikely to
+appear unintentionally.
+
+You can pass this constant when a function accepts null as an argument and you
+will get it as the value of an argument in a callback function if the argument
+value is null. To see which functions accept null values and passes null values
+to callbacks, look at the Python prototypes in the
+link:weechat_plugin_api.en.html[WeeChat plugin API reference ^↗^,window=_blank].
 
 [[language_guile]]
 ==== Guile (Scheme)

--- a/src/plugins/guile/weechat-guile-api.c
+++ b/src/plugins/guile/weechat-guile-api.c
@@ -924,7 +924,7 @@ weechat_guile_api_config_read_cb (const void *pointer, void *data,
         func_argv[1] = (char *)API_PTR2STR(config_file);
         func_argv[2] = (char *)API_PTR2STR(section);
         func_argv[3] = (option_name) ? (char *)option_name : empty_arg;
-        func_argv[4] = (value) ? (char *)value : empty_arg;
+        func_argv[4] = (value) ? (char *)value : NULL;
 
         rc = (int *) weechat_guile_exec (script,
                                          WEECHAT_SCRIPT_EXEC_INT,
@@ -1045,7 +1045,7 @@ weechat_guile_api_config_section_create_option_cb (const void *pointer, void *da
         func_argv[1] = (char *)API_PTR2STR(config_file);
         func_argv[2] = (char *)API_PTR2STR(section);
         func_argv[3] = (option_name) ? (char *)option_name : empty_arg;
-        func_argv[4] = (value) ? (char *)value : empty_arg;
+        func_argv[4] = (value) ? (char *)value : NULL;
 
         rc = (int *) weechat_guile_exec (script,
                                          WEECHAT_SCRIPT_EXEC_INT,

--- a/src/plugins/guile/weechat-guile.c
+++ b/src/plugins/guile/weechat-guile.c
@@ -365,8 +365,11 @@ weechat_guile_exec (struct t_plugin_script *script,
         {
             switch (format[i])
             {
-                case 's': /* string */
-                    argv2[i] = scm_from_locale_string ((char *)argv[i]);
+                case 's': /* string or null */
+                    if (argv[i])
+                        argv2[i] = scm_from_locale_string ((char *)argv[i]);
+                    else
+                        argv2[i] = SCM_ELISP_NIL;
                     break;
                 case 'i': /* integer */
                     argv2[i] = scm_from_int (*((int *)argv[i]));

--- a/src/plugins/javascript/weechat-js-api.cpp
+++ b/src/plugins/javascript/weechat-js-api.cpp
@@ -856,7 +856,7 @@ weechat_js_api_config_read_cb (const void *pointer, void *data,
         func_argv[1] = (char *)API_PTR2STR(config_file);
         func_argv[2] = (char *)API_PTR2STR(section);
         func_argv[3] = (option_name) ? (char *)option_name : empty_arg;
-        func_argv[4] = (value) ? (char *)value : empty_arg;
+        func_argv[4] = (value) ? (char *)value : NULL;
 
         rc = (int *)weechat_js_exec (script,
                                      WEECHAT_SCRIPT_EXEC_INT,
@@ -977,7 +977,7 @@ weechat_js_api_config_section_create_option_cb (const void *pointer, void *data,
         func_argv[1] = (char *)API_PTR2STR(config_file);
         func_argv[2] = (char *)API_PTR2STR(section);
         func_argv[3] = (option_name) ? (char *)option_name : empty_arg;
-        func_argv[4] = (value) ? (char *)value : empty_arg;
+        func_argv[4] = (value) ? (char *)value : NULL;
 
         rc = (int *)weechat_js_exec (script,
                                      WEECHAT_SCRIPT_EXEC_INT,

--- a/src/plugins/javascript/weechat-js.cpp
+++ b/src/plugins/javascript/weechat-js.cpp
@@ -205,8 +205,11 @@ weechat_js_exec (struct t_plugin_script *script,
         {
             switch (format[i])
             {
-                case 's': /* string */
-                    argv2[i] = v8::String::New((const char *)argv[i]);
+                case 's': /* string or null */
+                    if (argv[i])
+                        argv2[i] = v8::String::New((const char *)argv[i]);
+                    else
+                        argv2[i] = v8::Null();
                     break;
                 case 'i': /* integer */
                     argv2[i] = v8::Integer::New(*((int *)argv[i]));

--- a/src/plugins/lua/weechat-lua-api.c
+++ b/src/plugins/lua/weechat-lua-api.c
@@ -961,7 +961,7 @@ weechat_lua_api_config_read_cb (const void *pointer, void *data,
         func_argv[1] = (char *)API_PTR2STR(config_file);
         func_argv[2] = (char *)API_PTR2STR(section);
         func_argv[3] = (option_name) ? (char *)option_name : empty_arg;
-        func_argv[4] = (value) ? (char *)value : empty_arg;
+        func_argv[4] = (value) ? (char *)value : NULL;
 
         rc = (int *) weechat_lua_exec (script,
                                        WEECHAT_SCRIPT_EXEC_INT,
@@ -1082,7 +1082,7 @@ weechat_lua_api_config_section_create_option_cb (const void *pointer, void *data
         func_argv[1] = (char *)API_PTR2STR(config_file);
         func_argv[2] = (char *)API_PTR2STR(section);
         func_argv[3] = (option_name) ? (char *)option_name : empty_arg;
-        func_argv[4] = (value) ? (char *)value : empty_arg;
+        func_argv[4] = (value) ? (char *)value : NULL;
 
         rc = (int *) weechat_lua_exec (script,
                                        WEECHAT_SCRIPT_EXEC_INT,

--- a/src/plugins/lua/weechat-lua.c
+++ b/src/plugins/lua/weechat-lua.c
@@ -307,8 +307,11 @@ weechat_lua_exec (struct t_plugin_script *script, int ret_type,
         {
             switch (format[i])
             {
-                case 's': /* string */
-                    lua_pushstring (lua_current_interpreter, (char *)argv[i]);
+                case 's': /* string or null */
+                    if (argv[i])
+                        lua_pushstring (lua_current_interpreter, (char *)argv[i]);
+                    else
+                        lua_pushnil (lua_current_interpreter);
                     break;
                 case 'i': /* integer */
 #if LUA_VERSION_NUM >= 503

--- a/src/plugins/perl/weechat-perl-api.c
+++ b/src/plugins/perl/weechat-perl-api.c
@@ -903,7 +903,7 @@ weechat_perl_api_config_section_read_cb (const void *pointer, void *data,
         func_argv[1] = (char *)API_PTR2STR(config_file);
         func_argv[2] = (char *)API_PTR2STR(section);
         func_argv[3] = (option_name) ? (char *)option_name : empty_arg;
-        func_argv[4] = (value) ? (char *)value : empty_arg;
+        func_argv[4] = (value) ? (char *)value : NULL;
 
         rc = (int *) weechat_perl_exec (script,
                                         WEECHAT_SCRIPT_EXEC_INT,
@@ -1024,7 +1024,7 @@ weechat_perl_api_config_section_create_option_cb (const void *pointer, void *dat
         func_argv[1] = (char *)API_PTR2STR(config_file);
         func_argv[2] = (char *)API_PTR2STR(section);
         func_argv[3] = (option_name) ? (char *)option_name : empty_arg;
-        func_argv[4] = (value) ? (char *)value : empty_arg;
+        func_argv[4] = (value) ? (char *)value : NULL;
 
         rc = (int *) weechat_perl_exec (script,
                                         WEECHAT_SCRIPT_EXEC_INT,

--- a/src/plugins/perl/weechat-perl.c
+++ b/src/plugins/perl/weechat-perl.c
@@ -363,8 +363,11 @@ weechat_perl_exec (struct t_plugin_script *script,
         {
             switch (format[i])
             {
-                case 's': /* string */
-                    XPUSHs (sv_2mortal(newSVpv((char *)argv[i], 0)));
+                case 's': /* string or null */
+                    if (argv[i])
+                        XPUSHs (sv_2mortal(newSVpv((char *)argv[i], 0)));
+                    else
+                        XPUSHs (sv_2mortal(&PL_sv_undef));
                     break;
                 case 'i': /* integer */
                     XPUSHs (sv_2mortal(newSViv(*((int *)argv[i]))));

--- a/src/plugins/php/weechat-php-api.c
+++ b/src/plugins/php/weechat-php-api.c
@@ -1085,7 +1085,7 @@ weechat_php_api_config_section_read_cb (const void *pointer, void *data,
     func_argv[1] = (char *)API_PTR2STR(config_file);
     func_argv[2] = (char *)API_PTR2STR(section);
     func_argv[3] = option_name ? (char *)option_name : weechat_php_empty_arg;
-    func_argv[4] = value ? (char *)value : weechat_php_empty_arg;
+    func_argv[4] = value ? (char *)value : NULL;
 
     weechat_php_cb (pointer, data, func_argv, "sssss",
                     WEECHAT_SCRIPT_EXEC_INT, &rc);
@@ -1142,7 +1142,7 @@ weechat_php_api_config_section_create_option_cb (const void *pointer,
     func_argv[1] = (char *)API_PTR2STR(config_file);
     func_argv[2] = (char *)API_PTR2STR(section);
     func_argv[3] = option_name ? (char *)option_name : weechat_php_empty_arg;
-    func_argv[4] = value ? (char *)value : weechat_php_empty_arg;
+    func_argv[4] = value ? (char *)value : NULL;
 
     weechat_php_cb (pointer, data, func_argv, "sssss",
                     WEECHAT_SCRIPT_EXEC_INT, &rc);

--- a/src/plugins/php/weechat-php.c
+++ b/src/plugins/php/weechat-php.c
@@ -570,8 +570,11 @@ weechat_php_exec (struct t_plugin_script *script, int ret_type,
         {
             switch (format[i])
             {
-                case 's': /* string */
-                    ZVAL_STRING(&params[i], (char *)argv[i]);
+                case 's': /* string or null */
+                    if (argv[i])
+                        ZVAL_STRING(&params[i], (char *)argv[i]);
+                    else
+                        ZVAL_NULL(&params[i]);
                     break;
                 case 'i': /* integer */
                     ZVAL_LONG(&params[i], *((int *)argv[i]));

--- a/src/plugins/python/weechat-python-api.c
+++ b/src/plugins/python/weechat-python-api.c
@@ -890,7 +890,7 @@ weechat_python_api_config_read_cb (const void *pointer, void *data,
         func_argv[1] = (char *)API_PTR2STR(config_file);
         func_argv[2] = (char *)API_PTR2STR(section);
         func_argv[3] = (option_name) ? (char *)option_name : empty_arg;
-        func_argv[4] = (value) ? (char *)value : empty_arg;
+        func_argv[4] = (value) ? (char *)value : NULL;
 
         rc = (int *) weechat_python_exec (script,
                                           WEECHAT_SCRIPT_EXEC_INT,
@@ -1011,7 +1011,7 @@ weechat_python_api_config_section_create_option_cb (const void *pointer, void *d
         func_argv[1] = (char *)API_PTR2STR(config_file);
         func_argv[2] = (char *)API_PTR2STR(section);
         func_argv[3] = (option_name) ? (char *)option_name : empty_arg;
-        func_argv[4] = (value) ? (char *)value : empty_arg;
+        func_argv[4] = (value) ? (char *)value : NULL;
 
         rc = (int *) weechat_python_exec (script,
                                           WEECHAT_SCRIPT_EXEC_INT,

--- a/src/plugins/python/weechat-python.c
+++ b/src/plugins/python/weechat-python.c
@@ -446,7 +446,7 @@ weechat_python_exec (struct t_plugin_script *script,
             {
                 switch (format[i])
                 {
-                    case 's': /* string */
+                    case 's': /* string or null */
                         argv2[i] = argv[i];
                         if (weechat_utf8_is_valid (argv2[i], -1, NULL))
                             format2[i] = 's';  /* str */

--- a/src/plugins/python/weechat.pyi
+++ b/src/plugins/python/weechat.pyi
@@ -492,7 +492,7 @@ def config_new_section(config_file: str, name: str,
     ::
 
         # example
-        def my_section_read_cb(data: str, config_file: str, section: str, option_name: str, value: str) -> int:
+        def my_section_read_cb(data: str, config_file: str, section: str, option_name: str, value: str | None) -> int:
             # ...
             return weechat.WEECHAT_CONFIG_OPTION_SET_OK_CHANGED
             # return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
@@ -507,7 +507,7 @@ def config_new_section(config_file: str, name: str,
             # ...
             return weechat.WEECHAT_CONFIG_WRITE_OK
 
-        def my_section_create_option_cb(data: str, config_file: str, section: str, option_name: str, value: str) -> int:
+        def my_section_create_option_cb(data: str, config_file: str, section: str, option_name: str, value: str | None) -> int:
             # ...
             return weechat.WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE
 

--- a/src/plugins/ruby/weechat-ruby-api.c
+++ b/src/plugins/ruby/weechat-ruby-api.c
@@ -1098,7 +1098,7 @@ weechat_ruby_api_config_read_cb (const void *pointer, void *data,
         func_argv[1] = (char *)API_PTR2STR(config_file);
         func_argv[2] = (char *)API_PTR2STR(section);
         func_argv[3] = (option_name) ? (char *)option_name : empty_arg;
-        func_argv[4] = (value) ? (char *)value : empty_arg;
+        func_argv[4] = (value) ? (char *)value : NULL;
 
         rc = (int *) weechat_ruby_exec (script,
                                         WEECHAT_SCRIPT_EXEC_INT,
@@ -1219,7 +1219,7 @@ weechat_ruby_api_config_section_create_option_cb (const void *pointer, void *dat
         func_argv[1] = (char *)API_PTR2STR(config_file);
         func_argv[2] = (char *)API_PTR2STR(section);
         func_argv[3] = (option_name) ? (char *)option_name : empty_arg;
-        func_argv[4] = (value) ? (char *)value : empty_arg;
+        func_argv[4] = (value) ? (char *)value : NULL;
 
         rc = (int *) weechat_ruby_exec (script,
                                         WEECHAT_SCRIPT_EXEC_INT,

--- a/src/plugins/ruby/weechat-ruby.c
+++ b/src/plugins/ruby/weechat-ruby.c
@@ -480,8 +480,11 @@ weechat_ruby_exec (struct t_plugin_script *script,
         {
             switch (format[i])
             {
-                case 's': /* string */
-                    argv2[i] = rb_str_new2 ((char *)argv[i]);
+                case 's': /* string or null */
+                    if (argv[i])
+                        argv2[i] = rb_str_new2 ((char *)argv[i]);
+                    else
+                        argv2[i] = Qnil;
                     break;
                 case 'i': /* integer */
                     argv2[i] = INT2FIX (*((int *)argv[i]));

--- a/src/plugins/tcl/weechat-tcl-api.c
+++ b/src/plugins/tcl/weechat-tcl-api.c
@@ -1101,7 +1101,7 @@ weechat_tcl_api_config_section_read_cb (const void *pointer, void *data,
         func_argv[1] = (char *)API_PTR2STR(config_file);
         func_argv[2] = (char *)API_PTR2STR(section);
         func_argv[3] = (option_name) ? (char *)option_name : empty_arg;
-        func_argv[4] = (value) ? (char *)value : empty_arg;
+        func_argv[4] = (value) ? (char *)value : WEECHAT_NULL_STRING;
 
         rc = (int *) weechat_tcl_exec (script,
                                        WEECHAT_SCRIPT_EXEC_INT,
@@ -1222,7 +1222,7 @@ weechat_tcl_api_config_section_create_option_cb (const void *pointer, void *data
         func_argv[1] = (char *)API_PTR2STR(config_file);
         func_argv[2] = (char *)API_PTR2STR(section);
         func_argv[3] = (option_name) ? (char *)option_name : empty_arg;
-        func_argv[4] = (value) ? (char *)value : empty_arg;
+        func_argv[4] = (value) ? (char *)value : WEECHAT_NULL_STRING;
 
         rc = (int *) weechat_tcl_exec (script,
                                        WEECHAT_SCRIPT_EXEC_INT,


### PR DESCRIPTION
The callback_read and callback_create_option functions in the scripting
APIs always get the value as a string, never as null. This means that if
the value is null, there is no way for the script to distinguish this
from an empty string for string options. This makes it impossible to
properly make options with fallback values, like the irc server and
server_default options, as far as I can see.

All the scripting languages except Tcl use that language's equivalent
for null. For JavaScript which has both null and undefined, null is
used. For Tcl, the magic null string defined in commit 197a7a01e is used
and the documentation is updated to describe that.

I tested this with these scripts:
https://gist.github.com/trygveaa/2d49c609addf9773d2ed16e15d1e3447

You can load all of those scripts and see the result with this command
(assuming you have the scripts in the current directory):

    weechat -t -r "/filter add script * * script; /script load $(echo script_config.*)"