### PR TITLE
core: Prevent use of uninitialized memory when setting invalid color

### DIFF
--- a/src/core/wee-config-file.c
+++ b/src/core/wee-config-file.c
@@ -1480,6 +1480,14 @@ config_file_option_set (struct t_config_option *option, const char *value,
                         else
                             rc = WEECHAT_CONFIG_OPTION_SET_OK_SAME_VALUE;
                     }
+                    else
+                    {
+                        if (old_value_was_null)
+                        {
+                            free (option->value);
+                            option->value = NULL;
+                        }
+                    }
                 }
                 break;
             case CONFIG_NUM_OPTION_TYPES:


### PR DESCRIPTION
If a color option value is null and is tried being set to an invalid color, the value was set to uninitialized memory which can lead to a segfault.

Can be reproduced with this script:
https://gist.github.com/trygveaa/6ddb3a52f525a7fd8e0908bafa83e07c

The option doesn't have to be set from a script, it also happens with the /set command.