### PR TITLE
doc: Fix typo in highlight_disable_regex option name

### DIFF
--- a/doc/de/weechat_user.de.adoc
+++ b/doc/de/weechat_user.de.adoc
@@ -2239,7 +2239,7 @@ Zum Beispiel, Nachrichten die eine Hervorhebung besitzen, wo die Nachricht
 mit "flash" zwischen spitzen Klammern beginnt:
 
 ----
-/set weechat.look.highlight_regex "<flash.*>"
+/set weechat.look.highlight_disable_regex "<flash.*>"
 ----
 
 Dies kann auch mit der Buffereigenschaft „highlight_disable_regex“ eingestellt werden.

--- a/doc/en/weechat_user.en.adoc
+++ b/doc/en/weechat_user.en.adoc
@@ -2210,7 +2210,7 @@ For example to disable any highlight on messages with a word beginning
 with "flash" between chevrons:
 
 ----
-/set weechat.look.highlight_regex "<flash.*>"
+/set weechat.look.highlight_disable_regex "<flash.*>"
 ----
 
 This can also be set with the buffer property "highlight_disable_regex".

--- a/doc/fr/weechat_user.fr.adoc
+++ b/doc/fr/weechat_user.fr.adoc
@@ -2269,7 +2269,7 @@ Par exemple pour désactiver tout highlight sur les messages avec un mot
 commençant par "flash" entre chevrons :
 
 ----
-/set weechat.look.highlight_regex "<flash.*>"
+/set weechat.look.highlight_disable_regex "<flash.*>"
 ----
 
 Ceci peut aussi être défini avec la propriété de tampon "highlight_disable_regex".

--- a/doc/it/weechat_user.it.adoc
+++ b/doc/it/weechat_user.it.adoc
@@ -2426,7 +2426,7 @@ For example to disable any highlight on messages with a word beginning
 with "flash" between chevrons:
 
 ----
-/set weechat.look.highlight_regex "<flash.*>"
+/set weechat.look.highlight_disable_regex "<flash.*>"
 ----
 
 This can also be set with the buffer property "highlight_disable_regex".

--- a/doc/ja/weechat_user.ja.adoc
+++ b/doc/ja/weechat_user.ja.adoc
@@ -2327,7 +2327,7 @@ For example to disable any highlight on messages with a word beginning
 with "flash" between chevrons:
 
 ----
-/set weechat.look.highlight_regex "<flash.*>"
+/set weechat.look.highlight_disable_regex "<flash.*>"
 ----
 
 This can also be set with the buffer property "highlight_disable_regex".

--- a/doc/pl/weechat_user.pl.adoc
+++ b/doc/pl/weechat_user.pl.adoc
@@ -2244,7 +2244,7 @@ For example to disable any highlight on messages with a word beginning
 with "flash" between chevrons:
 
 ----
-/set weechat.look.highlight_regex "<flash.*>"
+/set weechat.look.highlight_disable_regex "<flash.*>"
 ----
 
 This can also be set with the buffer property "highlight_disable_regex".

--- a/doc/sr/weechat_user.sr.adoc
+++ b/doc/sr/weechat_user.sr.adoc
@@ -2098,7 +2098,7 @@ include::includes/autogen_user_options.sr.adoc[tag=charset_options]
 почиње на „flash” унутар угластих заграда:
 
 ----
-/set weechat.look.highlight_regex "<flash.*>"
+/set weechat.look.highlight_disable_regex "<flash.*>"
 ----
 
 Ово такође може да се постави и са особином бафера „highlight_disable_regex”.


### PR DESCRIPTION
The section describes highlight_disable_regex, but the example used highlight_regex instead.