### PR TITLE
ruby: add detection of Ruby 3.2

### DIFF
--- a/ChangeLog.adoc
+++ b/ChangeLog.adoc
@@ -57,6 +57,7 @@ Build::
   * spell: add detection of enchant-2 (issue #1859)
   * python: remove support of Python 2.x
   * debian: change dependency guile-2.2-dev to guile-3.0-dev
+  * ruby: add detection of Ruby 3.2
 
 [[v3.7.1]]
 == Version 3.7.1 (2022-10-21)

--- a/cmake/FindRuby.cmake
+++ b/cmake/FindRuby.cmake
@@ -37,7 +37,7 @@ if(PKG_CONFIG_FOUND)
     # set specific search path for macOS
     set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:/usr/local/opt/ruby/lib/pkgconfig")
   endif()
-  pkg_search_module(RUBY ruby-3.1 ruby-3.0 ruby-2.7 ruby-2.6 ruby-2.5 ruby-2.4 ruby-2.3 ruby-2.2 ruby-2.1 ruby-2.0 ruby-1.9 ruby)
+  pkg_search_module(RUBY ruby-3.2 ruby-3.1 ruby-3.0 ruby-2.7 ruby-2.6 ruby-2.5 ruby-2.4 ruby-2.3 ruby-2.2 ruby-2.1 ruby-2.0 ruby-1.9 ruby)
   if(RUBY_FOUND AND ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     # FIXME: weird hack: hardcoding the Ruby lib location on macOS
     set(RUBY_LDFLAGS "${RUBY_LDFLAGS} -L/usr/local/opt/ruby/lib")

--- a/configure.ac
+++ b/configure.ac
@@ -496,7 +496,7 @@ RUBY_VERSION=
 if test "x$enable_ruby" = "xyes" ; then
     RUBY_CFLAGS=""
     RUBY_LFLAGS=""
-    for v in "3.1" "3.0" "2.7" "2.6" "2.5" "2.4" "2.3" "2.2" "2.1" "2.0" "1.9" "1.8" ; do
+    for v in "3.2" "3.1" "3.0" "2.7" "2.6" "2.5" "2.4" "2.3" "2.2" "2.1" "2.0" "1.9" "1.8" ; do
         pkgconfig_ruby_found=`$PKGCONFIG --exists ruby-$v 2>/dev/null`
         if test "x$?" = "x0" ; then
             RUBY_VERSION=`$PKGCONFIG --modversion ruby-$v`


### PR DESCRIPTION
Ruby 3.2 has been released, it is currently not possible to build weechat with it and this PR aims to change that.

based on https://github.com/weechat/weechat/commit/d0c857934b1ce857823b63031439eb00663cada8