### PR TITLE
core: allow `/input move_next_word` going to the end of line

### DIFF
--- a/src/gui/gui-input.c
+++ b/src/gui/gui-input.c
@@ -1174,11 +1174,7 @@ gui_input_move_next_word (struct t_gui_buffer *buffer)
             buffer->input_buffer_pos = buffer->input_buffer_length;
     }
     else
-    {
-        buffer->input_buffer_pos =
-            utf8_pos (buffer->input_buffer,
-                      utf8_prev_char (buffer->input_buffer, pos) - buffer->input_buffer);
-    }
+        buffer->input_buffer_pos = buffer->input_buffer_length;
 
     gui_input_text_cursor_moved_signal (buffer);
 }


### PR DESCRIPTION
When the input buffer contains non word characters at the end, `/input move_next_word` will stop moving at the end of the last word. This is a bit confusing and not in line with what readline does (think bash).

When there are no words left in the input buffer, make `/input move_next_word` go to the end of line.