### PR TITLE
tests: remove NULL message from PrintYDateTags

### DIFF
--- a/tests/unit/gui/test-gui-chat.cpp
+++ b/tests/unit/gui/test-gui-chat.cpp
@@ -642,10 +642,6 @@ TEST(GuiChat, PrintYDateTags)
     gui_chat_printf_y_date_tags (gui_buffers, 0, 0, NULL, "test");
     POINTERS_EQUAL(NULL, buffer->own_lines->last_line);
 
-    /* NULL message */
-    gui_chat_printf_y_date_tags (buffer, 0, 0, NULL, NULL);
-    POINTERS_EQUAL(NULL, buffer->own_lines->last_line);
-
     /* empty message */
     gui_chat_printf_y_date_tags (buffer, 0, 0, NULL, "");
     POINTERS_EQUAL(NULL, buffer->own_lines->last_line);


### PR DESCRIPTION
In PrintYDateTags test, passing NULL as format for gui_chat_printf_y_date_tags() invokes vsnprintf() with NULL as format. With GLibc 2.37 this causes segfault. Remove this pattern test.

Fixes #1883 .

Actually I don't think passing null pointer as format for fprintf series functions is accepted by specification.