### PR TITLE
core: render newline characters in chat line messages

### DIFF
--- a/src/gui/gui-chat.c
+++ b/src/gui/gui-chat.c
@@ -312,7 +312,8 @@ void
 gui_chat_get_word_info (struct t_gui_window *window,
                         const char *data,
                         int *word_start_offset, int *word_end_offset,
-                        int *word_length_with_spaces, int *word_length)
+                        int *word_length_with_spaces, int *word_length,
+                        int *word_is_newlines)
 {
     const char *start_data, *next_char, *next_char2;
     int leading_spaces, char_size_screen;
@@ -321,6 +322,7 @@ gui_chat_get_word_info (struct t_gui_window *window,
     *word_end_offset = 0;
     *word_length_with_spaces = 0;
     *word_length = -1;
+    *word_is_newlines = 0;
 
     start_data = data;
 
@@ -334,8 +336,11 @@ gui_chat_get_word_info (struct t_gui_window *window,
             next_char2 = utf8_next_char (next_char);
             if (next_char2)
             {
-                if (next_char[0] != ' ')
+                if (next_char[0] != ' ' &&
+                    (leading_spaces || (next_char[0] == '\n') == *word_is_newlines))
                 {
+                    if (next_char[0] == '\n')
+                        *word_is_newlines = 1;
                     if (leading_spaces)
                         *word_start_offset = next_char - start_data;
                     leading_spaces = 0;

--- a/src/gui/gui-chat.h
+++ b/src/gui/gui-chat.h
@@ -83,7 +83,8 @@ extern void gui_chat_get_word_info (struct t_gui_window *window,
                                     const char *data, int *word_start_offset,
                                     int *word_end_offset,
                                     int *word_length_with_spaces,
-                                    int *word_length);
+                                    int *word_length,
+                                    int *word_is_newlines);
 extern char *gui_chat_get_time_string (time_t date);
 extern int gui_chat_get_time_length ();
 extern void gui_chat_change_time_format ();

--- a/src/gui/gui-window.c
+++ b/src/gui/gui-window.c
@@ -141,7 +141,7 @@ gui_window_get_context_at_xy (struct t_gui_window *window,
 {
     int win_x, win_y, coords_x_message;
     char *data_next_line, *str_temp;
-    const char *ptr_data, *word_start, *word_end, *last_space;
+    const char *ptr_data, *word_start, *word_end, *last_whitespace;
 
     *chat = 0;
     *line = NULL;
@@ -227,9 +227,9 @@ gui_window_get_context_at_xy (struct t_gui_window *window,
                 free (str_temp);
             }
             *end = gui_color_decode (ptr_data, NULL);
-            if (ptr_data[0] != ' ')
+            if (ptr_data[0] != ' ' && ptr_data[0] != '\n')
             {
-                last_space = NULL;
+                last_whitespace = NULL;
                 word_start = (*line)->data->message;
                 while (word_start && (word_start < ptr_data))
                 {
@@ -238,12 +238,12 @@ gui_window_get_context_at_xy (struct t_gui_window *window,
                                                                     0, 0, 0);
                     if (word_start)
                     {
-                        if (word_start[0] == ' ')
-                            last_space = word_start;
+                        if (word_start[0] == ' ' || word_start[0] == '\n')
+                            last_whitespace = word_start;
                         word_start = utf8_next_char (word_start);
                     }
                 }
-                word_start = (last_space) ? last_space + 1 : (*line)->data->message;
+                word_start = (last_whitespace) ? last_whitespace + 1 : (*line)->data->message;
                 word_end = ptr_data;
                 while (word_end && word_end[0])
                 {
@@ -252,7 +252,7 @@ gui_window_get_context_at_xy (struct t_gui_window *window,
                                                                   0, 0, 0);
                     if (word_end)
                     {
-                        if (word_end[0] == ' ')
+                        if (word_end[0] == ' ' || word_end[0] == '\n')
                             break;
                         word_end = utf8_next_char (word_end);
                     }

--- a/tests/unit/gui/test-gui-chat.cpp
+++ b/tests/unit/gui/test-gui-chat.cpp
@@ -34,19 +34,23 @@ extern "C"
 #define WEE_GET_WORD_INFO(__result_word_start_offset,                   \
                           __result_word_end_offset,                     \
                           __result_word_length_with_spaces,             \
-                          __result_word_length, __string)               \
+                          __result_word_length,                         \
+                          __result_word_is_newlines, __string)          \
     word_start_offset = -2;                                             \
     word_end_offset = -2;                                               \
     word_length_with_spaces = -2;                                       \
     word_length = -2;                                                   \
+    word_is_newlines = -2;                                              \
     gui_chat_get_word_info (gui_windows, __string,                      \
                             &word_start_offset, &word_end_offset,       \
-                            &word_length_with_spaces, &word_length);    \
+                            &word_length_with_spaces, &word_length,     \
+                            &word_is_newlines);                         \
     LONGS_EQUAL(__result_word_start_offset, word_start_offset);         \
     LONGS_EQUAL(__result_word_end_offset, word_end_offset);             \
     LONGS_EQUAL(__result_word_length_with_spaces,                       \
                 word_length_with_spaces);                               \
-    LONGS_EQUAL(__result_word_length, word_length);
+    LONGS_EQUAL(__result_word_length, word_length);                     \
+    LONGS_EQUAL(__result_word_is_newlines, word_is_newlines);
 
 TEST_GROUP(GuiChat)
 {
@@ -334,16 +338,19 @@ TEST(GuiChat, StringPos)
 TEST(GuiChat, GetWordInfo)
 {
     int word_start_offset, word_end_offset, word_length_with_spaces;
-    int word_length;
+    int word_length, word_is_newlines;
 
-    WEE_GET_WORD_INFO (0, 0, 0, -1, NULL);
-    WEE_GET_WORD_INFO (0, 0, 0, -1, "");
-    WEE_GET_WORD_INFO (0, 0, 1, 1, "a");
-    WEE_GET_WORD_INFO (0, 2, 3, 3, "abc");
-    WEE_GET_WORD_INFO (2, 4, 5, 3, "  abc");
-    WEE_GET_WORD_INFO (2, 4, 5, 3, "  abc  ");
-    WEE_GET_WORD_INFO (0, 4, 5, 5, "first second");
-    WEE_GET_WORD_INFO (1, 5, 6, 5, " first second");
+    WEE_GET_WORD_INFO (0, 0, 0, -1, 0, NULL);
+    WEE_GET_WORD_INFO (0, 0, 0, -1, 0, "");
+    WEE_GET_WORD_INFO (0, 0, 1, 1, 0, "a");
+    WEE_GET_WORD_INFO (0, 2, 3, 3, 0, "abc");
+    WEE_GET_WORD_INFO (2, 4, 5, 3, 0, "  abc");
+    WEE_GET_WORD_INFO (2, 4, 5, 3, 0, "  abc  ");
+    WEE_GET_WORD_INFO (0, 4, 5, 5, 0, "first second");
+    WEE_GET_WORD_INFO (1, 5, 6, 5, 0, " first second");
+    WEE_GET_WORD_INFO (0, 0, 1, 1, 1, "\nabc");
+    WEE_GET_WORD_INFO (2, 2, 3, 1, 1, "  \nabc");
+    WEE_GET_WORD_INFO (2, 3, 4, 2, 1, "  \n\nabc");
 }
 
 /*


### PR DESCRIPTION
If a chat line message contains a newline character (\n) it was previously rendered as J with reverse video. This commit makes it render as an actual newline instead, so messages with multiple lines become supported.

The rendering is fixed in normal mode as well as bare mode both when scrolled to the bottom and when scrolled up (which is different code paths). Focus events has also been updated to support this (except for _chat_line_y which returns -1 for all lines, but the docs says this variable is only for buffers with free content).

Currently, the only way to include a \n in a chat line message is with hdata_update because printf splits on \n and creates multiple separate lines, but hopefully either printf can be changed to not split on \n, or a new command which doesn't split can be added.