### PR TITLE
Add _chat_focused_line variable to get the focused line

### DIFF
--- a/doc/de/weechat_user.de.adoc
+++ b/doc/de/weechat_user.de.adoc
@@ -1698,6 +1698,8 @@ Diese Tasten werden im Kontext "cursor" verwendet (Cursor kann frei auf dem Bild
 | kbd:[Alt+←]    | -             | bewegt Cursor einen Bereich nach links. | `+/cursor move area_left+`
 | kbd:[Alt+→]    | -             | bewegt Cursor einen Bereich nach rechts. | `+/cursor move area_right+`
 | kbd:[m]        | Chat          | quotet Nachricht. | `+hsignal:chat_quote_message;/cursor stop+`
+// TRANSLATION MISSING
+| kbd:[l]        | Chat          | Quote focused line. | `+hsignal:chat_quote_focused_line;/cursor stop+`
 | kbd:[q]        | Chat          | quotet prefix + Nachricht. | `+hsignal:chat_quote_prefix_message;/cursor stop+`
 | kbd:[Q]        | Chat          | quotet Uhrzeit + prefix + Nachricht. | `+hsignal:chat_quote_time_prefix_message;/cursor stop+`
 | kbd:[b]        | Benutzerliste | verbannt nick (Ban). | `+/window ${_window_number};/ban ${nick}+`

--- a/doc/en/weechat_user.en.adoc
+++ b/doc/en/weechat_user.en.adoc
@@ -1682,6 +1682,7 @@ These keys are used in context "cursor" (free movement of cursor on screen).
 | kbd:[Alt+←]    | -        | Move cursor one area left. | `+/cursor move area_left+`
 | kbd:[Alt+→]    | -        | Move cursor one area right. | `+/cursor move area_right+`
 | kbd:[m]        | chat     | Quote message. | `+hsignal:chat_quote_message;/cursor stop+`
+| kbd:[l]        | chat     | Quote focused line. | `+hsignal:chat_quote_focused_line;/cursor stop+`
 | kbd:[q]        | chat     | Quote prefix + message. | `+hsignal:chat_quote_prefix_message;/cursor stop+`
 | kbd:[Q]        | chat     | Quote time + prefix + message. | `+hsignal:chat_quote_time_prefix_message;/cursor stop+`
 | kbd:[b]        | nicklist | Ban nick. | `+/window ${_window_number};/ban ${nick}+`

--- a/doc/fr/weechat_user.fr.adoc
+++ b/doc/fr/weechat_user.fr.adoc
@@ -1719,6 +1719,8 @@ Ces touches sont utilisées dans le contexte "cursor" (mouvement libre du curseu
 | kbd:[Alt+←]    | -                 | Déplacer le curseur vers la zone sur la gauche. | `+/cursor move area_left+`
 | kbd:[Alt+→]    | -                 | Déplacer le curseur vers la zone sur la droite. | `+/cursor move area_right+`
 | kbd:[m]        | chat              | Citer le message. | `+hsignal:chat_quote_message;/cursor stop+`
+// TRANSLATION MISSING
+| kbd:[l]        | chat              | Quote focused line. | `+hsignal:chat_quote_focused_line;/cursor stop+`
 | kbd:[q]        | chat              | Citer le préfixe + le message. | `+hsignal:chat_quote_prefix_message;/cursor stop+`
 | kbd:[Q]        | chat              | Citer l'heure + le préfixe + le message. | `+hsignal:chat_quote_time_prefix_message;/cursor stop+`
 | kbd:[b]        | liste des pseudos | Bannir le pseudo. | `+/window ${_window_number};/ban ${nick}+`

--- a/doc/it/weechat_user.it.adoc
+++ b/doc/it/weechat_user.it.adoc
@@ -1855,6 +1855,8 @@ sullo schermo.
 | kbd:[Alt+←]    | -          | Sposta il cursore nell'area a sinistra. | `+/cursor move area_left+`
 | kbd:[Alt+→]    | -          | Sposta il cursore nell'area a destra. | `+/cursor move area_right+`
 | kbd:[m]        | chat       | Cita messaggio. | `+hsignal:chat_quote_message;/cursor stop+`
+// TRANSLATION MISSING
+| kbd:[l]        | chat       | Quote focused line. | `+hsignal:chat_quote_focused_line;/cursor stop+`
 | kbd:[q]        | chat       | Cita prefisso + messaggio. | `+hsignal:chat_quote_prefix_message;/cursor stop+`
 | kbd:[Q]        | chat       | Cita ora + prefisso + messaggio. | `+hsignal:chat_quote_time_prefix_message;/cursor stop+`
 | kbd:[b]        | lista nick | Ban di un nick. | `+/window ${_window_number};/ban ${nick}+`

--- a/doc/ja/weechat_user.ja.adoc
+++ b/doc/ja/weechat_user.ja.adoc
@@ -1798,6 +1798,8 @@ kbd:[Ctrl+r] が押された状態) でのみ有効です。
 | kbd:[Alt+←]    | -                 | カーソルを左のエリアに移動 | `+/cursor move area_left+`
 | kbd:[Alt+→]    | -                 | カーソルを右のエリアに移動 | `+/cursor move area_right+`
 | kbd:[m]        | チャット          | メッセージを引用 | `+hsignal:chat_quote_message;/cursor stop+`
+// TRANSLATION MISSING
+| kbd:[l]        | チャット          | Quote focused line. | `+hsignal:chat_quote_focused_line;/cursor stop+`
 | kbd:[q]        | チャット          | プレフィックスとメッセージを引用 | `+hsignal:chat_quote_prefix_message;/cursor stop+`
 | kbd:[Q]        | チャット          | 時間、プレフィックス、メッセージを引用 | `+hsignal:chat_quote_time_prefix_message;/cursor stop+`
 | kbd:[b]        | ニックネームリスト| ニックネームをバンする | `+/window ${_window_number};/ban ${nick}+`

--- a/doc/pl/weechat_user.pl.adoc
+++ b/doc/pl/weechat_user.pl.adoc
@@ -1711,6 +1711,8 @@ ekranie).
 | kbd:[Alt+←]    | -        | Przesuń kursor obszar w lewo. | `+/cursor move area_left+`
 | kbd:[Alt+→]    | -        | Przesuń kursor obszar w prawo. | `+/cursor move area_right+`
 | kbd:[m]        | chat     | Cytuj wiadomość. | `+hsignal:chat_quote_message;/cursor stop+`
+// TRANSLATION MISSING
+| kbd:[l]        | chat     | Quote focused line. | `+hsignal:chat_quote_focused_line;/cursor stop+`
 | kbd:[q]        | chat     | Cytuj prefiks i wiadomość. | `+hsignal:chat_quote_prefix_message;/cursor stop+`
 | kbd:[Q]        | chat     | Cytuj czas, prefiks i wiadomość. | `+hsignal:chat_quote_time_prefix_message;/cursor stop+`
 | kbd:[b]        | nicklist | Zbanuj osobę. | `+/window ${_window_number};/ban ${nick}+`

--- a/doc/sr/weechat_user.sr.adoc
+++ b/doc/sr/weechat_user.sr.adoc
@@ -1606,6 +1606,8 @@ WeeChat нуди доста подразумеваних тастерских п
 | kbd:[Alt+←]    | -              | Помера курсор једну површину у лево. | `+/cursor move area_left+`
 | kbd:[Alt+→]    | -              | Помера курсор једну површину у десно. | `+/cursor move area_right+`
 | kbd:[m]        | чет            | Цитирање поруке. | `+hsignal:chat_quote_message;/cursor stop+`
+// TRANSLATION MISSING
+| kbd:[l]        | чет            | Quote focused line. | `+hsignal:chat_quote_focused_line;/cursor stop+`
 | kbd:[q]        | чет            | Цитирање префикса + поруке. | `+hsignal:chat_quote_prefix_message;/cursor stop+`
 | kbd:[Q]        | чет            | Quote time + prefix + message. | `+hsignal:chat_quote_time_prefix_message;/cursor stop+`
 | kbd:[b]        | листа надимака | Забрањује надимак. | `+/window ${_window_number};/ban ${nick}+`

--- a/src/gui/curses/gui-curses-key.c
+++ b/src/gui/curses/gui-curses-key.c
@@ -229,6 +229,7 @@ gui_key_default_bindings (int context, int create_option)
         BIND("meta-right","/cursor move area_right");
         /* chat */
         BIND("@chat:m", "hsignal:chat_quote_message;/cursor stop");
+        BIND("@chat:l", "hsignal:chat_quote_focused_line;/cursor stop");
         BIND("@chat:q", "hsignal:chat_quote_prefix_message;/cursor stop");
         BIND("@chat:Q", "hsignal:chat_quote_time_prefix_message;/cursor stop");
         /* nicklist */

--- a/src/gui/gui-chat.c
+++ b/src/gui/gui-chat.c
@@ -84,7 +84,7 @@ gui_chat_init ()
     /* some hsignals */
     hook_hsignal (NULL,
                   "chat_quote_time_prefix_message;chat_quote_prefix_message;"
-                  "chat_quote_message",
+                  "chat_quote_message;chat_quote_focused_line",
                   &gui_chat_hsignal_quote_line_cb, NULL, NULL);
 }
 
@@ -1104,7 +1104,9 @@ gui_chat_hsignal_quote_line_cb (const void *pointer, void *data,
             ptr_prefix++;
         }
     }
-    message = hashtable_get (hashtable, "_chat_line_message");
+
+    message = (strstr (signal, "focused_line")) ?
+        hashtable_get (hashtable, "_chat_focused_line") : hashtable_get (hashtable, "_chat_line_message");
 
     if (!message)
         return WEECHAT_RC_OK;

--- a/src/gui/gui-focus.c
+++ b/src/gui/gui-focus.c
@@ -71,6 +71,7 @@ gui_focus_get_info (int x, int y)
                                   &focus_info->chat_line,
                                   &focus_info->chat_line_x,
                                   &focus_info->chat_word,
+                                  &focus_info->chat_focused_line,
                                   &focus_info->chat_bol,
                                   &focus_info->chat_eol);
 
@@ -99,6 +100,8 @@ gui_focus_free_info (struct t_gui_focus_info *focus_info)
 {
     if (focus_info->chat_word)
         free (focus_info->chat_word);
+    if (focus_info->chat_focused_line)
+        free (focus_info->chat_focused_line);
     if (focus_info->chat_bol)
         free (focus_info->chat_bol);
     if (focus_info->chat_eol)
@@ -238,6 +241,7 @@ gui_focus_to_hashtable (struct t_gui_focus_info *focus_info, const char *key)
         HASHTABLE_SET_STR("_chat_line_message", "");
     }
     HASHTABLE_SET_STR_NOT_NULL("_chat_word", focus_info->chat_word);
+    HASHTABLE_SET_STR_NOT_NULL("_chat_focused_line", focus_info->chat_focused_line);
     HASHTABLE_SET_STR_NOT_NULL("_chat_bol", focus_info->chat_bol);
     HASHTABLE_SET_STR_NOT_NULL("_chat_eol", focus_info->chat_eol);
 

--- a/src/gui/gui-focus.h
+++ b/src/gui/gui-focus.h
@@ -31,6 +31,7 @@ struct t_gui_focus_info
     struct t_gui_line *chat_line;      /* line in chat area                 */
     int chat_line_x;                   /* x in line                         */
     char *chat_word;                   /* word at (x,y)                     */
+    char *chat_focused_line;           /* line at (x,y)                     */
     char *chat_bol;                    /* beginning of line until (x,y)     */
     char *chat_eol;                    /* (x,y) until end of line           */
     struct t_gui_bar_window *bar_window; /* bar window found                */

--- a/src/gui/gui-window.h
+++ b/src/gui/gui-window.h
@@ -138,6 +138,7 @@ extern void gui_window_get_context_at_xy (struct t_gui_window *window,
                                           struct t_gui_line **line,
                                           int *line_x,
                                           char **word,
+                                          char **focused_line,
                                           char **beginning,
                                           char **end);
 extern void gui_window_ask_refresh (int refresh);


### PR DESCRIPTION
This contains the single line that you focused on, like _chat_word
contains the word that you focused on. This will be equal to
_chat_line_message if the chat line only contains a single line, but if
the chat line has multiple lines, _chat_line_message will contain all of
them, but _chat_focused_line will only contain the single line that was
focused.

Also adds cursor key l to quote the focused line.

Fixes #1913