### PR TITLE
ruby: Restore default SIGCHLD signal handler on unload

### DIFF
--- a/src/plugins/ruby/weechat-ruby.c
+++ b/src/plugins/ruby/weechat-ruby.c
@@ -30,6 +30,7 @@
 #include <ruby/version.h>
 #endif
 
+#include <signal.h>
 #include <stdarg.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -1440,6 +1441,7 @@ weechat_plugin_end (struct t_weechat_plugin *plugin)
     ruby_quiet = 0;
 
     ruby_cleanup (0);
+    signal (SIGCHLD, SIG_DFL);
 
     /* free some data */
     if (ruby_action_install_list)


### PR DESCRIPTION
fixes #1889

I can't explain why some people can't reproduce #1889. Perhaps the order their plugins are unloaded is different, or there is another plugin that is installing yet another SIGCHLD signal handler.

I've examined ruby's signal.c from 3.2.2, 2.7.4, and 3.1.2; the issue should be happening in across all versions.

In any case, this change sets the SIGCHLD handler to the default handler, which should be a pretty safe thing to do in all cases. The manual for signal(2) says `The only portable use of signal() is to set a signal's disposition to SIG_DFL or SIG_IGN.` so I guess this should be fine even on BSD; but I've only tested on linux-x86_64
