### PR TITLE
core: fix display bug when drawing partially scrolled multiline

### DIFF
--- a/src/gui/curses/gui-curses-chat.c
+++ b/src/gui/curses/gui-curses-chat.c
@@ -507,6 +507,9 @@ gui_chat_display_prefix_suffix (struct t_gui_window *window,
 
     chars_displayed = 0;
 
+    if ((!simulate) && (window->win_chat_cursor_y >= window->win_chat_height))
+        return chars_displayed;
+
     /* insert spaces for aligning text under time/nick */
     length_align = gui_line_get_align (window->buffer, line, 0, 0);
 


### PR DESCRIPTION
If you have a chat line with multiple lines that were scrolled so that part of it is rendered at the bottom of the chat area, and part of it falls below the chat area, there was a bug where the prefix_suffix would be displayed at the end of the last line.

Looks like this happens because the gui_chat_display_prefix_suffix is called for the line below the last line displayed in the chat area. So we have to add a check for this so we don't add the prefix_suffix. This check is copied from gui_chat_display_word which checks for the same.

Fixes #1912