### PR TITLE
core: fix chat colors at certain positions not being applied

### DIFF
--- a/src/gui/curses/gui-curses-chat.c
+++ b/src/gui/curses/gui-curses-chat.c
@@ -1544,7 +1544,7 @@ gui_chat_display_line (struct t_gui_window *window, struct t_gui_line *line,
 
             /* if message ends with spaces, display them */
             if ((word_length <= 0) && (word_length_with_spaces > 0)
-                && !ptr_data[word_end_offset + 1])
+                && !ptr_data[word_end_offset])
             {
                 word_length = word_length_with_spaces;
             }
@@ -1582,7 +1582,7 @@ gui_chat_display_line (struct t_gui_window *window, struct t_gui_line *line,
 
                 /* display word */
                 gui_chat_display_word (window, line, ptr_data,
-                                       ptr_end_offset + 1,
+                                       ptr_end_offset,
                                        0, num_lines, count,
                                        pre_lines_displayed, &lines_displayed,
                                        simulate,
@@ -1594,7 +1594,7 @@ gui_chat_display_line (struct t_gui_window *window, struct t_gui_line *line,
                 else
                 {
                     /* move pointer after end of word */
-                    ptr_data = ptr_end_offset + 1;
+                    ptr_data = ptr_end_offset;
                     if (*(ptr_data - 1) == '\0')
                         ptr_data = NULL;
 

--- a/src/gui/gui-chat.c
+++ b/src/gui/gui-chat.c
@@ -338,7 +338,7 @@ gui_chat_get_word_info (struct t_gui_window *window,
             {
                 if (next_char[0] == '\n')
                 {
-                    *word_end_offset = next_char - start_data - 1;
+                    *word_end_offset = next_char - start_data;
                     if (*word_length < 0)
                         *word_length = 0;
                     return;
@@ -348,7 +348,7 @@ gui_chat_get_word_info (struct t_gui_window *window,
                     if (leading_spaces)
                         *word_start_offset = next_char - start_data;
                     leading_spaces = 0;
-                    *word_end_offset = next_char2 - start_data - 1;
+                    *word_end_offset = next_char2 - start_data;
                     char_size_screen = utf8_char_size_screen (next_char);
                     if (char_size_screen > 0)
                         (*word_length_with_spaces) += char_size_screen;
@@ -362,11 +362,11 @@ gui_chat_get_word_info (struct t_gui_window *window,
                     if (leading_spaces)
                     {
                         (*word_length_with_spaces)++;
-                        *word_end_offset = next_char2 - start_data - 1;
+                        *word_end_offset = next_char2 - start_data;
                     }
                     else
                     {
-                        *word_end_offset = next_char - start_data - 1;
+                        *word_end_offset = next_char - start_data;
                         return;
                     }
                 }
@@ -375,7 +375,7 @@ gui_chat_get_word_info (struct t_gui_window *window,
         }
         else
         {
-            *word_end_offset = data + strlen (data) - start_data - 1;
+            *word_end_offset = data + strlen (data) - start_data;
             return;
         }
     }

--- a/src/gui/gui-chat.h
+++ b/src/gui/gui-chat.h
@@ -83,8 +83,7 @@ extern void gui_chat_get_word_info (struct t_gui_window *window,
                                     const char *data, int *word_start_offset,
                                     int *word_end_offset,
                                     int *word_length_with_spaces,
-                                    int *word_length,
-                                    int *word_is_newlines);
+                                    int *word_length);
 extern char *gui_chat_get_time_string (time_t date);
 extern int gui_chat_get_time_length ();
 extern void gui_chat_change_time_format ();

--- a/tests/unit/gui/test-gui-chat.cpp
+++ b/tests/unit/gui/test-gui-chat.cpp
@@ -339,31 +339,31 @@ TEST(GuiChat, GetWordInfo)
 
     WEE_GET_WORD_INFO (0, 0, 0, -1, NULL);
     WEE_GET_WORD_INFO (0, 0, 0, -1, "");
-    WEE_GET_WORD_INFO (0, 0, 1, 1, "a");
-    WEE_GET_WORD_INFO (0, 2, 3, 3, "abc");
-    WEE_GET_WORD_INFO (2, 4, 5, 3, "  abc");
-    WEE_GET_WORD_INFO (2, 4, 5, 3, "  abc  ");
-    WEE_GET_WORD_INFO (0, 4, 5, 5, "first second");
-    WEE_GET_WORD_INFO (1, 5, 6, 5, " first second");
+    WEE_GET_WORD_INFO (0, 1, 1, 1, "a");
+    WEE_GET_WORD_INFO (0, 3, 3, 3, "abc");
+    WEE_GET_WORD_INFO (2, 5, 5, 3, "  abc");
+    WEE_GET_WORD_INFO (2, 5, 5, 3, "  abc  ");
+    WEE_GET_WORD_INFO (0, 5, 5, 5, "first second");
+    WEE_GET_WORD_INFO (1, 6, 6, 5, " first second");
 
-    WEE_GET_WORD_INFO (0, -1, 0, 0, "\nabc");
-    WEE_GET_WORD_INFO (0, 0, 1, 0, " \nabc");
-    WEE_GET_WORD_INFO (0, 1, 2, 0, "  \nabc");
-    WEE_GET_WORD_INFO (0, 4, 5, 5, "first\nsecond");
+    WEE_GET_WORD_INFO (0, 0, 0, 0, "\nabc");
+    WEE_GET_WORD_INFO (0, 1, 1, 0, " \nabc");
+    WEE_GET_WORD_INFO (0, 2, 2, 0, "  \nabc");
+    WEE_GET_WORD_INFO (0, 5, 5, 5, "first\nsecond");
 
     snprintf (string, sizeof (string), "%c%c01abc", GUI_COLOR_COLOR_CHAR, GUI_COLOR_FG_CHAR);
-    WEE_GET_WORD_INFO (4, 6, 3, 3, string);
+    WEE_GET_WORD_INFO (4, 7, 3, 3, string);
     snprintf (string, sizeof (string), "abc%c%c01", GUI_COLOR_COLOR_CHAR, GUI_COLOR_FG_CHAR);
-    WEE_GET_WORD_INFO (0, 6, 3, 3, string);
+    WEE_GET_WORD_INFO (0, 7, 3, 3, string);
     snprintf (string, sizeof (string), " %c%c01 abc", GUI_COLOR_COLOR_CHAR, GUI_COLOR_FG_CHAR);
-    WEE_GET_WORD_INFO (6, 8, 5, 3, string);
+    WEE_GET_WORD_INFO (6, 9, 5, 3, string);
 
     snprintf (string, sizeof (string), "\n%c%c01abc", GUI_COLOR_COLOR_CHAR, GUI_COLOR_FG_CHAR);
-    WEE_GET_WORD_INFO (0, -1, 0, 0, string);
+    WEE_GET_WORD_INFO (0, 0, 0, 0, string);
     snprintf (string, sizeof (string), "%c%c01\nabc", GUI_COLOR_COLOR_CHAR, GUI_COLOR_FG_CHAR);
-    WEE_GET_WORD_INFO (0, 3, 0, 0, string);
+    WEE_GET_WORD_INFO (0, 4, 0, 0, string);
     snprintf (string, sizeof (string), " %c%c01 \nabc", GUI_COLOR_COLOR_CHAR, GUI_COLOR_FG_CHAR);
-    WEE_GET_WORD_INFO (0, 5, 2, 0, string);
+    WEE_GET_WORD_INFO (0, 6, 2, 0, string);
 }
 
 /*

--- a/tests/unit/gui/test-gui-chat.cpp
+++ b/tests/unit/gui/test-gui-chat.cpp
@@ -34,23 +34,19 @@ extern "C"
 #define WEE_GET_WORD_INFO(__result_word_start_offset,                   \
                           __result_word_end_offset,                     \
                           __result_word_length_with_spaces,             \
-                          __result_word_length,                         \
-                          __result_word_is_newlines, __string)          \
+                          __result_word_length, __string)               \
     word_start_offset = -2;                                             \
     word_end_offset = -2;                                               \
     word_length_with_spaces = -2;                                       \
     word_length = -2;                                                   \
-    word_is_newlines = -2;                                              \
     gui_chat_get_word_info (gui_windows, __string,                      \
                             &word_start_offset, &word_end_offset,       \
-                            &word_length_with_spaces, &word_length,     \
-                            &word_is_newlines);                         \
+                            &word_length_with_spaces, &word_length);    \
     LONGS_EQUAL(__result_word_start_offset, word_start_offset);         \
     LONGS_EQUAL(__result_word_end_offset, word_end_offset);             \
     LONGS_EQUAL(__result_word_length_with_spaces,                       \
                 word_length_with_spaces);                               \
-    LONGS_EQUAL(__result_word_length, word_length);                     \
-    LONGS_EQUAL(__result_word_is_newlines, word_is_newlines);
+    LONGS_EQUAL(__result_word_length, word_length);
 
 TEST_GROUP(GuiChat)
 {
@@ -338,19 +334,36 @@ TEST(GuiChat, StringPos)
 TEST(GuiChat, GetWordInfo)
 {
     int word_start_offset, word_end_offset, word_length_with_spaces;
-    int word_length, word_is_newlines;
+    int word_length;
+    char string[32];
 
-    WEE_GET_WORD_INFO (0, 0, 0, -1, 0, NULL);
-    WEE_GET_WORD_INFO (0, 0, 0, -1, 0, "");
-    WEE_GET_WORD_INFO (0, 0, 1, 1, 0, "a");
-    WEE_GET_WORD_INFO (0, 2, 3, 3, 0, "abc");
-    WEE_GET_WORD_INFO (2, 4, 5, 3, 0, "  abc");
-    WEE_GET_WORD_INFO (2, 4, 5, 3, 0, "  abc  ");
-    WEE_GET_WORD_INFO (0, 4, 5, 5, 0, "first second");
-    WEE_GET_WORD_INFO (1, 5, 6, 5, 0, " first second");
-    WEE_GET_WORD_INFO (0, 0, 1, 1, 1, "\nabc");
-    WEE_GET_WORD_INFO (2, 2, 3, 1, 1, "  \nabc");
-    WEE_GET_WORD_INFO (2, 3, 4, 2, 1, "  \n\nabc");
+    WEE_GET_WORD_INFO (0, 0, 0, -1, NULL);
+    WEE_GET_WORD_INFO (0, 0, 0, -1, "");
+    WEE_GET_WORD_INFO (0, 0, 1, 1, "a");
+    WEE_GET_WORD_INFO (0, 2, 3, 3, "abc");
+    WEE_GET_WORD_INFO (2, 4, 5, 3, "  abc");
+    WEE_GET_WORD_INFO (2, 4, 5, 3, "  abc  ");
+    WEE_GET_WORD_INFO (0, 4, 5, 5, "first second");
+    WEE_GET_WORD_INFO (1, 5, 6, 5, " first second");
+
+    WEE_GET_WORD_INFO (0, -1, 0, 0, "\nabc");
+    WEE_GET_WORD_INFO (0, 0, 1, 0, " \nabc");
+    WEE_GET_WORD_INFO (0, 1, 2, 0, "  \nabc");
+    WEE_GET_WORD_INFO (0, 4, 5, 5, "first\nsecond");
+
+    snprintf (string, sizeof (string), "%c%c01abc", GUI_COLOR_COLOR_CHAR, GUI_COLOR_FG_CHAR);
+    WEE_GET_WORD_INFO (4, 6, 3, 3, string);
+    snprintf (string, sizeof (string), "abc%c%c01", GUI_COLOR_COLOR_CHAR, GUI_COLOR_FG_CHAR);
+    WEE_GET_WORD_INFO (0, 6, 3, 3, string);
+    snprintf (string, sizeof (string), " %c%c01 abc", GUI_COLOR_COLOR_CHAR, GUI_COLOR_FG_CHAR);
+    WEE_GET_WORD_INFO (6, 8, 5, 3, string);
+
+    snprintf (string, sizeof (string), "\n%c%c01abc", GUI_COLOR_COLOR_CHAR, GUI_COLOR_FG_CHAR);
+    WEE_GET_WORD_INFO (0, -1, 0, 0, string);
+    snprintf (string, sizeof (string), "%c%c01\nabc", GUI_COLOR_COLOR_CHAR, GUI_COLOR_FG_CHAR);
+    WEE_GET_WORD_INFO (0, 3, 0, 0, string);
+    snprintf (string, sizeof (string), " %c%c01 \nabc", GUI_COLOR_COLOR_CHAR, GUI_COLOR_FG_CHAR);
+    WEE_GET_WORD_INFO (0, 5, 2, 0, string);
 }
 
 /*


### PR DESCRIPTION
The new rendering of multiline lines had some issues with colors at certain positions not being applied. The color would not be applied if the color code was at either of these positions:

  - At the start of a line after a newline character
  - At the end of a line after a space and before a newline character
  - At a line by itself before a newline character

The way I had done it by considering newline characters as a word in gui_chat_get_word_info with a variable specifying that it's newline characters became messy and didn't really make sense, so rather than doing this, I changed gui_chat_get_word_info to stop before the first newline character. That way, we can just check if we are at a newline character at the start of the loop, and don't need any more special handling.

Fixes #1928