### PR TITLE
core: check for newline character in string_is_whitespace_char

### DIFF
--- a/src/core/wee-string.c
+++ b/src/core/wee-string.c
@@ -1312,7 +1312,7 @@ string_convert_escaped_chars (const char *string)
 }
 
 /*
- * Checks if first char of string is a whitespace (space or tab).
+ * Checks if first char of string is a whitespace (space, tab, newline or carriage return).
  *
  * Returns:
  *   1: first char is whitespace
@@ -1322,7 +1322,11 @@ string_convert_escaped_chars (const char *string)
 int
 string_is_whitespace_char (const char *string)
 {
-    return (string && ((string[0] == ' ') || string[0] == '\t')) ? 1 : 0;
+    return (string && (
+            (string[0] == ' ')
+            || (string[0] == '\t')
+            || (string[0] == '\n')
+            || (string[0] == '\r'))) ? 1 : 0;
 }
 
 /*

--- a/tests/unit/core/test-core-string.cpp
+++ b/tests/unit/core/test-core-string.cpp
@@ -1090,6 +1090,8 @@ TEST(CoreString, IsWhitespaceChar)
 
     LONGS_EQUAL(1, string_is_whitespace_char (" abc def"));
     LONGS_EQUAL(1, string_is_whitespace_char ("\tabc def"));
+    LONGS_EQUAL(1, string_is_whitespace_char ("\nabc def"));
+    LONGS_EQUAL(1, string_is_whitespace_char ("\rabc def"));
 }
 
 /*


### PR DESCRIPTION
This fixes a bug where if you had multiple lines in the input and pressed ctrl-w when the cursor was after the first word of any line but the first, it would delete both the word before the cursor and the last word on the preceding line.