### PR TITLE
Fix signals key_pressed and key_combo_*

### DIFF
--- a/src/gui/curses/gui-curses-key.c
+++ b/src/gui/curses/gui-curses-key.c
@@ -396,12 +396,13 @@ gui_key_flush (int paste)
              * or if the mouse code is valid UTF-8 (do not send partial mouse
              * code which is not UTF-8 valid)
              */
-            if (!paste
+            if (!paste && i > gui_key_last_key_pressed_sent
                 && (!gui_mouse_event_pending
                     || utf8_is_valid (key_str, -1, NULL)))
             {
                 (void) hook_signal_send ("key_pressed",
                                          WEECHAT_HOOK_SIGNAL_STRING, key_str);
+                gui_key_last_key_pressed_sent = i;
             }
 
             if (gui_current_window->buffer->text_search != GUI_TEXT_SEARCH_DISABLED)

--- a/src/gui/gui-key.c
+++ b/src/gui/gui-key.c
@@ -94,6 +94,7 @@ int gui_key_grab_delay = 0;         /* delay for grab (default is 500)      */
 int *gui_key_buffer = NULL;         /* input buffer (for paste detection)   */
 int gui_key_buffer_alloc = 0;       /* input buffer allocated size          */
 int gui_key_buffer_size = 0;        /* input buffer size in bytes           */
+int gui_key_last_key_pressed_sent = -1;
 
 int gui_key_paste_pending = 0;      /* 1 is big paste was detected and      */
                                     /* WeeChat is asking user what to do    */
@@ -2695,6 +2696,7 @@ gui_key_buffer_reset ()
         gui_key_buffer_optimize ();
     }
     gui_key_paste_lines = 0;
+    gui_key_last_key_pressed_sent = -1;
 }
 
 /*

--- a/src/gui/gui-key.c
+++ b/src/gui/gui-key.c
@@ -2388,6 +2388,11 @@ gui_key_pressed (const char *key_str)
 
     rc_expand = gui_key_expand (gui_key_combo, &key_name, &key_name_alias);
 
+    if (!rc_expand)
+    {
+        goto end_no_input;
+    }
+
     ptr_key = NULL;
     exact_match = 0;
 

--- a/src/gui/gui-key.h
+++ b/src/gui/gui-key.h
@@ -82,6 +82,7 @@ extern int gui_key_grab;
 extern int gui_key_grab_count;
 extern int *gui_key_buffer;
 extern int gui_key_buffer_size;
+extern int gui_key_last_key_pressed_sent;
 extern int gui_key_paste_pending;
 extern int gui_key_paste_bracketed;
 extern time_t gui_key_last_activity_time;


### PR DESCRIPTION
This fixes a couple of issues with these signals and fixes a regression with the vimode.py script that was introduced in WeeChat 4.0.0. See the commit messages for details.