### PR TITLE
Fix bar_item_col and bar_item_line for wrapped/new lines with horizontal filling

### DIFF
--- a/src/gui/gui-bar-window.c
+++ b/src/gui/gui-bar-window.c
@@ -224,7 +224,8 @@ gui_bar_window_search_by_xy (struct t_gui_window *window, int x, int y,
                     {
                         *bar_item = (*bar_window)->bar->items_name[item][subitem];
                         *bar_item_line = (*bar_window)->coords[i]->line;
-                        *bar_item_col = x - (*bar_window)->coords[i]->x;
+                        *bar_item_col = x - (y == (*bar_window)->coords[i]->y ?
+                            (*bar_window)->coords[i]->x : (*bar_window)->x);
                     }
                     break;
                 }
@@ -236,7 +237,8 @@ gui_bar_window_search_by_xy (struct t_gui_window *window, int x, int y,
                     subitem = (*bar_window)->coords[i]->subitem;
                     *bar_item = (*bar_window)->bar->items_name[item][subitem];
                     *bar_item_line = (*bar_window)->coords[i]->line;
-                    *bar_item_col = x - (*bar_window)->coords[i]->x;
+                    *bar_item_col = x - (y == (*bar_window)->coords[i]->y ?
+                        (*bar_window)->coords[i]->x : (*bar_window)->x);
                     if ((*bar_window)->bar->items_buffer[item][subitem])
                         *buffer = gui_buffer_search_by_full_name ((*bar_window)->bar->items_buffer[item][subitem]);
                     break;

--- a/src/gui/gui-bar-window.c
+++ b/src/gui/gui-bar-window.c
@@ -223,7 +223,7 @@ gui_bar_window_search_by_xy (struct t_gui_window *window, int x, int y,
                     if ((item >= 0) && (subitem >= 0))
                     {
                         *bar_item = (*bar_window)->bar->items_name[item][subitem];
-                        *bar_item_line = (*bar_window)->coords[i]->line;
+                        *bar_item_line = y - (*bar_window)->coords[i]->y;
                         *bar_item_col = x - (y == (*bar_window)->coords[i]->y ?
                             (*bar_window)->coords[i]->x : (*bar_window)->x);
                     }
@@ -236,7 +236,7 @@ gui_bar_window_search_by_xy (struct t_gui_window *window, int x, int y,
                     item = (*bar_window)->coords[i]->item;
                     subitem = (*bar_window)->coords[i]->subitem;
                     *bar_item = (*bar_window)->bar->items_name[item][subitem];
-                    *bar_item_line = (*bar_window)->coords[i]->line;
+                    *bar_item_line = y - (*bar_window)->coords[i]->y;
                     *bar_item_col = x - (y == (*bar_window)->coords[i]->y ?
                         (*bar_window)->coords[i]->x : (*bar_window)->x);
                     if ((*bar_window)->bar->items_buffer[item][subitem])


### PR DESCRIPTION
bar_item_col:

When the bar item filling is horizontal and the text of an item is
either wrapped or contains a \r so it's multiple lines and you focus on
a line that isn't the first, the bar_item_col value was incorrect. It
only accounted for focuses on the first line and set the col based on
where the item starts on that line, but for subsequent lines they start
at the beginning of the bar which is often a different column.

bar_item_line:

When the bar item filling is horizontal and the text of an item is
either wrapped or contains a \r so it's multiple lines and you focus on
a line that isn't the first, the bar_item_line value did not represent
the line you focused on in the bar item.

Instead, it represented which line the character you focused on
originally was in the string used to create the bar item. This is
different because \n in this string is converted to a space in a bar
item, so only \r actually creates a new line.

In my opinion, it's much more useful to know which line you focused on
in the bar item, and this is what the variable name sounds like it
represents. So the variable is changed to that.

Note that the coords->line variable is now unused. If it's useful, we
could assign it to a new variable in the focus hashtable, or if not we
should probably remove it.