### PR TITLE
fset: fix fset.color.help_description not applying

### DIFF
--- a/src/plugins/fset/fset-bar-item.c
+++ b/src/plugins/fset/fset-bar-item.c
@@ -204,12 +204,14 @@ fset_bar_item_fset_cb (const void *pointer, void *data,
 
     snprintf (str_help, sizeof (str_help),
               /* TRANSLATORS: "%s%s%s:" at beginning of string it the name of option */
-              _("%s%s%s: %s %s[%s%s]%s"),
+              _("%s%s%s: %s%s%s %s[%s%s]%s"),
               weechat_color (weechat_config_string (fset_config_color_help_name)),
               ptr_fset_option->name,
+              weechat_color ("bar_fg"),
               weechat_color (weechat_config_string (fset_config_color_help_description)),
               (ptr_fset_option->description && ptr_fset_option->description[0]) ?
               _(ptr_fset_option->description) : _("(no description)"),
+              weechat_color ("bar_fg"),
               weechat_color ("bar_delim"),
               *default_and_values,
               weechat_color ("bar_delim"),

--- a/src/plugins/fset/fset-bar-item.c
+++ b/src/plugins/fset/fset-bar-item.c
@@ -207,7 +207,7 @@ fset_bar_item_fset_cb (const void *pointer, void *data,
               _("%s%s%s: %s %s[%s%s]%s"),
               weechat_color (weechat_config_string (fset_config_color_help_name)),
               ptr_fset_option->name,
-              weechat_color ("bar_fg"),
+              weechat_color (weechat_config_string (fset_config_color_help_description)),
               (ptr_fset_option->description && ptr_fset_option->description[0]) ?
               _(ptr_fset_option->description) : _("(no description)"),
               weechat_color ("bar_delim"),


### PR DESCRIPTION
**Description**

**[why]**
The fset.color.help_description setting previously didn't apply to its corresponding UI element, in this case the description of configuration variable in the help bar in fset.

**[how]**
Change code that configures the foreground colour of this UI element to apply the aforementioned setting.