### PR TITLE
core: replace inet_addr() with inet_pton()

### DIFF
--- a/src/core/wee-network.c
+++ b/src/core/wee-network.c
@@ -554,10 +554,12 @@ network_pass_socks4proxy (struct t_proxy *proxy, int sock, const char *address,
     socks4.method = 1;
     socks4.port = htons (port);
     network_resolve (address, ip_addr, NULL);
-    socks4.address = inet_addr (ip_addr);
     strncpy (socks4.user, username, sizeof (socks4.user) - 1);
 
     free (username);
+
+    if (inet_pton (AF_INET, ip_addr, &socks4.address) != 1)
+        return 0;
 
     length = 8 + strlen (socks4.user) + 1;
     if (network_send_with_retry (sock, (char *) &socks4, length, 0) != length)


### PR DESCRIPTION
man pages as well as rpminspect suggest that we shouldn't be using inet_addr().