### PR TITLE
Improve error handling for hook_url

### DIFF
--- a/src/core/hook/wee-hook-url.c
+++ b/src/core/hook/wee-hook-url.c
@@ -172,7 +172,7 @@ hook_url_timer_cb (const void *pointer, void *data, int remaining_calls)
     {
         hook_url_run_callback (hook);
         ptr_error = hashtable_get (HOOK_URL(hook, output), "error");
-        if (ptr_error && ptr_error[0])
+        if (weechat_debug_core >= 1 && ptr_error && ptr_error[0])
         {
             gui_chat_printf (
                 NULL,
@@ -242,11 +242,14 @@ hook_url_transfer (struct t_hook *hook)
                        str_error_code_pthread);
         hook_url_run_callback (hook);
 
-        gui_chat_printf (NULL,
-                         _("%sError running thread in hook_url: %s (URL: \"%s\")"),
-                         gui_chat_prefix[GUI_CHAT_PREFIX_ERROR],
-                         strerror (rc),
-                         HOOK_URL(hook, url));
+        if (weechat_debug_core >= 1)
+        {
+            gui_chat_printf (NULL,
+                             _("%sError running thread in hook_url: %s (URL: \"%s\")"),
+                             gui_chat_prefix[GUI_CHAT_PREFIX_ERROR],
+                             strerror (rc),
+                             HOOK_URL(hook, url));
+        }
         unhook (hook);
         return;
     }

--- a/src/core/hook/wee-hook-url.c
+++ b/src/core/hook/wee-hook-url.c
@@ -220,6 +220,11 @@ hook_url_transfer (struct t_hook *hook)
                          &hook_url_transfer_thread, hook);
     if (rc != 0)
     {
+        snprintf (str_error, sizeof (str_error),
+                  "error calling pthread_create (%d)", rc);
+        hashtable_set (HOOK_URL(hook, output), "error", str_error);
+        hook_url_run_callback (hook);
+
         gui_chat_printf (NULL,
                          _("%sError running thread in hook_url: %s (URL: \"%s\")"),
                          gui_chat_prefix[GUI_CHAT_PREFIX_ERROR],

--- a/src/core/wee-url.c
+++ b/src/core/wee-url.c
@@ -1344,7 +1344,8 @@ weeurl_download (const char *url, struct t_hashtable *options,
     struct t_url_file url_file[2];
     char *url_file_option[2] = { "file_in", "file_out" };
     char *url_file_mode[2] = { "rb", "wb" };
-    char url_error[CURL_ERROR_SIZE + 1], **string_headers, **string_output;
+    char url_error[CURL_ERROR_SIZE + 1], url_error_code[12];
+    char **string_headers, **string_output;
     char str_response_code[32];
     CURLoption url_file_opt_func[2] = { CURLOPT_READFUNCTION, CURLOPT_WRITEFUNCTION };
     CURLoption url_file_opt_data[2] = { CURLOPT_READDATA, CURLOPT_WRITEDATA };
@@ -1358,6 +1359,7 @@ weeurl_download (const char *url, struct t_hashtable *options,
     string_headers = NULL;
     string_output = NULL;
     url_error[0] = '\0';
+    url_error_code[0] = '\0';
 
     for (i = 0; i < 2; i++)
     {
@@ -1465,6 +1467,7 @@ weeurl_download (const char *url, struct t_hashtable *options,
     {
         if (output)
         {
+            snprintf (url_error_code, sizeof (url_error_code), "%d", curl_rc);
             if (!url_error[0])
             {
                 snprintf (url_error, sizeof (url_error),
@@ -1507,6 +1510,8 @@ end:
         }
         if (url_error[0])
             hashtable_set (output, "error", url_error);
+        if (url_error_code[0])
+            hashtable_set (output, "error_code_curl", url_error_code);
     }
     return rc;
 }


### PR DESCRIPTION
This makes the callback being called when pthread_create fails, adds error codes to `output` for easier use in plugins/scripts and removes printing the errors to the core buffer unless `weechat_debug_core` is enabled. See the commit messages for details.

If you would like to keep the printing to core, we could add an option to the `option` hashtable to hook_url to disable it instead of disabling it by default.