### PR TITLE
Fix `chmod` and `fopen` TOCTOU bugs

### DIFF
--- a/src/core/wee-crypto.c
+++ b/src/core/wee-crypto.c
@@ -285,7 +285,6 @@ weecrypto_hash_file (const char *filename, int hash_algo,
                      void *hash, int *hash_size)
 {
     gcry_md_hd_t *hd_md;
-    struct stat st;
     FILE *file;
     size_t num_read;
     int rc, hd_md_opened, algo_size;
@@ -304,9 +303,6 @@ weecrypto_hash_file (const char *filename, int hash_algo,
         *hash_size = 0;
 
     if (!filename || !filename[0] || !hash)
-        goto hash_end;
-
-    if (stat (filename, &st) == -1)
         goto hash_end;
 
     file = fopen (filename, "r");

--- a/src/core/wee-dir.c
+++ b/src/core/wee-dir.c
@@ -1080,9 +1080,6 @@ dir_file_compress_gzip (const char *from, const char *to,
     if (!from || !to || (compression_level < 1) || (compression_level > 9))
         goto end;
 
-    if (access (to, F_OK) == 0)
-        goto end;
-
     buffer_in = malloc (buffer_size);
     if (!buffer_in)
         goto end;
@@ -1093,7 +1090,7 @@ dir_file_compress_gzip (const char *from, const char *to,
     source = fopen (from, "rb");
     if (!source)
         goto end;
-    dest = fopen (to, "wb");
+    dest = fopen (to, "wbx");
     if (!dest)
         goto end;
 
@@ -1201,9 +1198,6 @@ dir_file_compress_zstd (const char *from, const char *to,
     if (!from || !to || (compression_level < 1) || (compression_level > 19))
         goto end;
 
-    if (access (to, F_OK) == 0)
-        goto end;
-
     buffer_in_size = ZSTD_CStreamInSize ();
     buffer_in = malloc (buffer_in_size);
     if (!buffer_in)
@@ -1216,7 +1210,7 @@ dir_file_compress_zstd (const char *from, const char *to,
     source = fopen (from, "rb");
     if (!source)
         goto end;
-    dest = fopen (to, "wb");
+    dest = fopen (to, "wbx");
     if (!dest)
         goto end;
 

--- a/src/plugins/fset/fset-option.c
+++ b/src/plugins/fset/fset-option.c
@@ -1408,7 +1408,7 @@ fset_option_export (const char *filename, int with_help)
         return 0;
     }
 
-    chmod (filename2, 0600);
+    fchmod (fileno (file), 0600);
 
     hashtable_pointers = weechat_hashtable_new (
         8,


### PR DESCRIPTION
This PR fixes a couple of [TOCTOU](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use) bugs.

> [TOCTOU] is a class of software bugs caused by a race condition involving the checking of the state of a part of a system (such as a security credential) and the use of the results of that check.

- Instead of verifying that the file does not exist with access(2), I've simply altered the fopen(3) function call with the `x` mode, which will exclusively open the file -- it will only open the file if it can be created, or if it didn't already exist; if it does exist, it will error, as it would have before.
- Instead of using chmod(2), use fchmod(2), which operates on the file descriptor instead of the filename.
- It seems that stat(2) is used to verify that the file exists, since `st` is not used again in the scope. Rather than check for existence, open the file and if it does not exist, fopen(3) will error.