### PR TITLE
GUI: fix potential integer overflows by casting to `size_t`

### DIFF
--- a/src/gui/curses/gui-curses-color.c
+++ b/src/gui/curses/gui-curses-color.c
@@ -669,7 +669,7 @@ gui_color_init_vars ()
         gui_color_num_pairs = (gui_color_term_color_pairs >= 32768) ?
             32767 : gui_color_term_color_pairs - 1;
         gui_color_pairs = calloc (
-            (gui_color_term_colors + 2) * (gui_color_term_colors + 2),
+            (size_t)(gui_color_term_colors + 2) * (gui_color_term_colors + 2),
             sizeof (gui_color_pairs[0]));
         gui_color_pairs_used = 0;
 
@@ -1226,7 +1226,7 @@ gui_color_reset_pairs ()
     if (gui_color_pairs)
     {
         memset (gui_color_pairs, 0,
-                (gui_color_term_colors + 2)
+                (size_t)(gui_color_term_colors + 2)
                 * (gui_color_term_colors + 2)
                 * sizeof (gui_color_pairs[0]));
         gui_color_pairs_used = 0;


### PR DESCRIPTION
Not sure how big `gui_color_term_colors` can realistically get, but it has type `int` so it's possible to overflow via the multiplication _before_ it is implicitly cast to a `size_t` function parameter.

By explicitly casting to a larger type (`size_t`) _before_ the multiplication, the compiler will implicitly promote the other operands to type `size_t`, avoiding the risk of overflow.

Source: [Chapter 4. Type Conversions, _C in a Nutshell_](https://www.oreilly.com/library/view/c-in-a/0596006977/ch04.html)