### PR TITLE
relay: set server last_client_disconnect only for successful connections

### DIFF
--- a/src/plugins/relay/relay-client.c
+++ b/src/plugins/relay/relay-client.c
@@ -1426,6 +1426,7 @@ relay_client_new (int sock, const char *address, struct t_relay_server *server)
                                       address : "local");
         new_client->real_ip = NULL;
         new_client->status = RELAY_STATUS_CONNECTING;
+        new_client->ever_connected = 0;
         new_client->protocol = server->protocol;
         new_client->protocol_string = (server->protocol_string) ? strdup (server->protocol_string) : NULL;
         new_client->protocol_args = (server->protocol_args) ? strdup (server->protocol_args) : NULL;
@@ -1808,6 +1809,7 @@ relay_client_set_status (struct t_relay_client *client,
     if ((client->status == RELAY_STATUS_CONNECTED)
         && relay_config_display_clients[client->protocol])
     {
+        client->ever_connected = 1;
         weechat_printf_date_tags (
                     NULL, 0, "relay_client",
                     _("%s: client %s%s%s connected/authenticated"),
@@ -1822,7 +1824,10 @@ relay_client_set_status (struct t_relay_client *client,
 
         ptr_server = relay_server_search (client->protocol_string);
         if (ptr_server)
-            ptr_server->last_client_disconnect = client->end_time;
+        {
+            if (client->ever_connected)
+                ptr_server->last_client_disconnect = client->end_time;
+        }
 
         relay_client_outqueue_free_all (client);
 

--- a/src/plugins/relay/relay-client.h
+++ b/src/plugins/relay/relay-client.h
@@ -120,6 +120,7 @@ struct t_relay_client
     char *address;                     /* string with IP address            */
     char *real_ip;                     /* real IP (X-Real-IP HTTP header)   */
     enum t_relay_status status;        /* status (connecting, active,..)    */
+    int ever_connected;                /* 1 if ever successfully connected  */
     enum t_relay_protocol protocol;    /* protocol (irc,..)                 */
     char *protocol_string;             /* example: "ipv6.tls.irc.libera"    */
     char *protocol_args;               /* arguments used for protocol       */


### PR DESCRIPTION
With certain option settings, a relay client receives the backlog since the last_client_disconnect timestamp, which ideally would let the user conveniently pick up messages where they left off.

However, if an unsuccessful connection (e.g. failed authentication, port scan, or other spam request) to the relay was made before the user successfully reconnects to it, the user would fail to see messages received before the unsuccessful connection in the relay client, hence they might miss messages arrived while they were away.  This is because last_client_disconnect is also updated when an unsuccessful connection closes.

To solve this, update last_client_disconnect only when a *successfully-connected* client is disconnected, so unsuccessful connections cannot affect it.