### PR TITLE
tests: relay: add missing <string.h> include

### DIFF
--- a/tests/unit/plugins/relay/api/remote/test-relay-remote-network.cpp
+++ b/tests/unit/plugins/relay/api/remote/test-relay-remote-network.cpp
@@ -25,6 +25,7 @@
 
 extern "C"
 {
+#include <string.h>
 #include <cjson/cJSON.h>
 #include "src/core/core-config-file.h"
 #include "src/plugins/relay/relay.h"


### PR DESCRIPTION
Fixes build error on Fedora 40.