### PR TITLE
core: always send input_text_changed signal on buffer set input

### DIFF
--- a/src/gui/gui-buffer.c
+++ b/src/gui/gui-buffer.c
@@ -2353,7 +2353,7 @@ gui_buffer_set_input_prompt (struct t_gui_buffer *buffer,
 void
 gui_buffer_set_input (struct t_gui_buffer *buffer, const char *input)
 {
-    if (!buffer || (string_strcmp (buffer->input_buffer, input) == 0))
+    if (!buffer)
         return;
 
     gui_buffer_undo_snap (buffer);


### PR DESCRIPTION
When the buffer input is set to the same string it already has, we should still run the input modifiers and send the input_text_changed signal. This is because plugins/scripts may rely on them being run when they set the input.

An example is the go.py script. When you start it, it stores the input and sets it to an empty string, and uses some input modifiers to display custom data in the input field. Since this function just returned early if the input was empty, it had a bug where if you had /go bound to a key and pressed the key when you had an empty input, the buffers go adds to the input wouldn't be shown until you press another key.

This fixes a regression that was introduced in commit 7addd1bf0070c8b6c36f6e1d90245c44f742d7ee.