### PR TITLE
python: add workaround for crash on unload with Python 3.12

### DIFF
--- a/src/plugins/python/weechat-python.c
+++ b/src/plugins/python/weechat-python.c
@@ -1606,6 +1606,12 @@ weechat_plugin_init (struct t_weechat_plugin *plugin, int argc, char *argv[])
                            "",
                            &weechat_python_infolist_cb, NULL, NULL);
 
+#if PY_VERSION_HEX >= 0x030C0000 && PY_VERSION_HEX < 0x030D0000
+    // Workaround for crash when ending interpreters in Python 3.12
+    // See https://github.com/weechat/weechat/issues/2046
+    weechat_python_eval (NULL, 0, 0, "");
+#endif
+
     /* init OK */
     return WEECHAT_RC_OK;
 }

--- a/src/plugins/python/weechat-python.c
+++ b/src/plugins/python/weechat-python.c
@@ -1625,12 +1625,12 @@ weechat_plugin_end (struct t_weechat_plugin *plugin)
 {
     /* unload all scripts */
     python_quiet = 1;
+    plugin_script_end (plugin, &python_data);
     if (python_script_eval)
     {
         weechat_python_unload (python_script_eval);
         python_script_eval = NULL;
     }
-    plugin_script_end (plugin, &python_data);
     python_quiet = 0;
 
     /* free python interpreter */


### PR DESCRIPTION
Python 3.12 has a bug where it crashes when you unload all the interpreters unless you make sure to unload the first interpreter you loaded last. For some reason, loading the eval interpreter before any scripts also seems to prevent the issue, even if the eval interpreter is unloaded before the other interpreters.

So this just evals an empty string at the end of initing the Python plugin if the Python version is 3.12, to make sure the eval interpreter is loaded first.

Fixes #2046