### PR TITLE
irc: fix lag check interval comment

### DIFF
--- a/src/plugins/irc/irc-server.c
+++ b/src/plugins/irc/irc-server.c
@@ -4144,7 +4144,7 @@ irc_server_timer_cb (const void *pointer, void *data, int remaining_calls)
                             refresh_lag = 1;
                         }
 
-                        /* schedule next lag check in 5 seconds */
+                        /* schedule next lag check */
                         ptr_server->lag_check_time.tv_sec = 0;
                         ptr_server->lag_check_time.tv_usec = 0;
                         ptr_server->lag_next_check = time (NULL) +


### PR DESCRIPTION
The network lag check interval is stored in irc_config_network_lag_check, which does not default to 5 seconds.

Looks like the erroneous comment was introduced in 9d740130365a7aecd34f64a5c502eff74bf16d3e