### PR TITLE
lua: fix broken LUA_VERSION check

### DIFF
--- a/src/plugins/lua/weechat-lua.c
+++ b/src/plugins/lua/weechat-lua.c
@@ -1272,7 +1272,7 @@ weechat_plugin_init (struct t_weechat_plugin *plugin, int argc, char *argv[])
 #if defined(LUA_VERSION_MAJOR) && defined(LUA_VERSION_MINOR)
     weechat_hashtable_set (plugin->variables, "interpreter_version",
                            LUA_VERSION_MAJOR "." LUA_VERSION_MINOR);
-#elif LUA_VERSION
+#elif defined(LUA_VERSION)
     weechat_hashtable_set (plugin->variables, "interpreter_version",
                            LUA_VERSION);
 #else


### PR DESCRIPTION
/usr/include/lua-5.1/lua.h:19:25: error: token ""Lua 5.1"" is not valid in preprocessor expressions