### PR TITLE
core: Fix build on Android to define htobe64

### DIFF
--- a/src/core/core-crypto.c
+++ b/src/core/core-crypto.c
@@ -31,6 +31,12 @@
 #include <math.h>
 #include <gcrypt.h>
 
+#ifdef __ANDROID__
+/* Bring in htobe64 */
+#define _BSD_SOURCE
+#include <endian.h>
+#endif
+
 #include "weechat.h"
 #include "core-crypto.h"
 #include "core-config-file.h"


### PR DESCRIPTION
This is needed to get `htobe64` defined on Android - see https://android.googlesource.com/platform/bionic/+/refs/heads/main/libc/include/sys/endian.h.