### PR TITLE
cmake: require 3.12, resolve circular dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,8 +242,6 @@ endif()
 # Check for CURL
 find_package(CURL REQUIRED)
 
-set(STATIC_LIBS weechat_plugins)
-
 find_library(DL_LIBRARY
   NAMES dl
   PATHS /lib /usr/lib /usr/libexec /usr/local/lib /usr/local/libexec

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@
 # along with WeeChat.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 
 project(weechat C)
 
@@ -242,14 +242,12 @@ endif()
 # Check for CURL
 find_package(CURL REQUIRED)
 
-# weechat_gui_common MUST be the first lib in the list
-set(STATIC_LIBS weechat_gui_common)
+set(STATIC_LIBS weechat_plugins)
 
 find_library(DL_LIBRARY
   NAMES dl
   PATHS /lib /usr/lib /usr/libexec /usr/local/lib /usr/local/libexec
 )
-list(APPEND STATIC_LIBS weechat_plugins)
 if(DL_LIBRARY)
   string(REGEX REPLACE "/[^/]*$" "" DL_LIBRARY_PATH "${DL_LIBRARY}")
   set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -L${DL_LIBRARY_PATH}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,7 +20,6 @@
 #
 
 add_subdirectory(core)
-list(APPEND STATIC_LIBS weechat_core)
 
 add_subdirectory(plugins)
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -100,6 +100,6 @@ if(ENABLE_CJSON)
 endif()
 
 include_directories("${CMAKE_BINARY_DIR}")
-add_library(weechat_core STATIC ${LIB_CORE_SRC})
+add_library(weechat_core OBJECT ${LIB_CORE_SRC})
 target_link_libraries(weechat_core coverage_config)
 add_dependencies(weechat_core version_git)

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -43,7 +43,7 @@ set(LIB_GUI_COMMON_SRC
 )
 
 include_directories("${CMAKE_BINARY_DIR}")
-add_library(weechat_gui_common STATIC ${LIB_GUI_COMMON_SRC})
+add_library(weechat_gui_common OBJECT ${LIB_GUI_COMMON_SRC})
 target_link_libraries(weechat_gui_common coverage_config)
 list(APPEND STATIC_LIBS weechat_gui_common)
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -45,6 +45,5 @@ set(LIB_GUI_COMMON_SRC
 include_directories("${CMAKE_BINARY_DIR}")
 add_library(weechat_gui_common OBJECT ${LIB_GUI_COMMON_SRC})
 target_link_libraries(weechat_gui_common coverage_config)
-list(APPEND STATIC_LIBS weechat_gui_common)
 
 subdirs(curses)

--- a/src/gui/curses/headless/CMakeLists.txt
+++ b/src/gui/curses/headless/CMakeLists.txt
@@ -55,9 +55,7 @@ add_dependencies(${EXECUTABLE}
   weechat_ncurses_fake
 )
 
-# Due to circular references, we must link two times with libweechat_core.a and libweechat_gui_common.a
 target_link_libraries(${EXECUTABLE}
-  ${STATIC_LIBS}
   weechat_gui_headless
   weechat_ncurses_fake
   ${EXTRA_LIBS}

--- a/src/gui/curses/headless/CMakeLists.txt
+++ b/src/gui/curses/headless/CMakeLists.txt
@@ -56,10 +56,12 @@ add_dependencies(${EXECUTABLE}
 )
 
 target_link_libraries(${EXECUTABLE}
+  weechat_core
+  weechat_plugins
+  weechat_gui_common
   weechat_gui_headless
   weechat_ncurses_fake
   ${EXTRA_LIBS}
-  ${STATIC_LIBS}
   coverage_config
 )
 

--- a/src/gui/curses/normal/CMakeLists.txt
+++ b/src/gui/curses/normal/CMakeLists.txt
@@ -58,8 +58,12 @@ add_dependencies(${EXECUTABLE} weechat_gui_curses_normal)
 
 list(APPEND EXTRA_LIBS ${NCURSES_LIBRARY})
 
-# Due to circular references, we must link two times with libweechat_core.a and libweechat_gui_common.a
-target_link_libraries(${EXECUTABLE} ${STATIC_LIBS} weechat_gui_curses_normal ${EXTRA_LIBS} ${STATIC_LIBS} coverage_config)
+target_link_libraries(${EXECUTABLE}
+  weechat_gui_curses_normal
+  ${EXTRA_LIBS}
+  ${STATIC_LIBS}
+  coverage_config
+)
 
 # Create a symbolic link weechat-curses -> weechat
 # This link is created for compatibility with old versions on /upgrade.

--- a/src/gui/curses/normal/CMakeLists.txt
+++ b/src/gui/curses/normal/CMakeLists.txt
@@ -59,9 +59,11 @@ add_dependencies(${EXECUTABLE} weechat_gui_curses_normal)
 list(APPEND EXTRA_LIBS ${NCURSES_LIBRARY})
 
 target_link_libraries(${EXECUTABLE}
+  weechat_core
+  weechat_plugins
+  weechat_gui_common
   weechat_gui_curses_normal
   ${EXTRA_LIBS}
-  ${STATIC_LIBS}
   coverage_config
 )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -226,8 +226,6 @@ target_link_libraries(tests
   weechat_gui_headless
   weechat_ncurses_fake
   weechat_unit_tests_core
-  # due to circular references, we must link two times with libweechat_core.a
-  weechat_core
   ${EXTRA_LIBS}
   ${CURL_LIBRARIES}
   ${ZLIB_LIBRARY}


### PR DESCRIPTION
In order to resolve the circular dependency, we need to annotate the
respective static libraries as object "libraries."

This requires cmake 3.12, where Debian 10 (old old stable) and Ubuntu
20.04 have 3.13 and 3.16 respectively.

An alternative is to manually track and use the respective source files.
Since all platforms of interest meet the cmake requirement, we can opt
for the simpler approach.

---

What tends to be the policy wrt minimum required version - is Debian/Ubuntu the most significant factor? Are there any objections, if I bump a few other projects and do some cleanups?