### PR TITLE
.editorconfig: add initial configuration file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# To use this config on you editor, follow the instructions at:
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+indent_size = 4
+indent_style = space
+tab_width = 8
+trim_trailing_whitespace = true
+
+[{*.{c,cpp,h}}]
+max_line_length = 80
+
+[{CMakeLists.txt,*.cmake}]
+max_line_length = 80
+indent_size = 2
+
+[*.html]
+indent_size = 2
+
+[*.yml]
+indent_size = 2


### PR DESCRIPTION
To ease the initial hurdle of using the proper formatting across files, introduce a simple .editorconfig file.

Nearly every common editor supports it OOTB these days, including the GitHub and GitLab web editors.