### PR TITLE
cmake: remove unused HAVE_GCRYPT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,7 +207,6 @@ endif()
 
 # Check for libgcrypt
 pkg_check_modules(LIBGCRYPT REQUIRED libgcrypt)
-add_definitions(-DHAVE_GCRYPT)
 include_directories(${LIBGCRYPT_INCLUDE_DIRS})
 list(APPEND EXTRA_LIBS ${LIBGCRYPT_LDFLAGS})
 


### PR DESCRIPTION
Seemingly unused for ~12 years, since commit a99d13601 ("core: add new plugin "script" (scripts manager, replacing scripts weeget.py and script.pl)")