### PR TITLE
core: simplify plugin callback by refactoring if statements

### DIFF
--- a/src/core/core-command.c
+++ b/src/core/core-command.c
@@ -5189,34 +5189,31 @@ COMMAND_CALLBACK(plugin)
 
     if (string_strcmp (argv[1], "reload") == 0)
     {
-        if (argc > 2)
+        if (argc < 3)
         {
-            if (argc > 3)
-            {
-                plugin_argv = string_split (
+            plugin_unload_all ();
+            plugin_auto_load (NULL, 1, 1, 1, 0, NULL);
+        }
+        else if (argc == 3)
+            plugin_reload_name (argv[2], 0, NULL);
+        else
+        {
+            plugin_argv = string_split (
                     argv_eol[3], " ", NULL,
                     WEECHAT_STRING_SPLIT_STRIP_LEFT
                     | WEECHAT_STRING_SPLIT_STRIP_RIGHT
                     | WEECHAT_STRING_SPLIT_COLLAPSE_SEPS,
                     0, &plugin_argc);
-                if (strcmp (argv[2], "*") == 0)
-                {
-                    plugin_unload_all ();
-                    plugin_auto_load (NULL, 1, 1, 1, plugin_argc, plugin_argv);
-                }
-                else
-                {
-                    plugin_reload_name (argv[2], plugin_argc, plugin_argv);
-                }
-                string_free_split (plugin_argv);
+            if (strcmp (argv[2], "*") == 0)
+            {
+                plugin_unload_all ();
+                plugin_auto_load (NULL, 1, 1, 1, plugin_argc, plugin_argv);
             }
             else
-                plugin_reload_name (argv[2], 0, NULL);
-        }
-        else
-        {
-            plugin_unload_all ();
-            plugin_auto_load (NULL, 1, 1, 1, 0, NULL);
+            {
+                plugin_reload_name (argv[2], plugin_argc, plugin_argv);
+            }
+            string_free_split (plugin_argv);
         }
         return WEECHAT_RC_OK;
     }


### PR DESCRIPTION


**Refactor to Simplify Control Flow**

This refactor removes unnecessary nesting to make the control flow more readable.

**Current Control Flow:**

There are 3 possible paths through this code:

**Path 1**: argc > 3 (which implies argc > 2)
**Path 2**: argc == 3
**Path 3**: argc <= 2

**Proposed Changes:**

The nested if statements are unraveled, and the logic is simplified by handling these cases up front.

- There's no need to check argc > 2 and argc > 3 separately, as argc > 3 implies argc > 2.
- For 3 >= argc > 2, argc can only be equal to 3, so this is checked explicitly.
- The final case (argc <= 2) is handled in the else clause, as in the original.

