### PR TITLE
relay/api: support passing auth in sub protocol header

### DIFF
--- a/doc/en/weechat_relay_api.en.adoc
+++ b/doc/en/weechat_relay_api.en.adoc
@@ -101,7 +101,9 @@ Examples:
 [[authentication]]
 == Authentication
 
-The password must be sent in the header `Authorization` with `Basic` authentication schema.
+The password must be sent in the header `Authorization` with `Basic`
+authentication schema or in the header `Sec-WebSocket-Protocol` (see details
+below).
 
 The password can be sent as plain text or hashed, with one of these formats
 for user and password:
@@ -135,8 +137,8 @@ Example:
   `hash:sha256:1706431066:dfa1db3f6bb6445d18d9ec7427c10f6421274e3a4751e6c1ffc7dd28c94eadf6`:
   `aGFzaDpzaGEyNTY6MTcwNjQzMTA2NjpkZmExZGIzZjZiYjY0NDVkMThkOWVjNzQyN2MxMGY2NDIxMjc0ZTNhNDc1MWU2YzFmZmM3ZGQyOGM5NGVhZGY2`.
 
-The header `Authorization` is allowed in the first request with websocket protocol
-or any HTTP request in the other cases.
+The headers `Authorization` and `Sec-WebSocket-Protocol` are allowed in the first
+request with the websocket protocol or any HTTP request in the other cases.
 
 Request example with plain text password:
 
@@ -260,6 +262,37 @@ HTTP/1.1 401 Unauthorized
 {
     "error": "Invalid TOTP"
 }
+----
+
+[[authentication_sec_websocket_protocol]]
+=== Sec-WebSocket-Protocol
+
+The JavaScript WebSocket API used in current web browsers does not support
+specifying the `Authorization` header. Therefore it's also supported to send
+the password in the `Sec-WebSocket-Protocol` header which is the only header
+possible to set with this API.
+
+To use this header, you must specify the sub-protocols `api.weechat` and
+`base64url.bearer.authorization.weechat.<auth>` where `<auth>` is the base64url
+encoded string of the password in the same format as explained above.
+
+Example with password `secret_password` encoded in plain text. This makes the
+string to base64url encode `plain:secret_password` which is
+`cGxhaW46c2VjcmV0X3Bhc3N3b3Jk`.
+
+[source,http]
+----
+Sec-WebSocket-Protocol: api.weechat, base64url.bearer.authorization.weechat.cGxhaW46c2VjcmV0X3Bhc3N3b3Jk
+----
+
+This can be set with the JavaScript WebSocket API like this:
+
+[source,javascript]
+----
+const ws = new WebSocket("wss://localhost:9000/api", [
+  "api.weechat",
+  "base64url.bearer.authorization.weechat.cGxhaW46c2VjcmV0X3Bhc3N3b3Jk",
+])
 ----
 
 [[compression]]

--- a/src/plugins/relay/relay-websocket.c
+++ b/src/plugins/relay/relay-websocket.c
@@ -400,10 +400,11 @@ relay_websocket_parse_extensions (const char *extensions,
 char *
 relay_websocket_build_handshake (struct t_relay_http_request *request)
 {
-    const char *sec_websocket_key;
+    const char *sec_websocket_key, *sec_websocket_protocol_request;
     char *key, sec_websocket_accept[128], handshake[4096], hash[160 / 8];
-    char **extensions, str_window_bits[128], sec_websocket_extensions[1024];
-    int length, hash_size;
+    char **extensions, **protool_array, str_window_bits[128], sec_websocket_extensions[1024];
+    char sec_websocket_protocol[1024];
+    int i, length, hash_size, protocol_count;
 
     if (!request)
         return NULL;
@@ -481,6 +482,22 @@ relay_websocket_build_handshake (struct t_relay_http_request *request)
         sec_websocket_extensions[0] = '\0';
     }
 
+    sec_websocket_protocol_request = weechat_hashtable_get (request->headers, "sec-websocket-protocol");
+    protool_array = weechat_string_split (sec_websocket_protocol_request, ",", " ", 0, 0, &protocol_count);
+
+    sec_websocket_protocol[0] = '\0';
+    for (i = 0; i < protocol_count; i++)
+    {
+        if (strcmp (protool_array[i], WEBSOCKET_SUB_PROTOCOL_API_WEECHAT) == 0)
+        {
+            snprintf (
+                sec_websocket_protocol, sizeof (sec_websocket_protocol),
+                "Sec-WebSocket-Protocol: %s\r\n",
+                WEBSOCKET_SUB_PROTOCOL_API_WEECHAT);
+            break;
+        }
+    }
+
     /* build the handshake (it will be sent as-is to client) */
     snprintf (handshake, sizeof (handshake),
               "HTTP/1.1 101 Switching Protocols\r\n"
@@ -488,9 +505,11 @@ relay_websocket_build_handshake (struct t_relay_http_request *request)
               "Connection: Upgrade\r\n"
               "Sec-WebSocket-Accept: %s\r\n"
               "%s"
+              "%s"
               "\r\n",
               sec_websocket_accept,
-              sec_websocket_extensions);
+              sec_websocket_extensions,
+              sec_websocket_protocol);
 
     return strdup (handshake);
 }

--- a/src/plugins/relay/relay-websocket.h
+++ b/src/plugins/relay/relay-websocket.h
@@ -37,6 +37,8 @@
 #define WEBSOCKET_FRAME_OPCODE_PING         0x09
 #define WEBSOCKET_FRAME_OPCODE_PONG         0x0A
 
+#define WEBSOCKET_SUB_PROTOCOL_API_WEECHAT "api.weechat"
+
 struct t_relay_client;
 struct t_relay_http_request;
 

--- a/tests/unit/plugins/relay/test-relay-websocket.cpp
+++ b/tests/unit/plugins/relay/test-relay-websocket.cpp
@@ -248,6 +248,19 @@ TEST(RelayWebsocket, ClientHandshakeValid)
         "\r\n",
         relay_websocket_build_handshake (request));
 
+    relay_websocket_deflate_reinit (request->ws_deflate);
+    hashtable_set (request->headers, "sec-websocket-protocol",
+                   WEBSOCKET_SUB_PROTOCOL_API_WEECHAT
+                   ", base64url.bearer.authorization.weechat.cGxhaW46c2VjcmV0X3Bhc3N3b3Jk");
+    WEE_TEST_STR(
+        "HTTP/1.1 101 Switching Protocols\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        "Sec-WebSocket-Accept: fhLJYtv//ugX2vQXpifQgByRZ5Y=\r\n"
+        "Sec-WebSocket-Protocol: " WEBSOCKET_SUB_PROTOCOL_API_WEECHAT "\r\n"
+        "\r\n",
+        relay_websocket_build_handshake (request));
+
     relay_http_request_free (request);
 }
 


### PR DESCRIPTION
The API for connecting to WebSockets in browsers unfortunately doesn't support setting any Authorization header. This means that before this commit it was impossible to connect to the API relay from a web browser. The only thing that can be set apart from the URL is the Sec-WebSocket-Protocol header. Therefore this allows you to send the auth token in this header.

This is a weird way to send auth, but it seems to be the best one that makes it possible for browsers to connect. Kubernetes also does it this way: https://github.com/kubernetes/kubernetes/pull/47740

Here is a post describing the different ways to make it possible for a browser to authenticate against a websocket connection, and it also recommends doing it this way:
https://stackoverflow.com/questions/4361173/http-headers-in-websockets-client-api/77060459#77060459

Note that when this header is used to pass auth, the client also needs to specify the `api.weechat` sub protocol. This is because the client and server have to agree on a sub protocol when this header is specified, and in order to not send the fake protocol used for auth back to the client, we require specifying the protocol `api.weechat`, which the server then returns to the client. This is only necessary when the Sec-WebSocket-Protocol header is used. If the Authorization header is used for auth as before, nothing changes.