### PR TITLE
relay/api: combine request headers with the same name

### DIFF
--- a/src/plugins/relay/relay-http.c
+++ b/src/plugins/relay/relay-http.c
@@ -385,7 +385,7 @@ relay_http_parse_header (struct t_relay_http_request *request,
                          int ws_deflate_allowed)
 {
     char *pos, *name, *name_lower, *error, **items;
-    const char *ptr_value;
+    const char *existing_value, *ptr_value;
     int i, num_items;
     long number;
 
@@ -422,6 +422,12 @@ relay_http_parse_header (struct t_relay_http_request *request,
     while (ptr_value[0] == ' ')
     {
         ptr_value++;
+    }
+
+    existing_value = weechat_hashtable_get (request->headers, name_lower);
+    if (existing_value)
+    {
+        ptr_value = weechat_string_concat(", ", existing_value, ptr_value, NULL);
     }
 
     /* add header in the hashtable */

--- a/tests/unit/plugins/relay/test-relay-http.cpp
+++ b/tests/unit/plugins/relay/test-relay-http.cpp
@@ -541,6 +541,24 @@ TEST(RelayHttp, ParseHeader)
     request = relay_http_request_alloc ();
     CHECK(request);
     relay_http_parse_method_path (request, "GET /api/version");
+    relay_http_parse_header (request, "Accept-Encoding: gzip", 1);
+    relay_http_parse_header (request, "Accept-Encoding: zstd", 1);
+    LONGS_EQUAL(RELAY_HTTP_HEADERS, request->status);
+    STRCMP_EQUAL("GET /api/version\n"
+                 "Accept-Encoding: gzip\n"
+                 "Accept-Encoding: zstd\n",
+                 *(request->raw));
+    LONGS_EQUAL(1, request->headers->items_count);
+    STRCMP_EQUAL("gzip, zstd",
+                 (const char *)hashtable_get (request->headers, "accept-encoding"));
+    LONGS_EQUAL(2, request->accept_encoding->items_count);
+    CHECK(hashtable_has_key (request->accept_encoding, "gzip"));
+    CHECK(hashtable_has_key (request->accept_encoding, "zstd"));
+    relay_http_request_free (request);
+
+    request = relay_http_request_alloc ();
+    CHECK(request);
+    relay_http_parse_method_path (request, "GET /api/version");
     relay_http_parse_header (request, "Content-Length: 123", 1);
     LONGS_EQUAL(RELAY_HTTP_HEADERS, request->status);
     STRCMP_EQUAL("GET /api/version\n"


### PR DESCRIPTION
If a request repeats the same header name multiple times, merge the header values into a comma separated string. Previously, only the last header specified would be used.

For header fields that are defined as a comma-separated list, a client may choose to send it as multiple headers instead of one header with comma-separated values. The specification says that these are equivalent, so we can therefore join the headers into a comma-separated string.

This is specified at https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.2 which says:

    A sender MUST NOT generate multiple header fields with the same field
    name in a message unless either the entire field value for that
    header field is defined as a comma-separated list [i.e., #(values)]
    or the header field is a well-known exception (as noted below).

    A recipient MAY combine multiple header fields with the same field
    name into one "field-name: field-value" pair, without changing the
    semantics of the message, by appending each subsequent field value to
    the combined field value in order, separated by a comma.  The order
    in which header fields with the same field name are received is
    therefore significant to the interpretation of the combined field
    value; a proxy MUST NOT change the order of these field values when
    forwarding a message.