### PR TITLE
Fix crash when unloading Perl scripts with Perl 5.38

### DIFF
--- a/src/plugins/perl/weechat-perl.c
+++ b/src/plugins/perl/weechat-perl.c
@@ -570,7 +570,7 @@ weechat_perl_load (const char *filename, const char *code)
                 perl_args_count, perl_args, NULL);
 #if PERL_REVISION >= 6 || (PERL_REVISION == 5 && PERL_VERSION >= 38)
     /* restore the locale that could be changed by Perl >= 5.38 */
-    Perl_setlocale (LC_CTYPE, "");
+    Perl_setlocale (LC_ALL, "");
 #endif
     length = strlen (perl_weechat_code) + strlen (str_warning) +
         strlen (str_error) - 2 + 4 + strlen ((code) ? code : filename) + 4 + 1;
@@ -1303,7 +1303,7 @@ weechat_plugin_init (struct t_weechat_plugin *plugin, int argc, char *argv[])
                 perl_args, NULL);
 #if PERL_REVISION >= 6 || (PERL_REVISION == 5 && PERL_VERSION >= 38)
     /* restore the locale that could be changed by Perl >= 5.38 */
-    Perl_setlocale (LC_CTYPE, "");
+    Perl_setlocale (LC_ALL, "");
 #endif
 #endif /* MULTIPLICITY */
 


### PR DESCRIPTION
Apparently the issue with the locale being reset with Perl 5.38 can cause a crash when unloading the scripts on some systems (at least Ubuntu 24.04). There was a workaround added in commit f4b9cad72, but it doesn't work to avoid the crash. However if we set LC_ALL instead of LC_CTYPE the crash doesn't occur.

Fixes #2187