### PR TITLE
core: add `int` arg for all sigaction.sa_handler functions

### DIFF
--- a/src/core/core-debug.c
+++ b/src/core/core-debug.c
@@ -228,7 +228,7 @@ debug_dump_cb (const void *pointer, void *data,
  */
 
 void
-debug_sigsegv_cb ()
+debug_sigsegv_cb (int)
 {
     debug_dump (1);
     unhook_all ();

--- a/src/core/core-debug.h
+++ b/src/core/core-debug.h
@@ -27,7 +27,7 @@ struct t_gui_window_tree;
 extern long long debug_long_callbacks;
 
 extern void debug_build_info ();
-extern void debug_sigsegv_cb ();
+extern void debug_sigsegv_cb (int);
 extern void debug_windows_tree ();
 extern void debug_memory ();
 extern void debug_hdata ();

--- a/src/core/core-signal.c
+++ b/src/core/core-signal.c
@@ -65,7 +65,7 @@ volatile sig_atomic_t signal_sigusr2_count = 0;
  */
 
 void
-signal_sighup_cb ()
+signal_sighup_cb (int)
 {
     signal_sighup_count++;
 }
@@ -75,7 +75,7 @@ signal_sighup_cb ()
  */
 
 void
-signal_sigquit_cb ()
+signal_sigquit_cb (int)
 {
     signal_sigquit_count++;
 }
@@ -85,7 +85,7 @@ signal_sigquit_cb ()
  */
 
 void
-signal_sigterm_cb ()
+signal_sigterm_cb (int)
 {
     signal_sigterm_count++;
 }
@@ -95,7 +95,7 @@ signal_sigterm_cb ()
  */
 
 void
-signal_sigusr1_cb ()
+signal_sigusr1_cb (int)
 {
     signal_sigusr1_count++;
 }
@@ -105,7 +105,7 @@ signal_sigusr1_cb ()
  */
 
 void
-signal_sigusr2_cb ()
+signal_sigusr2_cb (int)
 {
     signal_sigusr2_count++;
 }

--- a/src/gui/curses/gui-curses-main.c
+++ b/src/gui/curses/gui-curses-main.c
@@ -150,7 +150,7 @@ gui_main_get_password (const char **prompt, char *password, int size)
  */
 
 void
-gui_main_signal_sigint ()
+gui_main_signal_sigint (int)
 {
     weechat_quit = 1;
 }
@@ -253,7 +253,7 @@ gui_main_init ()
  */
 
 void
-gui_main_signal_sigwinch ()
+gui_main_signal_sigwinch (int)
 {
     gui_signal_sigwinch_received = 1;
 }


### PR DESCRIPTION
```
src/gui/curses/gui-curses-main.c: In function ‘gui_main_loop’: src/gui/curses/gui-curses-main.c:399:33: error: passing argument 2 of ‘signal_catch’ from incompatible pointer type [-Wincompatible-pointer-types]
  399 |         signal_catch (SIGWINCH, &gui_main_signal_sigwinch);
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~
      |                                 |
      |                                 void (*)(void)
In file included from src/gui/curses/gui-curses-main.c:38:
src/gui/curses/../../core/core-signal.h:33:46: note: expected ‘void (*)(int)’ but argument is of type ‘void (*)(void)’
   33 | extern void signal_catch (int signum, void (*handler)(int));
      |                                       ~~~~~~~^~~~~~~~~~~~~
```