### PR TITLE
core: use <stdbool.h> instead of typedef in ncurses-fake.h

### DIFF
--- a/src/gui/curses/headless/ncurses-fake.h
+++ b/src/gui/curses/headless/ncurses-fake.h
@@ -20,6 +20,7 @@
 #ifndef WEECHAT_NCURSES_FAKE_H
 #define WEECHAT_NCURSES_FAKE_H
 
+#include <stdbool.h>
 #include <stddef.h>
 
 #define ERR (-1)
@@ -71,7 +72,6 @@ struct _window
 };
 typedef struct _window WINDOW;
 
-typedef unsigned char bool;
 typedef int attr_t;
 typedef unsigned chtype;
 


### PR DESCRIPTION
Fixes the following error when building in Fedora rawhide:
error: ‘bool’ cannot be defined via ‘typedef’.

Likely GCC 15 related.