### PR TITLE
weechat_perl_exec: Fix Syntax Error

### DIFF
--- a/src/plugins/perl/weechat-perl.c
+++ b/src/plugins/perl/weechat-perl.c
@@ -354,7 +354,7 @@ weechat_perl_exec (struct t_plugin_script *script,
     if (weechat_asprintf (
             &func,
             "%s::%s",
-            (char *) ((script->interpreter) ? script->interpreter : perl_main)
+            (char *) ((script->interpreter) ? script->interpreter : perl_main),
             function) < 0)
     {
         return NULL;


### PR DESCRIPTION
Building WeeChat 4.6.0 on OpenBSD failed with the following error.

```
/usr/ports/pobj/weechat-4.6.0/weechat-4.6.0/src/plugins/perl/weechat-perl.c:356:13: error: expected ')'
            function) < 0)
            ^
/usr/ports/pobj/weechat-4.6.0/weechat-4.6.0/src/plugins/perl/weechat-perl.c:352:9: note: to match this '('
    if (weechat_asprintf (
        ^
/usr/ports/pobj/weechat-4.6.0/weechat-4.6.0/src/plugins/perl/../weechat-plugin.h:1312:31: note: expanded from macro 'weechat_asprintf'
    (weechat_plugin->asprintf)(__result, __fmt, ##__argz)
```

On further inspection, the line in question was recently altered in 099e11d7b8bc17b94f7923d99dde005e0e1aa298, where a comma was forgotten in the else branch of the MULTIPLICITY ifdef.

After adding the comma, WeeChat builds as usual.