### PR TITLE
Fill out program information fields in COPYING

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -631,8 +631,8 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
+    WeeChat, the extendable chat client.
+    Copyright (C) 2025  https://github.com/weechat
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -652,7 +652,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    <program>  Copyright (C) <year>  <name of author>
+ WeeChat  Copyright (C) 2025  https://github.com/weechat
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.


### PR DESCRIPTION
I noticed that in the COPYING file some important fields were not filled out, like the ```<name>``` and ```<year>``` ones.