### PR TITLE
Bump required zstd to v1.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,7 +261,7 @@ find_package(ZLIB REQUIRED)
 
 # Check for zstd
 if(ENABLE_ZSTD)
-  pkg_check_modules(LIBZSTD REQUIRED libzstd)
+  pkg_check_modules(LIBZSTD REQUIRED libzstd>=1.4.0)
   add_definitions(-DHAVE_ZSTD)
 endif()
 


### PR DESCRIPTION
Bump the requirement to v1.4.0, which means we can remove all the ifdef guards.

It was released over 6 years ago, with latest release being 1.5.7.

The oldest distributions we target Ubuntu 20.04 and Debian Bullseye, have 1.4.4 and 1.4.8 respectively.