### PR TITLE
Optional username in sasl external

### DIFF
--- a/src/plugins/irc/irc-protocol.c
+++ b/src/plugins/irc/irc-protocol.c
@@ -591,7 +591,7 @@ IRC_PROTOCOL_CALLBACK(authenticate)
                 sasl_username, sasl_key, &sasl_error);
             break;
         case IRC_SASL_MECHANISM_EXTERNAL:
-            answer = strdup ("+");
+            answer = irc_sasl_mechanism_external (sasl_username) ? irc_sasl_mechanism_external (sasl_username) : strdup("+");
             break;
     }
     if (answer)

--- a/src/plugins/irc/irc-sasl.c
+++ b/src/plugins/irc/irc-sasl.c
@@ -91,6 +91,39 @@ irc_sasl_mechanism_plain (const char *sasl_username, const char *sasl_password)
     return answer_base64;
 }
 
+char *
+irc_sasl_mechanism_external (const char *sasl_username)
+{
+    char *answer_base64, *string;
+    int length;
+
+    if (!sasl_username)
+        return NULL;
+
+    if (weechat_asprintf (&string,
+                          "%s",
+                          sasl_username) < 0)
+    {
+        return NULL;
+    }
+
+    length = strlen (string);
+
+    answer_base64 = malloc ((length * 4) + 1);
+    if (answer_base64)
+    {
+        if (weechat_string_base_encode ("64", string, length, answer_base64) < 0)
+        {
+            free (answer_base64);
+            answer_base64 = NULL;
+        }
+    }
+
+    free (string);
+
+    return answer_base64;
+}
+
 /*
  * Builds answer for SASL authentication, using mechanism
  * "SCRAM-SHA-1", "SCRAM-SHA-256" or "SCRAM-SHA-512".

--- a/src/plugins/irc/irc-sasl.h
+++ b/src/plugins/irc/irc-sasl.h
@@ -45,6 +45,7 @@ extern char *irc_sasl_mechanism_string[];
 
 extern char *irc_sasl_mechanism_plain (const char *sasl_username,
                                        const char *sasl_password);
+extern char *irc_sasl_mechanism_external (const char *sasl_username);
 extern char *irc_sasl_mechanism_scram (struct t_irc_server *server,
                                        const char *hash_algo,
                                        const char *data_base64,


### PR DESCRIPTION
As per RFC 4422, an authorisation identity can optionally be provided using SASL EXTERNAL. This patch will send the configured sasl_username (if any) in a sasl external challenge.