### PR TITLE
CMAKE: Support specifying a Ruby version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,9 @@ if(COMMAND cmake_policy)
   endif()
 endif()
 
+# option RUBY_VERSION (used by ruby plugin)
+set(RUBY_VERSION "3.1" CACHE STRING "Ruby Version")
+
 add_definitions(-DHAVE_CONFIG_H)
 
 include(FindPkgConfig)

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -139,7 +139,7 @@ else()
 endif()
 
 if(ENABLE_SCRIPTS AND ENABLE_RUBY)
-  find_package(Ruby)
+  find_package(Ruby ${RUBY_VERSION} REQUIRED)
   if(RUBY_FOUND)
     add_subdirectory(ruby)
   else()


### PR DESCRIPTION
Hi, I'm a contributor at Exherbo GNU/Linux and a long time WeeChat user. In may I wrote this patch to fix weechat build in Exherbo, it basically enables you to pass RUBY_VERSION to CMake so it's explicity built against it, instead of using the system default one.
