### PR TITLE
relay: Change unix socket permisisons to 0770

### DIFF
--- a/src/plugins/relay/relay-server.c
+++ b/src/plugins/relay/relay-server.c
@@ -691,9 +691,9 @@ relay_server_create_socket (struct t_relay_server *server)
         return 0;
     }
 
-    /* change permissions: only the owner can use the unix socket */
+    /* change permissions: only the owner/group can use the unix socket */
     if (server->unix_socket)
-        chmod (server->path, 0700);
+        chmod (server->path, 0770);
 
 #ifdef SOMAXCONN
     if (listen (server->sock, SOMAXCONN) != 0)


### PR DESCRIPTION
Making the socket only accessible to the user complicates running headless weechat under a dedicated user, as it requires running nginx under the weechat user. 0770 permissions make it possible to add the nginx user to the weechat group and run both programs under separate users.