### PR TITLE
core: fix possible integer truncation in function eval_string_split

### DIFF
--- a/src/core/core-eval.c
+++ b/src/core/core-eval.c
@@ -510,8 +510,8 @@ eval_string_split (const char *text)
 {
     char *pos, *pos2, *pos3, *str_number, *separators, **items, *value;
     char str_value[32], *str_flags, **list_flags, *strip_items, **ptr_flag;
-    int num_items, count_items, random_item, flags;
-    long number, max_items;
+    int num_items, count_items, random_item, flags, max_items;
+    long number;
 
     str_number = NULL;
     separators = NULL;
@@ -582,7 +582,7 @@ eval_string_split (const char *text)
             }
             else if (strncmp (*ptr_flag, "max_items=", 10) == 0)
             {
-                if (!util_parse_long (*ptr_flag + 10, 10, &max_items)
+                if (!util_parse_int (*ptr_flag + 10, 10, &max_items)
                     || (max_items < 0))
                     goto end;
             }


### PR DESCRIPTION
Same truncation as 0c29e5a, in the sibling split function: max_items from the max_items=N flag is parsed with util_parse_long, then passed to string_split() whose num_items_max is int. A value above INT_MAX (try ${split:1,,max_items=2147483648,a,b,c}) wraps to a negative int and becomes count_items inside string_split. Parse it with util_parse_int instead.