### PR TITLE
xfer: strip directory separator from remote nick in download filename

### DIFF
--- a/src/plugins/xfer/xfer-file.c
+++ b/src/plugins/xfer/xfer-file.c
@@ -251,7 +251,7 @@ xfer_file_find_suffix (struct t_xfer *xfer)
 void
 xfer_file_find_filename (struct t_xfer *xfer)
 {
-    char *dir_separator, *path;
+    char *dir_separator, *path, *nick;
     struct t_hashtable *options;
 
     if (!XFER_IS_FILE(xfer->type))
@@ -287,12 +287,20 @@ xfer_file_find_filename (struct t_xfer *xfer)
     {
         strcat (xfer->local_filename, dir_separator);
     }
-    free (dir_separator);
     if (weechat_config_boolean (xfer_config_file_use_nick_in_filename))
     {
-        strcat (xfer->local_filename, xfer->remote_nick);
+        /*
+         * the remote nick comes from the server and can contain a directory
+         * separator: replace it so the nick cannot make the file be written
+         * outside the download directory
+         */
+        nick = (dir_separator) ?
+            weechat_string_replace (xfer->remote_nick, dir_separator, "_") : NULL;
+        strcat (xfer->local_filename, (nick) ? nick : xfer->remote_nick);
+        free (nick);
         strcat (xfer->local_filename, ".");
     }
+    free (dir_separator);
     strcat (xfer->local_filename, xfer->filename);
 
     free (path);


### PR DESCRIPTION
A received DCC file's local path is built from the remote nick when xfer.file.use_nick_in_filename is enabled (default on). The filename is reduced to a basename in xfer_add, but the nick comes straight from the IRC message prefix with no validation, so a malicious server can send a DCC SEND whose sender nick contains a directory separator and have the file written outside xfer.file.download_path.