### PR TITLE
Fix out-of-bounds read in irc_ctcp_recv_dcc quoted filename parsing

### DIFF
--- a/src/plugins/irc/irc-ctcp.c
+++ b/src/plugins/irc/irc-ctcp.c
@@ -857,7 +857,7 @@ irc_ctcp_recv_dcc (struct t_irc_protocol_ctxt *ctxt, const char *arguments)
              * double-quote
              */
             pos = strrchr (pos_file, '"');
-            if (!pos || (pos == pos_file))
+            if (!pos || (pos == pos_file) || !pos[1])
             {
                 weechat_printf (
                     ctxt->server->buffer,
@@ -1032,7 +1032,7 @@ irc_ctcp_recv_dcc (struct t_irc_protocol_ctxt *ctxt, const char *arguments)
              * double-quote
              */
             pos = strrchr (pos_file, '"');
-            if (!pos || (pos == pos_file))
+            if (!pos || (pos == pos_file) || !pos[1])
             {
                 weechat_printf (
                     ctxt->server->buffer,
@@ -1176,7 +1176,7 @@ irc_ctcp_recv_dcc (struct t_irc_protocol_ctxt *ctxt, const char *arguments)
              * double-quote
              */
             pos = strrchr (pos_file, '"');
-            if (!pos || (pos == pos_file))
+            if (!pos || (pos == pos_file) || !pos[1])
             {
                 weechat_printf (
                     ctxt->server->buffer,


### PR DESCRIPTION
Reading the DCC parser I noticed that when a quoted SEND/RESUME/ACCEPT filename ends the message, pos += 2 skips past the terminating NUL and the address scan then reads past the buffer, so reject a closing quote with nothing after it.