### PR TITLE
xfer: fix out-of-bounds read in xfer_chat_recv_cb on empty line

### DIFF
--- a/src/plugins/xfer/xfer-chat.c
+++ b/src/plugins/xfer/xfer-chat.c
@@ -162,7 +162,7 @@ xfer_chat_recv_cb (const void *pointer, void *data, int fd)
             {
                 ctcp_action = 0;
                 length = strlen (ptr_buf);
-                if (ptr_buf[length - 1] == '\r')
+                if ((length > 0) && (ptr_buf[length - 1] == '\r'))
                 {
                     ptr_buf[length - 1] = '\0';
                     length--;


### PR DESCRIPTION
Reading the DCC chat receive loop I noticed the trailing-\r strip has no length guard, unlike the same loop in relay-client.c. A peer message that yields an empty line (e.g. one beginning with "\n") makes length 0:

    xfer-chat.c:165: ptr_buf[length - 1]  ->  ptr_buf[-1]

strlen(ptr_buf) is 0 there, so it reads one byte before the receive buffer. Putting the buffer behind a guard page faults on that read. Add the (length > 0) check that relay-client.c already has.