### PR TITLE
relay: fix out-of-bounds read in relay_http_print_log_request

### DIFF
--- a/src/plugins/relay/relay-http.c
+++ b/src/plugins/relay/relay-http.c
@@ -1716,7 +1716,7 @@ relay_http_print_log_request (struct t_relay_http_request *request)
     weechat_log_printf ("    path_items. . . . . . . : %p", request->path_items);
     if (request->path_items)
     {
-        for (i = 0; request->path_items[0]; i++)
+        for (i = 0; request->path_items[i]; i++)
         {
             weechat_log_printf ("      '%s'", request->path_items[i]);
         }


### PR DESCRIPTION
Reading the relay log-dump code, this loop reads oddly next to its siblings:

    for (i = 0; request->path_items[0]; i++)
        weechat_log_printf ("      '%s'", request->path_items[i]);

path_items is the NUL-terminated array built from the request path. The condition tests element 0, never i, so it never goes false once a request has parsed at least one segment (any "GET /api/..."). i then walks past the terminator and off the end of the array, so the dump reads out-of-bounds heap as char* and logs it until it faults. Every other array-of-strings loop in the tree tests [i].

Reached from relay_client_print_log on a crash dump or /debug dump while an api client is connected. Reproduced with a 2-segment path: i runs unbounded instead of stopping at 2.

Fix tests path_items[i].