### PR TITLE
xfer: fix out-of-bounds write in xfer_dcc_resume_hash

### DIFF
--- a/src/plugins/xfer/xfer-dcc.c
+++ b/src/plugins/xfer/xfer-dcc.c
@@ -242,8 +242,8 @@ int
 xfer_dcc_resume_hash (struct t_xfer *xfer)
 {
     char *buf;
-    unsigned long long total_read;
-    ssize_t length_buf, to_read, num_read;
+    unsigned long long total_read, length_buf, to_read;
+    ssize_t num_read;
     int ret, fd;
 
     total_read = 0;


### PR DESCRIPTION
Tracking down odd behaviour resuming a DCC file transfer. The sending peer
controls the resume offset, so I pushed a large value through and watched the
receive child under a debugger.

The per-iteration read size in xfer_dcc_resume_hash sat in a signed ssize_t:

    to_read = xfer->start_resume - total_read;
    if (to_read > length_buf)
        num_read = read (fd, buf, length_buf);
    else
        num_read = read (fd, buf, to_read);

start_resume is taken verbatim from the remote "DCC ACCEPT <file> <port> <pos>"
(xfer.c:1460, never bounded). With an offset >= 2^63 the unsigned subtraction
lands negative in the ssize_t:

    to_read               = -1
    to_read > length_buf  = false      (clamp skipped)
    count to read()       = 18446744073709551615   (buffer is 1 MiB)

So the clamp is bypassed and read() gets a ~2^64 count. On Linux it copies up
to the file size into the 1 MiB buffer, past the end once the partly downloaded
file is larger than 1 MiB. Reached when CRC32 checking is on (hash_handle set)
and a receive is resumed.

Hold the size in unsigned long long so the comparison and the read count stay
in range.
