### PR TITLE
relay/api: only decompress compressed messages

### DIFF
--- a/src/plugins/relay/relay-websocket.c
+++ b/src/plugins/relay/relay-websocket.c
@@ -650,7 +650,7 @@ relay_websocket_decode_frame (const unsigned char *buffer,
     size_t size_decompressed;
     char *payload_decompressed;
     struct t_relay_websocket_frame *frames2, *ptr_frame;
-    int size, masked_frame, mask[4];
+    int size, compressed, masked_frame, mask[4];
 
     if (!buffer || !frames || !num_frames)
         return 0;
@@ -670,6 +670,10 @@ relay_websocket_decode_frame (const unsigned char *buffer,
             goto missing_data;
 
         opcode = buffer[index_buffer] & 15;
+
+	/* RSV1 of the first fragment indicates whether this message is
+	 * compressed */
+        compressed = (buffer[index_buffer] & 64) ? 1 : 0;
 
         /* check if frame is masked */
         masked_frame = (buffer[index_buffer + 1] & 128) ? 1 : 0;
@@ -777,9 +781,9 @@ relay_websocket_decode_frame (const unsigned char *buffer,
 
         /*
          * decompress data if frame is not empty and if "permessage-deflate"
-         * is enabled
+         * is enabled and the message is compressed
          */
-        if ((length_frame > 0) && ws_deflate && ws_deflate->enabled)
+        if ((length_frame > 0) && ws_deflate && ws_deflate->enabled && compressed)
         {
             if (!ws_deflate->strm_inflate)
             {


### PR DESCRIPTION
With permessage-deflate, RSV1 of the first fragment indicates whether or not the message is compressed [1]. If RSV1 is not set then the message should not be decompressed.

[1] https://datatracker.ietf.org/doc/html/rfc7692#section-6