### PR TITLE
core: fix integer overflow in eval of ${hide} and ${base_encode}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ _If you are upgrading: please see [UPGRADING.md](UPGRADING.md)._
 
 ### Security
 
+- core: fix integer overflow in size calculation when evaluating "${hide:...}" and "${base_encode:...}"
 - core: fix possible buffer overflow in command /color alias ([#2330](https://github.com/weechat/weechat/issues/2330))
 - core: fix possible buffer overflow in list of commands displayed by /help ([#2330](https://github.com/weechat/weechat/issues/2330))
 - irc: limit size of data received from the server to prevent memory exhaustion

--- a/src/core/core-eval.c
+++ b/src/core/core-eval.c
@@ -29,6 +29,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include <errno.h>
+#include <limits.h>
 #include <regex.h>
 #include <time.h>
 #include <sys/time.h>
@@ -372,6 +373,11 @@ eval_string_hide (const char *text)
     {
         length_hide_char = strlen (hide_char);
         length = utf8_strlen (ptr_string + 1);
+        if ((length_hide_char > 0) && (length >= INT_MAX / length_hide_char))
+        {
+            free (hide_char);
+            return strdup ("");
+        }
         hidden_string = malloc ((length * length_hide_char) + 1);
         if (hidden_string)
         {
@@ -893,6 +899,8 @@ eval_string_base_encode (const char *text)
 
     ptr_string++;
     length = strlen (ptr_string);
+    if (length >= (INT_MAX - 9) / 4)
+        goto end;
     result = malloc ((length * 4) + 8 + 1);
     if (!result)
         goto end;

--- a/tests/unit/core/test-core-eval.cpp
+++ b/tests/unit/core/test-core-eval.cpp
@@ -633,6 +633,29 @@ TEST(CoreEval, EvalExpression)
     WEE_CHECK_EVAL("********", "${hide:*,password}");
     WEE_CHECK_EVAL("\u2603\u2603\u2603", "${hide:${esc:\u2603},abc}");
 
+    /*
+     * hidden chars: the product (hide char length * number of chars) must not
+     * overflow the size of the allocated output (would corrupt the heap)
+     */
+    {
+        int big = 65536;
+        char *expr = (char *)malloc ((big * 2) + 16);
+        char *pos = expr;
+        memcpy (pos, "${hide:", 7);
+        pos += 7;
+        memset (pos, 'x', big);
+        pos += big;
+        *pos++ = ',';
+        memset (pos, 'y', big);
+        pos += big;
+        *pos++ = '}';
+        *pos = '\0';
+        value = eval_expression (expr, pointers, extra_vars, options);
+        STRCMP_EQUAL("", value);
+        free (value);
+        free (expr);
+    }
+
     /* test cut of chars (invalid values) */
     WEE_CHECK_EVAL("", "${cut:}");
     WEE_CHECK_EVAL("", "${cut:0,}");


### PR DESCRIPTION
guard the output size in eval_string_hide and eval_string_base_encode: the character count times the hide/encode factor is computed in int and can wrap, so malloc returns a tiny buffer that the following writes overrun.