### PR TITLE
core: avoid quadratic width scans for long words

### DIFF
--- a/src/gui/curses/gui-curses-chat.c
+++ b/src/gui/curses/gui-curses-chat.c
@@ -591,6 +591,7 @@ gui_chat_display_word (struct t_gui_window *window,
 {
     char *data, *ptr_data, *end_line, saved_char;
     int chars_displayed, pos_saved_char, chars_to_display, num_displayed;
+    int chars_remaining;
 
     chars_displayed = 0;
 
@@ -613,6 +614,7 @@ gui_chat_display_word (struct t_gui_window *window,
         word_end = NULL;
 
     ptr_data = data;
+    chars_remaining = gui_chat_strlen_screen (ptr_data);
     while (ptr_data && ptr_data[0])
     {
         chars_displayed += gui_chat_display_prefix_suffix (
@@ -626,7 +628,7 @@ gui_chat_display_word (struct t_gui_window *window,
             apply_style_inactive,
             nick_offline);
 
-        chars_to_display = gui_chat_strlen_screen (ptr_data);
+        chars_to_display = chars_remaining;
 
         /* too long for current line */
         if (window->win_chat_cursor_x + chars_to_display > gui_chat_get_real_width (window))
@@ -652,6 +654,7 @@ gui_chat_display_word (struct t_gui_window *window,
                                                               apply_style_inactive,
                                                               nick_offline);
             }
+            chars_remaining -= gui_chat_strlen_screen (ptr_data);
             ptr_data[pos_saved_char] = saved_char;
             if (pos_saved_char == 0)
                 break;
@@ -678,6 +681,7 @@ gui_chat_display_word (struct t_gui_window *window,
             }
             if (!ptr_data[0])
                 break;
+            chars_remaining = 0;
             ptr_data += strlen (ptr_data);
         }
 


### PR DESCRIPTION
## Summary

- Cache the remaining display width while wrapping a long word in `gui_chat_display_word`.
- Avoid re-running `gui_chat_strlen_screen()` over the whole remaining suffix after every wrapped segment.
- Keep the existing wrap logic; only the screen-width accounting changes.

## Motivation

A Matrix report described switching to a "toxic buffer" hanging WeeChat at 100% CPU, with profiling stopped in `wcwidth`.

A headless reproduction with a single 80k-column unbroken token shows the same shape: the unpatched render spends seconds repeatedly measuring the shrinking suffix. This change makes the expensive width scan happen once for the remaining word and then subtracts the width of each emitted chunk, so wrapping long unbroken words is linear in the input size instead of repeatedly scanning the full remainder.

## Validation

- Configured and built a headless test build with unit tests enabled.
- Headless smoke for an 80k unbroken ASCII token: unpatched render was about 4.90s; patched render was about 0.05s.
- Ran the full unit test binary. It still reports one failure in this environment at `PluginApiInfo.InfolistPluginCb` (`test-plugin-api-info.cpp:1226`); the same failure reproduces on unmodified `main`, so it does not appear to be caused by this change.

Reported by @strk.
