### PR TITLE
core: avoid zero-width read marker loop

### DIFF
--- a/src/gui/curses/gui-curses-chat.c
+++ b/src/gui/curses/gui-curses-chat.c
@@ -213,6 +213,11 @@ gui_chat_display_horizontal_line (struct t_gui_window *window, int simulate)
         if (!read_marker_string || !read_marker_string[0])
             read_marker_string = default_string;
         size_on_screen = utf8_strlen_screen (read_marker_string);
+        if (size_on_screen <= 0)
+        {
+            read_marker_string = default_string;
+            size_on_screen = utf8_strlen_screen (read_marker_string);
+        }
         gui_window_set_weechat_color (GUI_WINDOW_OBJECTS(window)->win_chat,
                                       GUI_COLOR_CHAT_READ_MARKER);
         gui_chat_clrtoeol (window);


### PR DESCRIPTION
## Summary

- Fall back to the default read marker when `weechat.look.read_marker_string` has zero display width.
- Prevent `gui_chat_display_horizontal_line` from iterating with a zero-width marker while drawing the horizontal line.

## Motivation

While investigating the toxic-buffer report, I found another display path with the same "loop does not make progress" shape.

The read marker option can be non-empty while still having zero screen width, for example with zero-width Unicode characters. In that case `size_on_screen` becomes 0, and the horizontal-line drawing loop advances with `x += size_on_screen`. Falling back to the default visible marker keeps the configured empty-looking marker from making the draw loop non-progressing.

## Validation

- Configured and built a headless test build with unit tests enabled.
- Headless smoke with a zero-width read marker string exited successfully under a 5s timeout on the patched build.
- Ran the full unit test binary. It still reports one failure in this environment at `PluginApiInfo.InfolistPluginCb` (`test-plugin-api-info.cpp:1226`); the same failure reproduces on unmodified `main`, so it does not appear to be caused by this change.

Found while investigating @strk's toxic-buffer report.
