### PR TITLE
perf: Improve Weechat upgrade processing

### DIFF
--- a/src/core/core-infolist.c
+++ b/src/core/core-infolist.c
@@ -277,7 +277,7 @@ infolist_new_var_buffer (struct t_infolist_item *item,
 }
 
 /*
- * Creates a new string variable in an item, taking ownership of "value"
+ * Creates a new integer variable in an item, taking ownership of "name"
  * instead of copying it (the infolist will free it later).
  *
  * INTERNAL USE ONLY, see comment in core-infolist.h.
@@ -286,8 +286,8 @@ infolist_new_var_buffer (struct t_infolist_item *item,
  */
 
 struct t_infolist_var *
-infolist_new_var_string_take_ownership (struct t_infolist_item *item,
-                                        const char *name, char *value)
+infolist_new_var_integer_take_name_ownership (struct t_infolist_item *item,
+                                              char *name, int value)
 {
     struct t_infolist_var *new_var;
 
@@ -297,7 +297,41 @@ infolist_new_var_string_take_ownership (struct t_infolist_item *item,
     new_var = malloc (sizeof (*new_var));
     if (new_var)
     {
-        new_var->name = strdup (name);
+        new_var->name = name;
+        new_var->type = INFOLIST_INTEGER;
+        new_var->value = malloc (sizeof (int));
+        if (new_var->value)
+            *((int *)new_var->value) = value;
+        new_var->size = 0;  /* not used for an integer */
+
+        infolist_var_link (item, new_var);
+    }
+
+    return new_var;
+}
+
+/*
+ * Creates a new string variable in an item, taking ownership of "name" and
+ * "value" instead of copying them (the infolist will free them later).
+ *
+ * INTERNAL USE ONLY, see comment in core-infolist.h.
+ *
+ * Returns pointer to new variable, NULL if error.
+ */
+
+struct t_infolist_var *
+infolist_new_var_string_take_ownership (struct t_infolist_item *item,
+                                        char *name, char *value)
+{
+    struct t_infolist_var *new_var;
+
+    if (!item || !name || !name[0])
+        return NULL;
+
+    new_var = malloc (sizeof (*new_var));
+    if (new_var)
+    {
+        new_var->name = name;
         new_var->type = INFOLIST_STRING;
         new_var->value = value;
         new_var->size = 0;  /* not used for a string */
@@ -309,8 +343,8 @@ infolist_new_var_string_take_ownership (struct t_infolist_item *item,
 }
 
 /*
- * Creates a new buffer variable in an item, taking ownership of "pointer"
- * instead of copying it (the infolist will free it later).
+ * Creates a new buffer variable in an item, taking ownership of "name" and
+ * "pointer" instead of copying them (the infolist will free them later).
  *
  * INTERNAL USE ONLY, see comment in core-infolist.h.
  *
@@ -319,7 +353,7 @@ infolist_new_var_string_take_ownership (struct t_infolist_item *item,
 
 struct t_infolist_var *
 infolist_new_var_buffer_take_ownership (struct t_infolist_item *item,
-                                        const char *name, void *pointer,
+                                        char *name, void *pointer,
                                         int size)
 {
     struct t_infolist_var *new_var;
@@ -330,10 +364,44 @@ infolist_new_var_buffer_take_ownership (struct t_infolist_item *item,
     new_var = malloc (sizeof (*new_var));
     if (new_var)
     {
-        new_var->name = strdup (name);
+        new_var->name = name;
         new_var->type = INFOLIST_BUFFER;
         new_var->value = pointer;
         new_var->size = size;
+
+        infolist_var_link (item, new_var);
+    }
+
+    return new_var;
+}
+
+/*
+ * Creates a new time variable in an item, taking ownership of "name"
+ * instead of copying it (the infolist will free it later).
+ *
+ * INTERNAL USE ONLY, see comment in core-infolist.h.
+ *
+ * Returns pointer to new variable, NULL if error.
+ */
+
+struct t_infolist_var *
+infolist_new_var_time_take_name_ownership (struct t_infolist_item *item,
+                                           char *name, time_t time)
+{
+    struct t_infolist_var *new_var;
+
+    if (!item || !name || !name[0])
+        return NULL;
+
+    new_var = malloc (sizeof (*new_var));
+    if (new_var)
+    {
+        new_var->name = name;
+        new_var->type = INFOLIST_TIME;
+        new_var->value = malloc (sizeof (time_t));
+        if (new_var->value)
+            *((time_t *)new_var->value) = time;
+        new_var->size = 0;  /* not used for a time */
 
         infolist_var_link (item, new_var);
     }

--- a/src/core/core-infolist.c
+++ b/src/core/core-infolist.c
@@ -131,6 +131,22 @@ infolist_new_item (struct t_infolist *infolist)
 }
 
 /*
+ * Adds a variable at the end of the variables list of an item.
+ */
+
+static void
+infolist_var_link (struct t_infolist_item *item, struct t_infolist_var *new_var)
+{
+    new_var->prev_var = item->last_var;
+    new_var->next_var = NULL;
+    if (item->last_var)
+        item->last_var->next_var = new_var;
+    else
+        item->vars = new_var;
+    item->last_var = new_var;
+}
+
+/*
  * Create a new integer variable in an item.
  *
  * Return pointer to new variable, NULL if error.
@@ -155,13 +171,7 @@ infolist_new_var_integer (struct t_infolist_item *item,
             *((int *)new_var->value) = value;
         new_var->size = 0;  /* not used for an integer */
 
-        new_var->prev_var = item->last_var;
-        new_var->next_var = NULL;
-        if (item->last_var)
-            item->last_var->next_var = new_var;
-        else
-            item->vars = new_var;
-        item->last_var = new_var;
+        infolist_var_link (item, new_var);
     }
 
     return new_var;
@@ -190,13 +200,7 @@ infolist_new_var_string (struct t_infolist_item *item,
         new_var->value = (value) ? strdup (value) : NULL;
         new_var->size = 0;  /* not used for a string */
 
-        new_var->prev_var = item->last_var;
-        new_var->next_var = NULL;
-        if (item->last_var)
-            item->last_var->next_var = new_var;
-        else
-            item->vars = new_var;
-        item->last_var = new_var;
+        infolist_var_link (item, new_var);
     }
 
     return new_var;
@@ -225,13 +229,7 @@ infolist_new_var_pointer (struct t_infolist_item *item,
         new_var->value = pointer;
         new_var->size = 0;  /* not used for a pointer */
 
-        new_var->prev_var = item->last_var;
-        new_var->next_var = NULL;
-        if (item->last_var)
-            item->last_var->next_var = new_var;
-        else
-            item->vars = new_var;
-        item->last_var = new_var;
+        infolist_var_link (item, new_var);
     }
 
     return new_var;
@@ -272,13 +270,7 @@ infolist_new_var_buffer (struct t_infolist_item *item,
         }
         new_var->size = size;
 
-        new_var->prev_var = item->last_var;
-        new_var->next_var = NULL;
-        if (item->last_var)
-            item->last_var->next_var = new_var;
-        else
-            item->vars = new_var;
-        item->last_var = new_var;
+        infolist_var_link (item, new_var);
     }
 
     return new_var;
@@ -309,13 +301,7 @@ infolist_new_var_time (struct t_infolist_item *item,
             *((time_t *)new_var->value) = time;
         new_var->size = 0;  /* not used for a time */
 
-        new_var->prev_var = item->last_var;
-        new_var->next_var = NULL;
-        if (item->last_var)
-            item->last_var->next_var = new_var;
-        else
-            item->vars = new_var;
-        item->last_var = new_var;
+        infolist_var_link (item, new_var);
     }
 
     return new_var;

--- a/src/core/core-infolist.c
+++ b/src/core/core-infolist.c
@@ -277,6 +277,71 @@ infolist_new_var_buffer (struct t_infolist_item *item,
 }
 
 /*
+ * Creates a new string variable in an item, taking ownership of "value"
+ * instead of copying it (the infolist will free it later).
+ *
+ * INTERNAL USE ONLY, see comment in core-infolist.h.
+ *
+ * Returns pointer to new variable, NULL if error.
+ */
+
+struct t_infolist_var *
+infolist_new_var_string_take_ownership (struct t_infolist_item *item,
+                                        const char *name, char *value)
+{
+    struct t_infolist_var *new_var;
+
+    if (!item || !name || !name[0])
+        return NULL;
+
+    new_var = malloc (sizeof (*new_var));
+    if (new_var)
+    {
+        new_var->name = strdup (name);
+        new_var->type = INFOLIST_STRING;
+        new_var->value = value;
+        new_var->size = 0;  /* not used for a string */
+
+        infolist_var_link (item, new_var);
+    }
+
+    return new_var;
+}
+
+/*
+ * Creates a new buffer variable in an item, taking ownership of "pointer"
+ * instead of copying it (the infolist will free it later).
+ *
+ * INTERNAL USE ONLY, see comment in core-infolist.h.
+ *
+ * Returns pointer to new variable, NULL if error.
+ */
+
+struct t_infolist_var *
+infolist_new_var_buffer_take_ownership (struct t_infolist_item *item,
+                                        const char *name, void *pointer,
+                                        int size)
+{
+    struct t_infolist_var *new_var;
+
+    if (!item || !name || !name[0] || (size <= 0))
+        return NULL;
+
+    new_var = malloc (sizeof (*new_var));
+    if (new_var)
+    {
+        new_var->name = strdup (name);
+        new_var->type = INFOLIST_BUFFER;
+        new_var->value = pointer;
+        new_var->size = size;
+
+        infolist_var_link (item, new_var);
+    }
+
+    return new_var;
+}
+
+/*
  * Create a new time variable in an item.
  *
  * Return pointer to new variable, NULL if error.

--- a/src/core/core-infolist.h
+++ b/src/core/core-infolist.h
@@ -92,6 +92,22 @@ extern struct t_infolist_var *infolist_new_var_buffer (struct t_infolist_item *i
                                                        const char *name,
                                                        void *pointer,
                                                        int size);
+/*
+ * INTERNAL USE ONLY (core-upgrade-file.c): unlike infolist_new_var_string()/
+ * infolist_new_var_buffer() above, these two do NOT copy "value"/"pointer";
+ * the infolist takes ownership of the pointer (it will be freed by
+ * infolist_var_free()) and the caller must not use or free it afterwards.
+ * Do not expose these via struct t_weechat_plugin / weechat-plugin.h: the
+ * plugin API contract is that infolist_new_var_string/_buffer copy the
+ * value, and callers rely on that.
+ */
+extern struct t_infolist_var *infolist_new_var_string_take_ownership (struct t_infolist_item *item,
+                                                                      const char *name,
+                                                                      char *value);
+extern struct t_infolist_var *infolist_new_var_buffer_take_ownership (struct t_infolist_item *item,
+                                                                      const char *name,
+                                                                      void *pointer,
+                                                                      int size);
 extern struct t_infolist_var *infolist_new_var_time (struct t_infolist_item *item,
                                                      const char *name,
                                                      time_t time);

--- a/src/core/core-infolist.h
+++ b/src/core/core-infolist.h
@@ -94,20 +94,28 @@ extern struct t_infolist_var *infolist_new_var_buffer (struct t_infolist_item *i
                                                        int size);
 /*
  * INTERNAL USE ONLY (core-upgrade-file.c): unlike infolist_new_var_string()/
- * infolist_new_var_buffer() above, these two do NOT copy "value"/"pointer";
- * the infolist takes ownership of the pointer (it will be freed by
- * infolist_var_free()) and the caller must not use or free it afterwards.
+ * infolist_new_var_buffer()/infolist_new_var_integer()/infolist_new_var_time()
+ * above, these four do NOT copy "name" (and, for the string/buffer variants,
+ * "value"/"pointer" either); the infolist takes ownership of the pointer(s)
+ * (they will be freed by infolist_var_free()) and the caller must not use or
+ * free them afterwards.
  * Do not expose these via struct t_weechat_plugin / weechat-plugin.h: the
- * plugin API contract is that infolist_new_var_string/_buffer copy the
- * value, and callers rely on that.
+ * plugin API contract is that infolist_new_var_* copy the name/value, and
+ * callers rely on that.
  */
+extern struct t_infolist_var *infolist_new_var_integer_take_name_ownership (struct t_infolist_item *item,
+                                                                            char *name,
+                                                                            int value);
 extern struct t_infolist_var *infolist_new_var_string_take_ownership (struct t_infolist_item *item,
-                                                                      const char *name,
+                                                                      char *name,
                                                                       char *value);
 extern struct t_infolist_var *infolist_new_var_buffer_take_ownership (struct t_infolist_item *item,
-                                                                      const char *name,
+                                                                      char *name,
                                                                       void *pointer,
                                                                       int size);
+extern struct t_infolist_var *infolist_new_var_time_take_name_ownership (struct t_infolist_item *item,
+                                                                         char *name,
+                                                                         time_t time);
 extern struct t_infolist_var *infolist_new_var_time (struct t_infolist_item *item,
                                                      const char *name,
                                                      time_t time);

--- a/src/core/core-upgrade-file.c
+++ b/src/core/core-upgrade-file.c
@@ -247,6 +247,7 @@ upgrade_file_new (const char *filename,
         }
 
         /* init positions */
+        new_upgrade_file->read_offset = 0;
         new_upgrade_file->last_read_pos = 0;
         new_upgrade_file->last_read_length = 0;
 
@@ -433,7 +434,7 @@ upgrade_file_write_object (struct t_upgrade_file *upgrade_file, int object_id,
 int
 upgrade_file_read_integer (struct t_upgrade_file *upgrade_file, int *value)
 {
-    upgrade_file->last_read_pos = ftell (upgrade_file->file);
+    upgrade_file->last_read_pos = upgrade_file->read_offset;
     upgrade_file->last_read_length = sizeof (*value);
 
     if (value)
@@ -446,6 +447,7 @@ upgrade_file_read_integer (struct t_upgrade_file *upgrade_file, int *value)
         if (fseek (upgrade_file->file, sizeof (*value), SEEK_CUR) < 0)
             return 0;
     }
+    upgrade_file->read_offset += sizeof (*value);
     return 1;
 }
 
@@ -471,7 +473,7 @@ upgrade_file_read_string (struct t_upgrade_file *upgrade_file, char **string)
     if (!upgrade_file_read_integer (upgrade_file, &length))
         return 0;
 
-    upgrade_file->last_read_pos = ftell (upgrade_file->file);
+    upgrade_file->last_read_pos = upgrade_file->read_offset;
     upgrade_file->last_read_length = length;
 
     if (string)
@@ -496,6 +498,7 @@ upgrade_file_read_string (struct t_upgrade_file *upgrade_file, char **string)
         if (fseek (upgrade_file->file, length, SEEK_CUR) < 0)
             return 0;
     }
+    upgrade_file->read_offset += length;
     return 1;
 }
 
@@ -525,7 +528,7 @@ upgrade_file_read_buffer (struct t_upgrade_file *upgrade_file,
 
     if (*size > 0)
     {
-        upgrade_file->last_read_pos = ftell (upgrade_file->file);
+        upgrade_file->last_read_pos = upgrade_file->read_offset;
         upgrade_file->last_read_length = *size;
 
         *buffer = malloc (*size);
@@ -540,6 +543,7 @@ upgrade_file_read_buffer (struct t_upgrade_file *upgrade_file,
             if (fseek (upgrade_file->file, *size, SEEK_CUR) < 0)
                 return 0;
         }
+        upgrade_file->read_offset += *size;
     }
 
     return 1;
@@ -556,7 +560,7 @@ upgrade_file_read_buffer (struct t_upgrade_file *upgrade_file,
 int
 upgrade_file_read_time (struct t_upgrade_file *upgrade_file, time_t *time)
 {
-    upgrade_file->last_read_pos = ftell (upgrade_file->file);
+    upgrade_file->last_read_pos = upgrade_file->read_offset;
     upgrade_file->last_read_length = sizeof (*time);
 
     if (time)
@@ -570,6 +574,7 @@ upgrade_file_read_time (struct t_upgrade_file *upgrade_file, time_t *time)
             return 0;
     }
 
+    upgrade_file->read_offset += sizeof (*time);
     return 1;
 }
 

--- a/src/core/core-upgrade-file.c
+++ b/src/core/core-upgrade-file.c
@@ -661,6 +661,21 @@ upgrade_file_read_object (struct t_upgrade_file *upgrade_file)
                 goto end;
             }
 
+            /*
+             * for every variable type below, "name" (and, for string/buffer,
+             * the value too) is transferred to the infolist via a
+             * "take ownership" constructor instead of being copied again:
+             * "name" was just freshly allocated by upgrade_file_read_string()
+             * above and is not used afterwards, so re-strdup'ing it inside
+             * the infolist would be a wasted allocation+copy on every single
+             * field of every restored object; on success, the local pointer
+             * is reset so the cleanup below and the next loop iteration
+             * don't free memory now owned by the infolist; on failure (e.g.
+             * empty variable name), free it here instead of leaving it for
+             * the cleanup below, since the next loop iteration would
+             * otherwise overwrite it (via upgrade_file_read_string) before
+             * it is ever freed
+             */
             switch (type_var)
             {
                 case INFOLIST_INTEGER:
@@ -669,7 +684,14 @@ upgrade_file_read_object (struct t_upgrade_file *upgrade_file)
                         UPGRADE_ERROR(_("read - variable"), "integer");
                         goto end;
                     }
-                    infolist_new_var_integer (item, name, value);
+                    if (infolist_new_var_integer_take_name_ownership (
+                            item, name, value))
+                        name = NULL;
+                    else
+                    {
+                        free (name);
+                        name = NULL;
+                    }
                     break;
                 case INFOLIST_STRING:
                     if (!upgrade_file_read_string (upgrade_file, &value_str))
@@ -677,23 +699,16 @@ upgrade_file_read_object (struct t_upgrade_file *upgrade_file)
                         UPGRADE_ERROR(_("read - variable"), "string");
                         goto end;
                     }
-                    /*
-                     * transfer ownership of value_str to the infolist var
-                     * instead of copying it again (values can be large,
-                     * e.g. pasted multi-line text); on success, reset the
-                     * local pointer so the cleanup below and the next loop
-                     * iteration don't free memory now owned by the
-                     * infolist; on failure (e.g. empty variable name),
-                     * free it here instead of leaving it for the cleanup
-                     * below, since the next loop iteration would otherwise
-                     * overwrite value_str (via upgrade_file_read_string)
-                     * before it is ever freed
-                     */
                     if (infolist_new_var_string_take_ownership (item, name,
                                                                 value_str))
+                    {
+                        name = NULL;
                         value_str = NULL;
+                    }
                     else
                     {
+                        free (name);
+                        name = NULL;
                         free (value_str);
                         value_str = NULL;
                     }
@@ -706,12 +721,16 @@ upgrade_file_read_object (struct t_upgrade_file *upgrade_file)
                         UPGRADE_ERROR(_("read - variable"), "buffer");
                         goto end;
                     }
-                    /* transfer ownership, see comment above for strings */
                     if (infolist_new_var_buffer_take_ownership (item, name,
                                                                 buffer, size))
+                    {
+                        name = NULL;
                         buffer = NULL;
+                    }
                     else
                     {
+                        free (name);
+                        name = NULL;
                         free (buffer);
                         buffer = NULL;
                     }
@@ -722,7 +741,14 @@ upgrade_file_read_object (struct t_upgrade_file *upgrade_file)
                         UPGRADE_ERROR(_("read - variable"), "time");
                         goto end;
                     }
-                    infolist_new_var_time (item, name, time);
+                    if (infolist_new_var_time_take_name_ownership (
+                            item, name, time))
+                        name = NULL;
+                    else
+                    {
+                        free (name);
+                        name = NULL;
+                    }
                     break;
             }
         }

--- a/src/core/core-upgrade-file.c
+++ b/src/core/core-upgrade-file.c
@@ -228,6 +228,15 @@ upgrade_file_new (const char *filename,
             return NULL;
         }
 
+        /*
+         * use a bigger stdio buffer than the default: upgrade files are
+         * read/written as a huge number of small (per-field) fread/fwrite
+         * calls, so a small buffer means many more underlying syscalls
+         * than necessary; failure to set it is not fatal, default
+         * buffering is still correct, just slower
+         */
+        setvbuf (new_upgrade_file->file, NULL, _IOFBF, UPGRADE_FILE_BUFFER_SIZE);
+
         /* change permissions if write mode */
         if (!callback_read)
         {

--- a/src/core/core-upgrade-file.c
+++ b/src/core/core-upgrade-file.c
@@ -677,7 +677,26 @@ upgrade_file_read_object (struct t_upgrade_file *upgrade_file)
                         UPGRADE_ERROR(_("read - variable"), "string");
                         goto end;
                     }
-                    infolist_new_var_string (item, name, value_str);
+                    /*
+                     * transfer ownership of value_str to the infolist var
+                     * instead of copying it again (values can be large,
+                     * e.g. pasted multi-line text); on success, reset the
+                     * local pointer so the cleanup below and the next loop
+                     * iteration don't free memory now owned by the
+                     * infolist; on failure (e.g. empty variable name),
+                     * free it here instead of leaving it for the cleanup
+                     * below, since the next loop iteration would otherwise
+                     * overwrite value_str (via upgrade_file_read_string)
+                     * before it is ever freed
+                     */
+                    if (infolist_new_var_string_take_ownership (item, name,
+                                                                value_str))
+                        value_str = NULL;
+                    else
+                    {
+                        free (value_str);
+                        value_str = NULL;
+                    }
                     break;
                 case INFOLIST_POINTER:
                     break;
@@ -687,7 +706,15 @@ upgrade_file_read_object (struct t_upgrade_file *upgrade_file)
                         UPGRADE_ERROR(_("read - variable"), "buffer");
                         goto end;
                     }
-                    infolist_new_var_buffer (item, name, buffer, size);
+                    /* transfer ownership, see comment above for strings */
+                    if (infolist_new_var_buffer_take_ownership (item, name,
+                                                                buffer, size))
+                        buffer = NULL;
+                    else
+                    {
+                        free (buffer);
+                        buffer = NULL;
+                    }
                     break;
                 case INFOLIST_TIME:
                     if (!upgrade_file_read_time (upgrade_file, &time))

--- a/src/core/core-upgrade-file.h
+++ b/src/core/core-upgrade-file.h
@@ -47,6 +47,9 @@ struct t_upgrade_file
 {
     char *filename;                        /* filename with path            */
     FILE *file;                            /* file pointer                  */
+    long read_offset;                      /* current read offset in file,  */
+                                            /* tracked manually to avoid an  */
+                                            /* ftell() call on every field   */
     long last_read_pos;                    /* last read position            */
     int last_read_length;                  /* last read length              */
     int (*callback_read)                   /* callback called when reading  */

--- a/src/core/core-upgrade-file.h
+++ b/src/core/core-upgrade-file.h
@@ -26,6 +26,11 @@
 
 #define UPGRADE_SIGNATURE "===== WeeChat Upgrade file v2.2 - binary, do not edit! ====="
 
+/* stdio buffer size used for upgrade files (much bigger than the libc
+ * default, since upgrade files are read/written as many small per-field
+ * fread/fwrite calls) */
+#define UPGRADE_FILE_BUFFER_SIZE (256 * 1024)
+
 #define UPGRADE_ERROR(msg1, msg2)                                       \
     upgrade_file_error(upgrade_file, msg1, msg2, __FILE__, __LINE__)
 

--- a/src/core/core-upgrade.c
+++ b/src/core/core-upgrade.c
@@ -666,7 +666,9 @@ upgrade_weechat_read_buffer_line (struct t_infolist *infolist)
              * saved value right below anyway, so computing it would be
              * wasted work (and, before this fix, left str_time colorized
              * for the wrong highlight state, since it was never
-             * recomputed after the overwrite)
+             * recomputed after the overwrite); for the same reason, pass
+             * the saved time string directly (known_str_time) instead of
+             * letting gui_line_new() recompute/recolorize it
              */
             new_line = gui_line_new (
                 upgrade_current_buffer,
@@ -678,7 +680,8 @@ upgrade_weechat_read_buffer_line (struct t_infolist *infolist)
                 infolist_string (infolist, "tags"),
                 infolist_string (infolist, "prefix"),
                 infolist_string (infolist, "message"),
-                infolist_integer (infolist, "highlight"));
+                infolist_integer (infolist, "highlight"),
+                infolist_string (infolist, "str_time"));
             if (new_line)
             {
                 new_line->data->id = infolist_integer (infolist, "id");
@@ -698,7 +701,7 @@ upgrade_weechat_read_buffer_line (struct t_infolist *infolist)
                 infolist_string (infolist, "tags"),
                 NULL,
                 infolist_string (infolist, "message"),
-                -1);
+                -1, NULL);
             if (new_line)
             {
                 new_line->data->id = infolist_integer (infolist, "id");

--- a/src/core/core-upgrade.c
+++ b/src/core/core-upgrade.c
@@ -659,6 +659,15 @@ upgrade_weechat_read_buffer_line (struct t_infolist *infolist)
     switch (upgrade_current_buffer->type)
     {
         case GUI_BUFFER_TYPE_FORMATTED:
+            /*
+             * pass the saved highlight state directly (known_highlight)
+             * instead of letting gui_line_new() run its regex-based
+             * highlight detection: the result would be overwritten by the
+             * saved value right below anyway, so computing it would be
+             * wasted work (and, before this fix, left str_time colorized
+             * for the wrong highlight state, since it was never
+             * recomputed after the overwrite)
+             */
             new_line = gui_line_new (
                 upgrade_current_buffer,
                 -1,
@@ -668,13 +677,12 @@ upgrade_weechat_read_buffer_line (struct t_infolist *infolist)
                 infolist_integer (infolist, "date_usec_printed"),
                 infolist_string (infolist, "tags"),
                 infolist_string (infolist, "prefix"),
-                infolist_string (infolist, "message"));
+                infolist_string (infolist, "message"),
+                infolist_integer (infolist, "highlight"));
             if (new_line)
             {
                 new_line->data->id = infolist_integer (infolist, "id");
                 gui_line_add (new_line);
-                new_line->data->highlight = infolist_integer (infolist,
-                                                              "highlight");
                 if (infolist_integer (infolist, "last_read_line"))
                     upgrade_current_buffer->lines->last_read_line = new_line;
             }
@@ -689,7 +697,8 @@ upgrade_weechat_read_buffer_line (struct t_infolist *infolist)
                 infolist_integer (infolist, "date_usec_printed"),
                 infolist_string (infolist, "tags"),
                 NULL,
-                infolist_string (infolist, "message"));
+                infolist_string (infolist, "message"),
+                -1);
             if (new_line)
             {
                 new_line->data->id = infolist_integer (infolist, "id");

--- a/src/core/core-upgrade.c
+++ b/src/core/core-upgrade.c
@@ -682,7 +682,7 @@ upgrade_weechat_read_buffer_line (struct t_infolist *infolist)
             if (new_line)
             {
                 new_line->data->id = infolist_integer (infolist, "id");
-                gui_line_add (new_line);
+                gui_line_add (new_line, 1);
                 if (infolist_integer (infolist, "last_read_line"))
                     upgrade_current_buffer->lines->last_read_line = new_line;
             }

--- a/src/gui/gui-chat.c
+++ b/src/gui/gui-chat.c
@@ -952,7 +952,8 @@ gui_chat_printf_datetime_tags_internal (struct t_gui_buffer *buffer,
                              date_usec_printed,
                              tags,
                              pos_prefix,
-                             ptr_msg);
+                             ptr_msg,
+                             -1);
     if (!new_line)
         goto no_print;
 
@@ -1300,7 +1301,8 @@ gui_chat_printf_y_datetime_tags (struct t_gui_buffer *buffer, int y,
                              tv_date_printed.tv_usec,
                              tags,
                              NULL,
-                             vbuffer);
+                             vbuffer,
+                             -1);
     if (!new_line)
         goto end;
 
@@ -1338,7 +1340,7 @@ gui_chat_printf_y_datetime_tags (struct t_gui_buffer *buffer, int y,
                 {
                     new_line_empty = gui_line_new (new_line->data->buffer,
                                                    i, 0, 0, 0, 0, NULL, NULL,
-                                                   "");
+                                                   "", -1);
                     if (new_line_empty)
                         gui_line_add_y (new_line_empty);
                 }

--- a/src/gui/gui-chat.c
+++ b/src/gui/gui-chat.c
@@ -953,7 +953,7 @@ gui_chat_printf_datetime_tags_internal (struct t_gui_buffer *buffer,
                              tags,
                              pos_prefix,
                              ptr_msg,
-                             -1);
+                             -1, NULL);
     if (!new_line)
         goto no_print;
 
@@ -1302,7 +1302,7 @@ gui_chat_printf_y_datetime_tags (struct t_gui_buffer *buffer, int y,
                              tags,
                              NULL,
                              vbuffer,
-                             -1);
+                             -1, NULL);
     if (!new_line)
         goto end;
 
@@ -1340,7 +1340,7 @@ gui_chat_printf_y_datetime_tags (struct t_gui_buffer *buffer, int y,
                 {
                     new_line_empty = gui_line_new (new_line->data->buffer,
                                                    i, 0, 0, 0, 0, NULL, NULL,
-                                                   "", -1);
+                                                   "", -1, NULL);
                     if (new_line_empty)
                         gui_line_add_y (new_line_empty);
                 }

--- a/src/gui/gui-chat.c
+++ b/src/gui/gui-chat.c
@@ -1079,7 +1079,7 @@ gui_chat_printf_datetime_tags_internal (struct t_gui_buffer *buffer,
     }
 
     /* add line in the buffer */
-    gui_line_add (new_line);
+    gui_line_add (new_line, 0);
 
     /* run hook_print for the new line */
     if (new_line->data->buffer && new_line->data->buffer->print_hooks_enabled)

--- a/src/gui/gui-line.c
+++ b/src/gui/gui-line.c
@@ -1571,7 +1571,13 @@ gui_line_set_highlight (struct t_gui_line *line, int max_notify_level)
 }
 
 /*
- * Create a new line for a buffer.
+ * Creates a new line for a buffer.
+ *
+ * "known_highlight" is -1 if the highlight state of the line is not known
+ * yet and must be computed (the normal case), or 0/1 if the caller already
+ * knows the highlight state (e.g. when restoring a line from an upgrade
+ * file, where the value was saved) and the regex-based detection in
+ * gui_line_set_highlight() must be skipped.
  */
 
 struct t_gui_line *
@@ -1579,7 +1585,8 @@ gui_line_new (struct t_gui_buffer *buffer, int y,
               time_t date, int date_usec,
               time_t date_printed, int date_usec_printed,
               const char *tags,
-              const char *prefix, const char *message)
+              const char *prefix, const char *message,
+              int known_highlight)
 {
     struct t_gui_line *new_line;
     struct t_gui_line_data *new_line_data;
@@ -1631,7 +1638,10 @@ gui_line_new (struct t_gui_buffer *buffer, int y,
             gui_chat_strlen_screen (prefix) : 0;
         max_notify_level = gui_line_get_max_notify_level (new_line);
         gui_line_set_notify_level (new_line, max_notify_level);
-        gui_line_set_highlight (new_line, max_notify_level);
+        if (known_highlight >= 0)
+            new_line->data->highlight = known_highlight;
+        else
+            gui_line_set_highlight (new_line, max_notify_level);
         if (new_line->data->highlight && (new_line->data->notify_level >= 0))
             new_line->data->notify_level = GUI_HOTLIST_HIGHLIGHT;
         new_line->data->str_time = gui_chat_get_time_string (

--- a/src/gui/gui-line.c
+++ b/src/gui/gui-line.c
@@ -2048,12 +2048,27 @@ gui_line_add_y (struct t_gui_line *line)
     struct t_gui_window *ptr_win;
     int old_line_displayed;
 
-    /* search if line exists for "y" */
-    for (ptr_line = line->data->buffer->own_lines->first_line; ptr_line;
-         ptr_line = ptr_line->next_line)
+    /*
+     * search if line exists for "y": fast path for the common append case
+     * (lines added in increasing "y" order, e.g. when restoring a buffer
+     * from an upgrade file) to avoid an O(n) scan from the first line on
+     * every call; since the list is ordered by "y", if the last line's "y"
+     * is already lower than the new one, no earlier line can match either,
+     * so the scan below would have reached the end (ptr_line = NULL) anyway
+     */
+    if (line->data->buffer->own_lines->last_line
+        && (line->data->buffer->own_lines->last_line->data->y < line->data->y))
     {
-        if (ptr_line->data->y >= line->data->y)
-            break;
+        ptr_line = NULL;
+    }
+    else
+    {
+        for (ptr_line = line->data->buffer->own_lines->first_line; ptr_line;
+             ptr_line = ptr_line->next_line)
+        {
+            if (ptr_line->data->y >= line->data->y)
+                break;
+        }
     }
 
     if (ptr_line && (ptr_line->data->y == line->data->y))

--- a/src/gui/gui-line.c
+++ b/src/gui/gui-line.c
@@ -1578,6 +1578,11 @@ gui_line_set_highlight (struct t_gui_line *line, int max_notify_level)
  * knows the highlight state (e.g. when restoring a line from an upgrade
  * file, where the value was saved) and the regex-based detection in
  * gui_line_set_highlight() must be skipped.
+ *
+ * "known_str_time" is NULL if the time string is not known yet and must be
+ * computed (the normal case), or a previously computed string (e.g. when
+ * restoring a line from an upgrade file, where the value was saved) so that
+ * gui_chat_get_time_string() does not have to recompute/recolorize it.
  */
 
 struct t_gui_line *
@@ -1586,7 +1591,7 @@ gui_line_new (struct t_gui_buffer *buffer, int y,
               time_t date_printed, int date_usec_printed,
               const char *tags,
               const char *prefix, const char *message,
-              int known_highlight)
+              int known_highlight, const char *known_str_time)
 {
     struct t_gui_line *new_line;
     struct t_gui_line_data *new_line_data;
@@ -1644,8 +1649,10 @@ gui_line_new (struct t_gui_buffer *buffer, int y,
             gui_line_set_highlight (new_line, max_notify_level);
         if (new_line->data->highlight && (new_line->data->notify_level >= 0))
             new_line->data->notify_level = GUI_HOTLIST_HIGHLIGHT;
-        new_line->data->str_time = gui_chat_get_time_string (
-            date, date_usec, new_line->data->highlight);
+        new_line->data->str_time = (known_str_time) ?
+            strdup (known_str_time) :
+            gui_chat_get_time_string (date, date_usec,
+                                      new_line->data->highlight);
     }
     else
     {

--- a/src/gui/gui-line.c
+++ b/src/gui/gui-line.c
@@ -1891,10 +1891,14 @@ gui_line_hook_update (struct t_gui_line *line,
 
 /*
  * Add a new line in a buffer with formatted content.
+ *
+ * "from_upgrade" must be non-zero only when the line is being replayed from
+ * an upgrade file (see upgrade_weechat_read_buffer_line()), to skip hotlist
+ * recomputation for it (see comment below).
  */
 
 void
-gui_line_add (struct t_gui_line *line)
+gui_line_add (struct t_gui_line *line, int from_upgrade)
 {
     struct t_gui_window *ptr_win;
     char *message_for_signal;
@@ -1930,11 +1934,28 @@ gui_line_add (struct t_gui_line *line)
         if ((line->data->notify_level >= GUI_HOTLIST_MIN)
             && line->data->highlight)
         {
-            (void) gui_hotlist_add (
-                line->data->buffer,
-                GUI_HOTLIST_HIGHLIGHT,
-                NULL,  /* creation_time */
-                1);  /* check_conditions */
+            /*
+             * skip hotlist recomputation while replaying a line from an
+             * upgrade file: the hotlist is restored separately from its
+             * own saved state (see upgrade_weechat_read_hotlist()), which
+             * always clears the hotlist before rebuilding it, so anything
+             * added here during line replay is guaranteed to be thrown
+             * away right after - and gui_hotlist_add()'s condition check
+             * involves a real eval_expression() call, not worth doing per
+             * line; this must be scoped to the replay itself (from_upgrade)
+             * and not to the whole "weechat_upgrading" window, which stays
+             * set well after replay ends (through plugin init/reconnect),
+             * or real messages arriving in that window would silently
+             * never reach the hotlist
+             */
+            if (!from_upgrade)
+            {
+                (void) gui_hotlist_add (
+                    line->data->buffer,
+                    GUI_HOTLIST_HIGHLIGHT,
+                    NULL,  /* creation_time */
+                    1);  /* check_conditions */
+            }
             if (!weechat_upgrading)
             {
                 message_for_signal = gui_line_build_string_prefix_message (
@@ -1963,7 +1984,9 @@ gui_line_add (struct t_gui_line *line)
                     free (message_for_signal);
                 }
             }
-            if (line->data->notify_level >= GUI_HOTLIST_MIN)
+            /* see comment above about skipping this while replaying */
+            if (!from_upgrade
+                && (line->data->notify_level >= GUI_HOTLIST_MIN))
             {
                 (void) gui_hotlist_add (
                     line->data->buffer,

--- a/src/gui/gui-line.h
+++ b/src/gui/gui-line.h
@@ -137,7 +137,8 @@ extern struct t_gui_line *gui_line_new (struct t_gui_buffer *buffer,
                                         int date_usec_printed,
                                         const char *tags,
                                         const char *prefix,
-                                        const char *message);
+                                        const char *message,
+                                        int known_highlight);
 extern void gui_line_hook_update (struct t_gui_line *line,
                                   struct t_hashtable *hashtable,
                                   struct t_hashtable *hashtable2);

--- a/src/gui/gui-line.h
+++ b/src/gui/gui-line.h
@@ -138,7 +138,8 @@ extern struct t_gui_line *gui_line_new (struct t_gui_buffer *buffer,
                                         const char *tags,
                                         const char *prefix,
                                         const char *message,
-                                        int known_highlight);
+                                        int known_highlight,
+                                        const char *known_str_time);
 extern void gui_line_hook_update (struct t_gui_line *line,
                                   struct t_hashtable *hashtable,
                                   struct t_hashtable *hashtable2);

--- a/src/gui/gui-line.h
+++ b/src/gui/gui-line.h
@@ -142,7 +142,7 @@ extern struct t_gui_line *gui_line_new (struct t_gui_buffer *buffer,
 extern void gui_line_hook_update (struct t_gui_line *line,
                                   struct t_hashtable *hashtable,
                                   struct t_hashtable *hashtable2);
-extern void gui_line_add (struct t_gui_line *line);
+extern void gui_line_add (struct t_gui_line *line, int from_upgrade);
 extern void gui_line_add_y (struct t_gui_line *line);
 extern void gui_line_clear (struct t_gui_line *line);
 extern void gui_line_mix_buffers (struct t_gui_buffer *buffer);

--- a/tests/unit/gui/test-gui-chat.cpp
+++ b/tests/unit/gui/test-gui-chat.cpp
@@ -424,32 +424,32 @@ TEST(GuiChat, PipeBuildMessage)
 
     WEE_TEST_STR(NULL, gui_chat_pipe_build_message (NULL));
 
-    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, NULL, NULL, NULL);
+    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, NULL, NULL, NULL, -1);
     WEE_TEST_STR("", gui_chat_pipe_build_message (line));
     gui_line_free_data (line);
     free (line);
 
-    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, NULL, "nick", NULL);
+    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, NULL, "nick", NULL, -1);
     WEE_TEST_STR("nick", gui_chat_pipe_build_message (line));
     gui_line_free_data (line);
     free (line);
 
-    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, NULL, NULL, "the message");
+    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, NULL, NULL, "the message", -1);
     WEE_TEST_STR("the message", gui_chat_pipe_build_message (line));
     gui_line_free_data (line);
     free (line);
 
-    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, NULL, "prefix", "");
+    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, NULL, "prefix", "", -1);
     WEE_TEST_STR("prefix", gui_chat_pipe_build_message (line));
     gui_line_free_data (line);
     free (line);
 
-    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, NULL, "", "the message");
+    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, NULL, "", "the message", -1);
     WEE_TEST_STR("the message", gui_chat_pipe_build_message (line));
     gui_line_free_data (line);
     free (line);
 
-    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, NULL, "prefix", "the message");
+    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, NULL, "prefix", "the message", -1);
     WEE_TEST_STR("prefix the message", gui_chat_pipe_build_message (line));
     gui_line_free_data (line);
     free (line);

--- a/tests/unit/gui/test-gui-chat.cpp
+++ b/tests/unit/gui/test-gui-chat.cpp
@@ -424,32 +424,32 @@ TEST(GuiChat, PipeBuildMessage)
 
     WEE_TEST_STR(NULL, gui_chat_pipe_build_message (NULL));
 
-    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, NULL, NULL, NULL, -1);
+    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, NULL, NULL, NULL, -1, NULL);
     WEE_TEST_STR("", gui_chat_pipe_build_message (line));
     gui_line_free_data (line);
     free (line);
 
-    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, NULL, "nick", NULL, -1);
+    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, NULL, "nick", NULL, -1, NULL);
     WEE_TEST_STR("nick", gui_chat_pipe_build_message (line));
     gui_line_free_data (line);
     free (line);
 
-    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, NULL, NULL, "the message", -1);
+    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, NULL, NULL, "the message", -1, NULL);
     WEE_TEST_STR("the message", gui_chat_pipe_build_message (line));
     gui_line_free_data (line);
     free (line);
 
-    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, NULL, "prefix", "", -1);
+    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, NULL, "prefix", "", -1, NULL);
     WEE_TEST_STR("prefix", gui_chat_pipe_build_message (line));
     gui_line_free_data (line);
     free (line);
 
-    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, NULL, "", "the message", -1);
+    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, NULL, "", "the message", -1, NULL);
     WEE_TEST_STR("the message", gui_chat_pipe_build_message (line));
     gui_line_free_data (line);
     free (line);
 
-    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, NULL, "prefix", "the message", -1);
+    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, NULL, "prefix", "the message", -1, NULL);
     WEE_TEST_STR("prefix the message", gui_chat_pipe_build_message (line));
     gui_line_free_data (line);
     free (line);

--- a/tests/unit/gui/test-gui-line.cpp
+++ b/tests/unit/gui/test-gui-line.cpp
@@ -946,7 +946,7 @@ TEST(GuiLine, New)
     STRCMP_EQUAL("", line1->data->prefix);
     LONGS_EQUAL(0, line1->data->prefix_length);
     STRCMP_EQUAL("", line1->data->message);
-    gui_line_add (line1);
+    gui_line_add (line1, 0);
     POINTERS_EQUAL(NULL, line1->prev_line);
     POINTERS_EQUAL(NULL, line1->next_line);
 
@@ -980,7 +980,7 @@ TEST(GuiLine, New)
     STRCMP_EQUAL("prefix", line2->data->prefix);
     LONGS_EQUAL(6, line2->data->prefix_length);
     STRCMP_EQUAL("message", line2->data->message);
-    gui_line_add (line2);
+    gui_line_add (line2, 0);
     POINTERS_EQUAL(line1, line2->prev_line);
     POINTERS_EQUAL(NULL, line2->next_line);
 
@@ -1033,7 +1033,7 @@ TEST(GuiLine, New)
     STRCMP_EQUAL(NULL, line1->data->prefix);
     LONGS_EQUAL(0, line1->data->prefix_length);
     STRCMP_EQUAL("", line1->data->message);
-    gui_line_add (line1);
+    gui_line_add (line1, 0);
     POINTERS_EQUAL(NULL, line1->prev_line);
     POINTERS_EQUAL(NULL, line1->next_line);
 
@@ -1067,7 +1067,7 @@ TEST(GuiLine, New)
     STRCMP_EQUAL(NULL, line2->data->prefix);
     LONGS_EQUAL(0, line2->data->prefix_length);
     STRCMP_EQUAL("message", line2->data->message);
-    gui_line_add (line2);
+    gui_line_add (line2, 0);
     CHECK(line2->prev_line);
     POINTERS_EQUAL(NULL, line2->next_line);
 

--- a/tests/unit/gui/test-gui-line.cpp
+++ b/tests/unit/gui/test-gui-line.cpp
@@ -42,7 +42,7 @@ extern "C"
 
 #define WEE_BUILD_STR_PREFIX_MSG(__result, __prefix, __message)         \
     line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, "tag1,tag2",      \
-                         __prefix, __message, -1);                      \
+                         __prefix, __message, -1, NULL);                \
     str = gui_line_build_string_prefix_message (line->data->prefix,     \
                                                 line->data->message);   \
     STRCMP_EQUAL(__result, str);                                        \
@@ -52,7 +52,7 @@ extern "C"
 
 #define WEE_BUILD_STR_MSG_TAGS(__tags, __message, __colors)             \
     line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, __tags,           \
-                         NULL, __message, -1);                          \
+                         NULL, __message, -1, NULL);                    \
     str = gui_line_build_string_message_tags (line->data->message,      \
                                               line->data->tags_count,   \
                                               line->data->tags_array,   \
@@ -247,7 +247,7 @@ TEST(GuiLine, BuildStringMessageTags)
     struct t_gui_line *line;
     char *str, str_message[256], str_result[256];
 
-    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, "tag1,tag2", NULL, "test", -1);
+    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, "tag1,tag2", NULL, "test", -1, NULL);
     STRCMP_EQUAL(NULL,
                  gui_line_build_string_message_tags (line->data->message,
                                                      -1,
@@ -914,7 +914,7 @@ TEST(GuiLine, New)
                        NULL, 0,
                        date.tv_sec, date.tv_usec,
                        date_printed.tv_sec, date_printed.tv_usec,
-                       NULL, NULL, NULL, -1));
+                       NULL, NULL, NULL, -1, NULL));
 
     /* create a new test buffer (formatted content) */
     buffer = gui_buffer_new_user ("test", GUI_BUFFER_TYPE_FORMATTED);
@@ -924,7 +924,7 @@ TEST(GuiLine, New)
                           0,
                           date.tv_sec, date.tv_usec,
                           date_printed.tv_sec, date_printed.tv_usec,
-                          NULL, NULL, NULL, -1);
+                          NULL, NULL, NULL, -1, NULL);
     CHECK(line1);
     CHECK(line1->data);
     POINTERS_EQUAL(NULL, line1->prev_line);
@@ -955,7 +955,7 @@ TEST(GuiLine, New)
                           date.tv_sec, date.tv_usec,
                           date_printed.tv_sec, date_printed.tv_usec,
                           "tag1,tag2,tag3",
-                          "prefix", "message", -1);
+                          "prefix", "message", -1, NULL);
     CHECK(line2);
     CHECK(line2->data);
     POINTERS_EQUAL(NULL, line2->prev_line);
@@ -990,14 +990,14 @@ TEST(GuiLine, New)
                           0,
                           date.tv_sec, date.tv_usec,
                           date_printed.tv_sec, date_printed.tv_usec,
-                          NULL, NULL, "test", -1);
+                          NULL, NULL, "test", -1, NULL);
     CHECK(line3);
     LONGS_EQUAL(INT_MAX, line3->data->id);
     line4 = gui_line_new (buffer,
                           0,
                           date.tv_sec, date.tv_usec,
                           date_printed.tv_sec, date_printed.tv_usec,
-                          NULL, NULL, "test", -1);
+                          NULL, NULL, "test", -1, NULL);
     CHECK(line4);
     LONGS_EQUAL(0, line4->data->id);
 
@@ -1011,7 +1011,7 @@ TEST(GuiLine, New)
                           0,
                           date.tv_sec, date.tv_usec,
                           date_printed.tv_sec, date_printed.tv_usec,
-                          NULL, NULL, NULL, -1);
+                          NULL, NULL, NULL, -1, NULL);
     CHECK(line1);
     CHECK(line1->data);
     POINTERS_EQUAL(NULL, line1->prev_line);
@@ -1042,7 +1042,7 @@ TEST(GuiLine, New)
                           date.tv_sec, date.tv_usec,
                           date_printed.tv_sec, date_printed.tv_usec,
                           "tag1,tag2,tag3",
-                          NULL, "message", -1);
+                          NULL, "message", -1, NULL);
     CHECK(line2);
     CHECK(line2->data);
     POINTERS_EQUAL(NULL, line2->prev_line);

--- a/tests/unit/gui/test-gui-line.cpp
+++ b/tests/unit/gui/test-gui-line.cpp
@@ -42,7 +42,7 @@ extern "C"
 
 #define WEE_BUILD_STR_PREFIX_MSG(__result, __prefix, __message)         \
     line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, "tag1,tag2",      \
-                         __prefix, __message);                          \
+                         __prefix, __message, -1);                      \
     str = gui_line_build_string_prefix_message (line->data->prefix,     \
                                                 line->data->message);   \
     STRCMP_EQUAL(__result, str);                                        \
@@ -52,7 +52,7 @@ extern "C"
 
 #define WEE_BUILD_STR_MSG_TAGS(__tags, __message, __colors)             \
     line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, __tags,           \
-                         NULL, __message);                              \
+                         NULL, __message, -1);                          \
     str = gui_line_build_string_message_tags (line->data->message,      \
                                               line->data->tags_count,   \
                                               line->data->tags_array,   \
@@ -247,7 +247,7 @@ TEST(GuiLine, BuildStringMessageTags)
     struct t_gui_line *line;
     char *str, str_message[256], str_result[256];
 
-    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, "tag1,tag2", NULL, "test");
+    line = gui_line_new (gui_buffers, -1, 0, 0, 0, 0, "tag1,tag2", NULL, "test", -1);
     STRCMP_EQUAL(NULL,
                  gui_line_build_string_message_tags (line->data->message,
                                                      -1,
@@ -914,7 +914,7 @@ TEST(GuiLine, New)
                        NULL, 0,
                        date.tv_sec, date.tv_usec,
                        date_printed.tv_sec, date_printed.tv_usec,
-                       NULL, NULL, NULL));
+                       NULL, NULL, NULL, -1));
 
     /* create a new test buffer (formatted content) */
     buffer = gui_buffer_new_user ("test", GUI_BUFFER_TYPE_FORMATTED);
@@ -924,7 +924,7 @@ TEST(GuiLine, New)
                           0,
                           date.tv_sec, date.tv_usec,
                           date_printed.tv_sec, date_printed.tv_usec,
-                          NULL, NULL, NULL);
+                          NULL, NULL, NULL, -1);
     CHECK(line1);
     CHECK(line1->data);
     POINTERS_EQUAL(NULL, line1->prev_line);
@@ -955,7 +955,7 @@ TEST(GuiLine, New)
                           date.tv_sec, date.tv_usec,
                           date_printed.tv_sec, date_printed.tv_usec,
                           "tag1,tag2,tag3",
-                          "prefix", "message");
+                          "prefix", "message", -1);
     CHECK(line2);
     CHECK(line2->data);
     POINTERS_EQUAL(NULL, line2->prev_line);
@@ -990,14 +990,14 @@ TEST(GuiLine, New)
                           0,
                           date.tv_sec, date.tv_usec,
                           date_printed.tv_sec, date_printed.tv_usec,
-                          NULL, NULL, "test");
+                          NULL, NULL, "test", -1);
     CHECK(line3);
     LONGS_EQUAL(INT_MAX, line3->data->id);
     line4 = gui_line_new (buffer,
                           0,
                           date.tv_sec, date.tv_usec,
                           date_printed.tv_sec, date_printed.tv_usec,
-                          NULL, NULL, "test");
+                          NULL, NULL, "test", -1);
     CHECK(line4);
     LONGS_EQUAL(0, line4->data->id);
 
@@ -1011,7 +1011,7 @@ TEST(GuiLine, New)
                           0,
                           date.tv_sec, date.tv_usec,
                           date_printed.tv_sec, date_printed.tv_usec,
-                          NULL, NULL, NULL);
+                          NULL, NULL, NULL, -1);
     CHECK(line1);
     CHECK(line1->data);
     POINTERS_EQUAL(NULL, line1->prev_line);
@@ -1042,7 +1042,7 @@ TEST(GuiLine, New)
                           date.tv_sec, date.tv_usec,
                           date_printed.tv_sec, date_printed.tv_usec,
                           "tag1,tag2,tag3",
-                          NULL, "message");
+                          NULL, "message", -1);
     CHECK(line2);
     CHECK(line2->data);
     POINTERS_EQUAL(NULL, line2->prev_line);


### PR DESCRIPTION
## Background

After experiencing a long /upgrade save+load I started looking at the steps taken during the restore of the upgrade files and what changes could be made to speed it up.
For small buffers and scrollback it won't matter much, but the bigger the scrollback, the more that read/write pass costs. This branch goes after overhead from a few different angles.

Upgrade files were being read and written as a huge number of tiny fread/fwrite calls using the default stdio buffer size, so I bumped that up to 256 KB to cut down on the actual syscalls happening underneath. I also noticed every single field read was calling ftell() just to record a position that's only ever used if something goes wrong and an error needs to be reported, so instead of asking the OS for the current position every time, it now just keeps a running counter itself.

Then there was a memory/allocation problem: every field coming out of the upgrade file was effectively being copied twice, once when it was read off disk into a temporary buffer, and again when that buffer got handed to the infolist via strdup(). Since the first copy was just going to be thrown away, I added "take ownership" versions of the infolist constructors so the data (and its name) gets handed over directly instead of duplicated a second time.

On the GUI side restoring lines was redoing work that had already been done once and saved. gui_line_new() was recomputing the highlight state and the colorized timestamp string for every restored line, even though both of those were already sitting in the upgrade file and were about to be overwritten anyway.
I added a way to pass those in as "already known" so that recomputation gets skipped. I also found that appending lines during restore was scanning from the very start of the line list every single time to find where to insert, which is fine for one line but turns into quadratic behavior across an entire restored buffer, so there's now a fast path for the common case where lines come in already in order.
And restoring lines was also triggering hotlist updates that were guaranteed to be wasted, since the hotlist gets rebuilt from its own saved state right after anyway, so that got skipped too during replay.


## A bug found along the way

While working on the highlight-state change, I realized that when a line got restored, WeeChat would compute its colorized timestamp based on the highlight state at that moment, but then immediately overwrite the highlight state with the value that had actually been saved, without ever going back and recomputing the timestamp's colors.
So a restored line's timestamp could end up colorized as if it weren't a highlight when it actually was, or the other way around. Since I was already threading the "known" highlight and timestamp values through this code for performance reasons, the fix fell out naturally: pass the saved values straight through instead of computing them, which is both faster and no longer produces a timestamp colorized for a highlight state that's about to be replaced.