### PR TITLE
core: grow/shrink shared hashtable buckets based on load factor

### DIFF
--- a/src/core/core-hashtable.c
+++ b/src/core/core-hashtable.c
@@ -40,6 +40,30 @@
 #include "../plugins/plugin.h"
 
 
+/*
+ * Grow (double) the internal array when the average chain length
+ * (items_count / size) exceeds this value.
+ */
+#define HASHTABLE_LOAD_FACTOR_MAX 2
+
+/*
+ * Shrink (halve) the internal array when the average chain length
+ * (items_count / size) falls below 1 / HASHTABLE_LOAD_FACTOR_MIN.
+ *
+ * Kept well below 1 / HASHTABLE_LOAD_FACTOR_MAX (ie 1/2) on purpose: this
+ * leaves a hysteresis gap around the grow threshold so that adding/removing
+ * a single item near any boundary can never flip the table back and forth
+ * between growing and shrinking.
+ */
+#define HASHTABLE_LOAD_FACTOR_MIN 4
+
+/*
+ * Never shrink the internal array below this many buckets: avoids
+ * repeatedly rehashing an already-small table for a negligible memory gain.
+ */
+#define HASHTABLE_MIN_SIZE 8
+
+
 char *hashtable_type_string[HASHTABLE_NUM_TYPES] =
 { WEECHAT_HASHTABLE_INTEGER,
   WEECHAT_HASHTABLE_STRING,
@@ -202,10 +226,12 @@ hashtable_keycmp_default_cb (struct t_hashtable *hashtable,
 /*
  * Create a new hashtable.
  *
- * The size is NOT a limit for number of items in hashtable. It is the size of
- * internal array to store hashed keys: a high value uses more memory, but has
- * better performance because this reduces the collisions of hashed keys and
- * then reduce length of linked lists.
+ * The size is NOT a limit for number of items in hashtable, and it is only
+ * an *initial* size: it is the size of the internal array used to store
+ * hashed keys, and the array is grown or shrunk automatically (see
+ * hashtable_rehash) as items are added or removed, to keep the average
+ * length of the linked lists low regardless of how many items end up in
+ * the hashtable, down to a minimum of HASHTABLE_MIN_SIZE buckets.
  *
  * Return pointer to new hashtable, NULL if error.
  */
@@ -399,6 +425,74 @@ hashtable_free_value (struct t_hashtable *hashtable,
 }
 
 /*
+ * Rehash a hashtable: allocate a new internal array of "new_size" buckets
+ * and move all existing items into it.
+ *
+ * This keeps the average linked-list length in each bucket low as items are
+ * added or removed, instead of it growing linearly with items_count for a
+ * fixed-size array.
+ *
+ * Each item is reinserted at its sorted position in its new bucket (not
+ * simply appended), to preserve the per-bucket sorted-by-key invariant that
+ * hashtable_get_item and hashtable_set_with_size rely on for their
+ * early-exit comparison.
+ */
+
+void
+hashtable_rehash (struct t_hashtable *hashtable, int new_size)
+{
+    struct t_hashtable_item **new_htable, *ptr_item, *ptr_next_item;
+    struct t_hashtable_item *ptr_bucket_item, *pos_item;
+    unsigned long long hash;
+    int i;
+
+    new_htable = malloc (new_size * sizeof (*new_htable));
+    if (!new_htable)
+        return;
+
+    for (i = 0; i < new_size; i++)
+    {
+        new_htable[i] = NULL;
+    }
+
+    for (i = 0; i < hashtable->size; i++)
+    {
+        ptr_item = hashtable->htable[i];
+        while (ptr_item)
+        {
+            ptr_next_item = ptr_item->next_item;
+
+            hash = hashtable->callback_hash_key (hashtable, ptr_item->key) % new_size;
+
+            /* find sorted position for item in its new bucket */
+            pos_item = NULL;
+            for (ptr_bucket_item = new_htable[hash];
+                 ptr_bucket_item
+                     && ((int)(hashtable->callback_keycmp) (hashtable, ptr_item->key, ptr_bucket_item->key) > 0);
+                 ptr_bucket_item = ptr_bucket_item->next_item)
+            {
+                pos_item = ptr_bucket_item;
+            }
+
+            ptr_item->prev_item = pos_item;
+            ptr_item->next_item = (pos_item) ? pos_item->next_item : new_htable[hash];
+            if (ptr_item->next_item)
+                (ptr_item->next_item)->prev_item = ptr_item;
+            if (pos_item)
+                pos_item->next_item = ptr_item;
+            else
+                new_htable[hash] = ptr_item;
+
+            ptr_item = ptr_next_item;
+        }
+    }
+
+    free (hashtable->htable);
+    hashtable->htable = new_htable;
+    hashtable->size = new_size;
+}
+
+/*
  * Set value for a key in hashtable.
  *
  * The size arguments are used only for type "buffer".
@@ -485,6 +579,10 @@ hashtable_set_with_size (struct t_hashtable *hashtable,
     hashtable->newest_item = new_item;
 
     hashtable->items_count++;
+
+    /* grow the table if the average chain length is too high */
+    if (hashtable->items_count > hashtable->size * HASHTABLE_LOAD_FACTOR_MAX)
+        hashtable_rehash (hashtable, hashtable->size * 2);
 
     return new_item;
 }
@@ -1239,6 +1337,10 @@ hashtable_add_from_infolist (struct t_hashtable *hashtable,
 
 /*
  * Remove an item from hashtable.
+ *
+ * Does not check/adjust the load factor: this is also called in a loop by
+ * hashtable_remove_all, where shrinking mid-loop would invalidate the
+ * loop's bucket indices (see hashtable_remove for the load factor check).
  */
 
 void
@@ -1278,6 +1380,9 @@ hashtable_remove_item (struct t_hashtable *hashtable,
 
 /*
  * Remove an item from hashtable (searches it with key).
+ *
+ * Also shrinks the internal array (see hashtable_rehash) if the average
+ * chain length drops too low after the removal.
  */
 
 void
@@ -1285,17 +1390,34 @@ hashtable_remove (struct t_hashtable *hashtable, const void *key)
 {
     struct t_hashtable_item *ptr_item;
     unsigned long long hash;
+    int new_size;
 
     if (!hashtable || !key)
         return;
 
     ptr_item = hashtable_get_item (hashtable, key, &hash);
     if (ptr_item)
+    {
         hashtable_remove_item (hashtable, ptr_item, hash);
+
+        /* shrink the table if the average chain length is too low */
+        if ((hashtable->size > HASHTABLE_MIN_SIZE)
+            && (hashtable->items_count * HASHTABLE_LOAD_FACTOR_MIN < hashtable->size))
+        {
+            new_size = hashtable->size / 2;
+            if (new_size < HASHTABLE_MIN_SIZE)
+                new_size = HASHTABLE_MIN_SIZE;
+            hashtable_rehash (hashtable, new_size);
+        }
+    }
 }
 
 /*
  * Remove all items from hashtable.
+ *
+ * Does not shrink the internal array: callers typically clear a hashtable
+ * only to immediately refill it, so keeping the existing capacity avoids
+ * forcing an unnecessary re-grow rehash right afterwards.
  */
 
 void

--- a/src/core/core-hashtable.h
+++ b/src/core/core-hashtable.h
@@ -128,7 +128,8 @@ struct t_hashtable_item
 
 struct t_hashtable
 {
-    int size;                          /* hashtable size                    */
+    int size;                          /* hashtable size (grows/shrinks     */
+                                       /* automatically)                    */
     struct t_hashtable_item **htable;  /* table to map hashes with linked   */
                                        /* lists                             */
     int items_count;                   /* number of items in hashtable      */

--- a/src/core/core-string.c
+++ b/src/core/core-string.c
@@ -4590,6 +4590,11 @@ string_shared_get (const char *string)
         /*
          * use large htable inside hashtable to prevent too many collisions,
          * which would slow down search of a string in the hashtable
+         * this is only an initial size: hashtable_new()/hashtable_set()
+         * grow the internal array automatically as items are added, so a
+         * modest starting size is enough even for buffers with a large
+         * number of unique shared strings (eg: many distinct tag
+         * combinations restored from an upgrade file)
          */
         string_hashtable_shared = hashtable_new (1024,
                                                  WEECHAT_HASHTABLE_POINTER,

--- a/tests/unit/core/test-core-hashtable.cpp
+++ b/tests/unit/core/test-core-hashtable.cpp
@@ -559,6 +559,351 @@ TEST(CoreHashtable, SetGetRemove)
     hashtable_free (hashtable);
 }
 
+/*
+ * Test functions:
+ *   hashtable_rehash (via hashtable_set_with_size, growing on high load factor)
+ */
+
+TEST(CoreHashtable, Rehash)
+{
+    struct t_hashtable *hashtable;
+    struct t_hashtable_item *ptr_item;
+    char key[32], value[32];
+    int i;
+
+    hashtable = hashtable_new (4,
+                               WEECHAT_HASHTABLE_STRING,
+                               WEECHAT_HASHTABLE_STRING,
+                               NULL,
+                               NULL);
+    LONGS_EQUAL(4, hashtable->size);
+
+    /* fill up to the load factor limit: no rehash must happen yet */
+    for (i = 0; i < 8; i++)
+    {
+        snprintf (key, sizeof (key), "key%d", i);
+        snprintf (value, sizeof (value), "value%d", i);
+        hashtable_set (hashtable, key, value);
+    }
+    LONGS_EQUAL(8, hashtable->items_count);
+    LONGS_EQUAL(4, hashtable->size);
+
+    /* one more item pushes items_count above size * load factor: size doubles */
+    hashtable_set (hashtable, "key8", "value8");
+    LONGS_EQUAL(9, hashtable->items_count);
+    LONGS_EQUAL(8, hashtable->size);
+
+    /* all items must still be reachable with their original value after the rehash */
+    for (i = 0; i < 9; i++)
+    {
+        snprintf (key, sizeof (key), "key%d", i);
+        snprintf (value, sizeof (value), "value%d", i);
+        STRCMP_EQUAL(value, (const char *)hashtable_get (hashtable, key));
+    }
+
+    /* each bucket must keep its items sorted by key after the rehash */
+    for (i = 0; i < hashtable->size; i++)
+    {
+        for (ptr_item = hashtable->htable[i];
+             ptr_item && ptr_item->next_item;
+             ptr_item = ptr_item->next_item)
+        {
+            CHECK(strcmp ((const char *)ptr_item->key,
+                          (const char *)ptr_item->next_item->key) < 0);
+        }
+    }
+
+    /* fill up to the next load factor limit to trigger a second rehash */
+    for (i = 9; i < 17; i++)
+    {
+        snprintf (key, sizeof (key), "key%d", i);
+        snprintf (value, sizeof (value), "value%d", i);
+        hashtable_set (hashtable, key, value);
+    }
+    LONGS_EQUAL(17, hashtable->items_count);
+    LONGS_EQUAL(16, hashtable->size);
+
+    for (i = 0; i < 17; i++)
+    {
+        snprintf (key, sizeof (key), "key%d", i);
+        snprintf (value, sizeof (value), "value%d", i);
+        STRCMP_EQUAL(value, (const char *)hashtable_get (hashtable, key));
+    }
+
+    for (i = 0; i < hashtable->size; i++)
+    {
+        for (ptr_item = hashtable->htable[i];
+             ptr_item && ptr_item->next_item;
+             ptr_item = ptr_item->next_item)
+        {
+            CHECK(strcmp ((const char *)ptr_item->key,
+                          (const char *)ptr_item->next_item->key) < 0);
+        }
+    }
+
+    hashtable_free (hashtable);
+}
+
+/*
+ * Test functions:
+ *   hashtable_remove (shrink)
+ */
+
+TEST(CoreHashtable, ShrinkBasic)
+{
+    struct t_hashtable *hashtable;
+    struct t_hashtable_item *ptr_item;
+    char key[32], value[32];
+    int i;
+
+    hashtable = hashtable_new (32,
+                               WEECHAT_HASHTABLE_STRING,
+                               WEECHAT_HASHTABLE_STRING,
+                               NULL,
+                               NULL);
+
+    /* fill with enough items to stay below the grow threshold */
+    for (i = 0; i < 20; i++)
+    {
+        snprintf (key, sizeof (key), "key%d", i);
+        snprintf (value, sizeof (value), "value%d", i);
+        hashtable_set (hashtable, key, value);
+    }
+    LONGS_EQUAL(20, hashtable->items_count);
+    LONGS_EQUAL(32, hashtable->size);
+
+    /* remove down to 8 items: still above the shrink threshold */
+    for (i = 19; i >= 8; i--)
+    {
+        snprintf (key, sizeof (key), "key%d", i);
+        hashtable_remove (hashtable, key);
+    }
+    LONGS_EQUAL(8, hashtable->items_count);
+    LONGS_EQUAL(32, hashtable->size);
+
+    /* one more removal pushes items_count below size / load factor: size halves */
+    hashtable_remove (hashtable, "key7");
+    LONGS_EQUAL(7, hashtable->items_count);
+    LONGS_EQUAL(16, hashtable->size);
+
+    /* all remaining items must still be reachable with their original value */
+    for (i = 0; i < 7; i++)
+    {
+        snprintf (key, sizeof (key), "key%d", i);
+        snprintf (value, sizeof (value), "value%d", i);
+        STRCMP_EQUAL(value, (const char *)hashtable_get (hashtable, key));
+    }
+
+    /* each bucket must keep its items sorted by key after the shrink */
+    for (i = 0; i < hashtable->size; i++)
+    {
+        for (ptr_item = hashtable->htable[i];
+             ptr_item && ptr_item->next_item;
+             ptr_item = ptr_item->next_item)
+        {
+            CHECK(strcmp ((const char *)ptr_item->key,
+                          (const char *)ptr_item->next_item->key) < 0);
+        }
+    }
+
+    hashtable_free (hashtable);
+}
+
+TEST(CoreHashtable, ShrinkNoneAboveThreshold)
+{
+    struct t_hashtable *hashtable;
+    char key[32], value[32];
+    int i;
+
+    hashtable = hashtable_new (32,
+                               WEECHAT_HASHTABLE_STRING,
+                               WEECHAT_HASHTABLE_STRING,
+                               NULL,
+                               NULL);
+
+    for (i = 0; i < 10; i++)
+    {
+        snprintf (key, sizeof (key), "key%d", i);
+        snprintf (value, sizeof (value), "value%d", i);
+        hashtable_set (hashtable, key, value);
+    }
+    LONGS_EQUAL(10, hashtable->items_count);
+    LONGS_EQUAL(32, hashtable->size);
+
+    /* removing one item stays above the shrink threshold: no rehash */
+    hashtable_remove (hashtable, "key9");
+    LONGS_EQUAL(9, hashtable->items_count);
+    LONGS_EQUAL(32, hashtable->size);
+
+    hashtable_free (hashtable);
+}
+
+TEST(CoreHashtable, ShrinkNoThrashNearBoundary)
+{
+    struct t_hashtable *hashtable;
+    char key[32], value[32];
+    int i;
+
+    hashtable = hashtable_new (32,
+                               WEECHAT_HASHTABLE_STRING,
+                               WEECHAT_HASHTABLE_STRING,
+                               NULL,
+                               NULL);
+
+    /* fill to exactly half load: the boundary a naive design would react to */
+    for (i = 0; i < 16; i++)
+    {
+        snprintf (key, sizeof (key), "key%d", i);
+        snprintf (value, sizeof (value), "value%d", i);
+        hashtable_set (hashtable, key, value);
+    }
+    LONGS_EQUAL(16, hashtable->items_count);
+    LONGS_EQUAL(32, hashtable->size);
+
+    /* toggling a single extra item near that boundary must never resize */
+    for (i = 0; i < 3; i++)
+    {
+        hashtable_set (hashtable, "extra", "extra_value");
+        LONGS_EQUAL(17, hashtable->items_count);
+        LONGS_EQUAL(32, hashtable->size);
+
+        hashtable_remove (hashtable, "extra");
+        LONGS_EQUAL(16, hashtable->items_count);
+        LONGS_EQUAL(32, hashtable->size);
+    }
+
+    /* remove real items down past the actual shrink threshold */
+    for (i = 15; i >= 7; i--)
+    {
+        snprintf (key, sizeof (key), "key%d", i);
+        hashtable_remove (hashtable, key);
+    }
+    LONGS_EQUAL(7, hashtable->items_count);
+    LONGS_EQUAL(16, hashtable->size);
+
+    /* the same toggle test must also be stable at the new (halved) size */
+    for (i = 0; i < 3; i++)
+    {
+        hashtable_set (hashtable, "extra2", "extra_value2");
+        LONGS_EQUAL(8, hashtable->items_count);
+        LONGS_EQUAL(16, hashtable->size);
+
+        hashtable_remove (hashtable, "extra2");
+        LONGS_EQUAL(7, hashtable->items_count);
+        LONGS_EQUAL(16, hashtable->size);
+    }
+
+    hashtable_free (hashtable);
+}
+
+TEST(CoreHashtable, ShrinkMinSize)
+{
+    struct t_hashtable *hashtable;
+    char key[32], value[32];
+    int i;
+
+    hashtable = hashtable_new (32,
+                               WEECHAT_HASHTABLE_STRING,
+                               WEECHAT_HASHTABLE_STRING,
+                               NULL,
+                               NULL);
+
+    for (i = 0; i < 5; i++)
+    {
+        snprintf (key, sizeof (key), "key%d", i);
+        snprintf (value, sizeof (value), "value%d", i);
+        hashtable_set (hashtable, key, value);
+    }
+    LONGS_EQUAL(5, hashtable->items_count);
+    LONGS_EQUAL(32, hashtable->size);
+
+    /* first removal: size halves once (32 -> 16) */
+    hashtable_remove (hashtable, "key0");
+    LONGS_EQUAL(4, hashtable->items_count);
+    LONGS_EQUAL(16, hashtable->size);
+
+    /* second removal: size halves again (16 -> 8, the minimum size) */
+    hashtable_remove (hashtable, "key1");
+    LONGS_EQUAL(3, hashtable->items_count);
+    LONGS_EQUAL(8, hashtable->size);
+
+    /* further removals down to zero items must never shrink below the minimum */
+    hashtable_remove (hashtable, "key2");
+    LONGS_EQUAL(2, hashtable->items_count);
+    LONGS_EQUAL(8, hashtable->size);
+
+    hashtable_remove (hashtable, "key3");
+    LONGS_EQUAL(1, hashtable->items_count);
+    LONGS_EQUAL(8, hashtable->size);
+
+    hashtable_remove (hashtable, "key4");
+    LONGS_EQUAL(0, hashtable->items_count);
+    LONGS_EQUAL(8, hashtable->size);
+
+    hashtable_free (hashtable);
+
+    /* a hashtable created at the minimum size must never attempt to shrink */
+    hashtable = hashtable_new (8,
+                               WEECHAT_HASHTABLE_STRING,
+                               WEECHAT_HASHTABLE_STRING,
+                               NULL,
+                               NULL);
+    hashtable_set (hashtable, "key0", "value0");
+    hashtable_set (hashtable, "key1", "value1");
+    hashtable_set (hashtable, "key2", "value2");
+    LONGS_EQUAL(3, hashtable->items_count);
+    LONGS_EQUAL(8, hashtable->size);
+
+    hashtable_remove (hashtable, "key0");
+    hashtable_remove (hashtable, "key1");
+    hashtable_remove (hashtable, "key2");
+    LONGS_EQUAL(0, hashtable->items_count);
+    LONGS_EQUAL(8, hashtable->size);
+
+    hashtable_free (hashtable);
+}
+
+TEST(CoreHashtable, ShrinkRemoveAllKeepsSize)
+{
+    struct t_hashtable *hashtable;
+    char key[32], value[32];
+    int i, grown_size;
+
+    hashtable = hashtable_new (8,
+                               WEECHAT_HASHTABLE_STRING,
+                               WEECHAT_HASHTABLE_STRING,
+                               NULL,
+                               NULL);
+
+    /* fill enough to force at least one grow */
+    for (i = 0; i < 20; i++)
+    {
+        snprintf (key, sizeof (key), "key%d", i);
+        snprintf (value, sizeof (value), "value%d", i);
+        hashtable_set (hashtable, key, value);
+    }
+    LONGS_EQUAL(20, hashtable->items_count);
+    CHECK(hashtable->size > 8);
+    grown_size = hashtable->size;
+
+    /* removing everything at once must not shrink the table */
+    hashtable_remove_all (hashtable);
+    LONGS_EQUAL(0, hashtable->items_count);
+    POINTERS_EQUAL(NULL, hashtable->oldest_item);
+    POINTERS_EQUAL(NULL, hashtable->newest_item);
+    LONGS_EQUAL(grown_size, hashtable->size);
+
+    /* the hashtable must still work correctly at the retained size */
+    hashtable_set (hashtable, "foo", "bar");
+    hashtable_set (hashtable, "baz", "qux");
+    LONGS_EQUAL(2, hashtable->items_count);
+    LONGS_EQUAL(grown_size, hashtable->size);
+    STRCMP_EQUAL("bar", (const char *)hashtable_get (hashtable, "foo"));
+    STRCMP_EQUAL("qux", (const char *)hashtable_get (hashtable, "baz"));
+
+    hashtable_free (hashtable);
+}
+
 void
 test_hashtable_map_string_cb (void *data,
                               struct t_hashtable *hashtable,


### PR DESCRIPTION
Add hashtable_rehash() to core-hashtable.c: reallocates the bucket array to a new size and reinserts every item at its sorted position in its new bucket, preserving the invariant hashtable_get_item's early-exit comparison relies on.

hashtable_set_with_size() calls it once items_count exceeds twice the current size (doubling), so hashtable_new()'s size argument is now just an initial size rather than a fixed ceiling. hashtable_remove() calls it symmetrically once items_count drops below a quarter of the current size (halving, down to a floor of 8 buckets), so a hashtable that grew for a transient spike does not keep the larger array indefinitely. The 2x/4x gap between the grow and shrink thresholds is a deliberate hysteresis margin: it keeps a single add/remove pair near either boundary from flipping the table back and forth between growing and shrinking.

Avoiding long strcmp-based collision chains for any workload with many unique shared strings (eg. large upgrade files with many distinct tag combinations) without over-allocating for smaller ones, in either direction as the hashtable's contents change over its lifetime.