### PR TITLE
core: fix buffer overflow in display of time in chat area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ _If you are upgrading: please see [UPGRADING.md](UPGRADING.md)._
 
 ### Security
 
+- core: fix buffer overflow in display of time in chat area with a custom time format
 - core: fix integer overflow in size calculation when evaluating "${hide:...}" and "${base_encode:...}" ([#2335](https://github.com/weechat/weechat/issues/2335))
 - core: fix possible buffer overflow in command /color alias ([#2330](https://github.com/weechat/weechat/issues/2330))
 - core: fix possible buffer overflow in list of commands displayed by /help ([#2330](https://github.com/weechat/weechat/issues/2330))

--- a/src/gui/gui-chat.c
+++ b/src/gui/gui-chat.c
@@ -412,7 +412,11 @@ gui_chat_get_word_info (struct t_gui_window *window,
 char *
 gui_chat_get_time_string (time_t date, int date_usec, int highlight)
 {
-    char text_time[128], text_time2[(128*3)+16], text_time_char[2];
+    /*
+     * text_time2 receives, for each of the (max 127) chars in text_time, up to
+     * one color code (3 bytes) plus the char itself, so 4 bytes per char
+     */
+    char text_time[128], text_time2[(128*4)+16], text_time_char[2];
     char *text_with_color;
     int i, time_first_digit, time_last_digit, last_color;
     struct timeval tv;

--- a/tests/unit/gui/test-gui-chat.cpp
+++ b/tests/unit/gui/test-gui-chat.cpp
@@ -28,6 +28,8 @@
 extern "C"
 {
 #include <string.h>
+#include "src/core/core-config.h"
+#include "src/core/core-config-file.h"
 #include "src/gui/gui-buffer.h"
 #include "src/gui/gui-chat.h"
 #include "src/gui/gui-color.h"
@@ -379,7 +381,38 @@ TEST(GuiChat, GetWordInfo)
 
 TEST(GuiChat, GetTimeString)
 {
-    /* TODO: write tests */
+    char *saved_format, *str, format_alt[128];
+    int i;
+
+    saved_format = strdup (CONFIG_STRING(config_look_buffer_time_format));
+
+    /* empty format => NULL */
+    config_file_option_set (config_look_buffer_time_format, "", 1);
+    POINTERS_EQUAL(NULL, gui_chat_get_time_string (1645288340, 0, 0));
+
+    /* date == 0 => NULL */
+    config_file_option_set (config_look_buffer_time_format, "%H:%M:%S", 1);
+    POINTERS_EQUAL(NULL, gui_chat_get_time_string (0, 0, 0));
+
+    str = gui_chat_get_time_string (1645288340, 0, 0);
+    CHECK(str != NULL);
+    free (str);
+
+    /*
+     * a format alternating digits and non-digits makes the color switch on
+     * every char, so each char emits a color code (3 bytes) plus itself; with
+     * a near-full text_time buffer this overflows an undersized text_time2
+     */
+    for (i = 0; i < 126; i++)
+        format_alt[i] = (i % 2 == 0) ? '1' : 'a';
+    format_alt[126] = '\0';
+    config_file_option_set (config_look_buffer_time_format, format_alt, 1);
+    str = gui_chat_get_time_string (1645288340, 0, 0);
+    CHECK(str != NULL);
+    free (str);
+
+    config_file_option_set (config_look_buffer_time_format, saved_format, 1);
+    free (saved_format);
 }
 
 /*


### PR DESCRIPTION
size text_time2 for up to 4 bytes per char (a color code plus the char) in gui_chat_get_time_string, otherwise a buffer_time_format that alternates digits and non-digits overflows the fixed stack buffer while coloring the time.